### PR TITLE
Fix broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,10 @@ Notes and oddities:
 
 Helpful Links
 -------------
-* [BoE Forum at Spiderweb
-  Software](http://spiderwebforums.ipbhost.com/index.php?/forum/12-blades-
-  of-exile/)
+* [BoE Forum at Spiderweb Software](http://spiderwebforums.ipbhost.com/index.php?/forum/12-blades-of-exile/)
 * [Official IRC channel](http://webchat.freenode.net/?channels=%23openboe) (or join
 #openboe on irc.freenode.net)
-* [Original Game
-  Source](http://www.spiderwebsoftware.com/blades/opensource.html) - Where
+* [Original Game Source](http://www.spiderwebsoftware.com/blades/opensource.html) - Where
   it all began. Warning: Terrifying code.
 * [Experimental Builds](http://celmin.pwcsite.com/oboe/?C=M;O=D) - will be put
   up whenever Celtic Minstrel feels like it.


### PR DESCRIPTION
2 links were affected by hard wrapping, unintentionally splitting them into two (broken) segments. This commit fixes that.