### PR TITLE
Erase specials refactor

### DIFF
--- a/src/game/boe.town.cpp
+++ b/src/game/boe.town.cpp
@@ -1282,7 +1282,8 @@ void erase_hidden_towns(cOutdoors& sector, int quadrant_x, int quadrant_y)
 void erase_completed_specials(cOutdoors& sector)
 {
 	for (auto tile_index = 0; tile_index < sector.special_locs.size(); tile_index++) {
-		if (sector.special_locs[tile_index].spec < 0)
+		if (sector.special_locs[tile_index].spec < 0 ||
+			sector.special_locs[tile_index].spec >= sector.specials.size())
 			continue;
 
 		auto sn = sector.specials[sector.special_locs[tile_index].spec];

--- a/src/game/boe.town.hpp
+++ b/src/game/boe.town.hpp
@@ -1,5 +1,6 @@
 
 #include <SFML/Graphics.hpp>
+#include "outdoors.hpp"
 
 void force_town_enter(short which_town,location where_start);
 void start_town_mode(short which_town, short entry_dir);
@@ -21,7 +22,10 @@ void dump_gold(short print_mes);
 void pick_lock(location where,short pc_num);
 void bash_door(location where,short pc_num);
 void erase_specials();
+void erase_hidden_towns(cOutdoors& sector, int quadrant_x, int quadrant_y);
+void erase_completed_specials(cOutdoors& sector);
 void erase_out_specials();
+bool does_location_have_special(cOutdoors& sector, location loc, eTerSpec type);
 void clear_map();
 void draw_map(bool need_refresh);
 bool is_door(location destination);

--- a/src/scenario/area.hpp
+++ b/src/scenario/area.hpp
@@ -16,6 +16,7 @@
 #include "vector2d.hpp"
 #include "location.hpp"
 #include "special.hpp"
+#include "mathutil.hpp"
 
 enum {
 	AREA_TINY = 24,
@@ -41,6 +42,11 @@ public:
 		, terrain(dim, dim)
 		, maps(dim, boost::dynamic_bitset<>(dim))
 	{}
+
+	bool is_on_map(location loc) const
+	{
+		return loc.x < max_dim && loc.y < max_dim && loc.x >= 0 && loc.y >= 0;
+	}
 };
 
 #endif

--- a/src/scenario/scenario.cpp
+++ b/src/scenario/scenario.cpp
@@ -528,3 +528,14 @@ cItem cScenario::return_treasure(int loot, bool allow_junk) {
 		treas.value = 0;
 	return treas;
 }
+
+cOutdoors& cScenario::get_sector(int x, int y)
+{
+	return *outdoors[x][y];
+}
+
+bool cScenario::is_town_entrance_valid(spec_loc_t loc) const
+{
+	auto towns_in_scenario = towns.size();
+	return loc.spec >= 0 && loc.spec < towns_in_scenario;
+}

--- a/src/scenario/scenario.hpp
+++ b/src/scenario/scenario.hpp
@@ -103,6 +103,8 @@ public:
 	ter_num_t get_ground_from_ter(ter_num_t ter);
 	ter_num_t get_ter_from_ground(unsigned short ground);
 	ter_num_t get_trim_terrain(unsigned short ground, unsigned short trim_g, eTrimType trim);
+	cOutdoors& get_sector(int x, int y);
+	bool is_town_entrance_valid(spec_loc_t loc) const;
 	
 	bool is_ter_used(ter_num_t ter);
 	bool is_monst_used(mon_num_t monst);

--- a/src/scenario/special.hpp
+++ b/src/scenario/special.hpp
@@ -16,6 +16,8 @@
 
 namespace legacy { struct special_node_type; };
 
+static const short SDF_COMPLETE = 250;
+
 // TODO: Add win/lose option to END_SCENARIO
 // TODO: Allow OUT_MOVE_PARTY to change the current sector
 enum class eSpecType {


### PR DESCRIPTION
This cleans up the `erase_out_specials()` method in `boe.town.cpp` and introduces a few new helper methods.
Also introduces a minor fix on what is now `erase_completed_specials()` where we weren't ensuring the index did not exceed the vectors elements;