### PR TITLE
Fix travis for Linux build

### DIFF
--- a/.travis-install-deps.sh
+++ b/.travis-install-deps.sh
@@ -7,5 +7,5 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 	brew install scons sfml
 else
 	sudo apt-get update -qq
-	sudo apt-get install -qq libsfml-dev libboost-dev libboost-filesystem-dev libboost-thread-dev
+	sudo apt-get install -qq libsfml-dev libboost-dev libboost-filesystem-dev libboost-thread-dev libxml2-utils
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: cpp
 sudo: required
 services: ['docker']
 
-script: travis_wait scons --jobs=2
+script: CXXFLAGS=-DBOOST_NO_CXX11_SCOPED_ENUMS scons
 
 compiler:
  - clang
@@ -24,8 +24,8 @@ branches:
 
 notifications:
  email: false
- irc:
-  channels: ["irc.freenode.net#openboe"]
-  use_notice: true
-  on_success: change
-  on_failure: always
+# irc:
+#  channels: ["irc.freenode.net#openboe"]
+#  use_notice: true
+#  on_success: change
+#  on_failure: always

--- a/SConstruct
+++ b/SConstruct
@@ -25,6 +25,9 @@ else:
 env.VariantDir('#build/obj', 'src')
 env.VariantDir('#build/obj/test', 'test')
 
+# Allow arbitrary flags
+env.Append(CXXFLAGS=os.environ.get('CXXFLAGS', ''))
+
 debug = ARGUMENTS.get('debug', 0)
 if int(debug):
    env.Append(CCFLAGS = '-g')


### PR DESCRIPTION
Several issues was detected with linux build:
- travis_wait raise timeout
- --jobs=2 sometimes fails
- add flag BOOST_NO_CXX11_SCOPED_ENUMS to fix compilation with old boost filesystme
- add missing tool xmllint