### PR TITLE
SCons: Fix warning on posix build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -404,9 +404,10 @@ elif str(platform) == "win32":
 
 if str(platform) == "darwin":
 	env.VariantDir("#build/pkg", "pkg/mac")
+	SConscript("build/pkg/SConscript")
 elif str(platform) == "win32" and subprocess.call(['where', '/Q', 'makensis']) == 0:
 	env.VariantDir("#build/pkg", "pkg/win")
-SConscript("build/pkg/SConscript")
+	SConscript("build/pkg/SConscript")
 
 # Cleanup
 


### PR DESCRIPTION
`build/pkg/SConscript` only exists for darwin or for win32 when makensis is available, so it should not be added inconditionally.

Without this patch it triggers this warning on posix:
```
scons: warning: Ignoring missing SConscript 'build/pkg/SConscript'
```