### PR TITLE
Fix incorrect damage values in transcript

### DIFF
--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -2850,7 +2850,7 @@ void monster_attack(short who_att,iLiving* target) {
 				store_hp = target->get_health();
 				sound_type = get_monst_sound(attacker,i);
 				size_t i_monst = univ.get_target_i(*target);
-				bool damaged = false;
+				short damaged = false;
 				if(m_target != nullptr) {
 					// TODO: Maybe this damage should be printed?
 					damaged = damage_monst(*m_target,7,r2,dam_type,sound_type,false);

--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -2850,14 +2850,14 @@ void monster_attack(short who_att,iLiving* target) {
 				store_hp = target->get_health();
 				sound_type = get_monst_sound(attacker,i);
 				size_t i_monst = univ.get_target_i(*target);
-				short damaged = false;
+				short damaged = 0;
 				if(m_target != nullptr) {
 					// TODO: Maybe this damage should be printed?
 					damaged = damage_monst(*m_target,7,r2,dam_type,sound_type,false);
 				} else if(pc_target != nullptr) {
 					damaged = damage_pc(*pc_target,r2,dam_type,attacker->m_type,sound_type);
 					if(store_hp - target->get_health() <= 0)
-						damaged = false;
+						damaged = 0;
 				}
 				if(damaged) {
 					damaged_message(store_hp - target->get_health(), attacker->a[i].type);

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -2242,11 +2242,9 @@ bool flying() {
 }
 
 void hit_party(short how_much,eDamageType damage_type,short snd_type) {
-	bool dummy;
-	
 	for(short i = 0; i < 6; i++)
 		if(univ.party[i].main_status == eMainStatus::ALIVE)
-			dummy = damage_pc(univ.party[i],how_much,damage_type,eRace::UNKNOWN,snd_type);
+			damage_pc(univ.party[i],how_much,damage_type,eRace::UNKNOWN,snd_type);
 	put_pc_screen();
 }
 
@@ -2258,7 +2256,7 @@ void slay_party(eMainStatus mode) {
 	put_pc_screen();
 }
 
-bool damage_pc(cPlayer& which_pc,short how_much,eDamageType damage_type,eRace type_of_attacker, short sound_type,bool do_print) {
+short damage_pc(cPlayer& which_pc,short how_much,eDamageType damage_type,eRace type_of_attacker, short sound_type,bool do_print) {
 	short r1,level;
 	
 	if(which_pc.main_status != eMainStatus::ALIVE)
@@ -2316,7 +2314,6 @@ bool damage_pc(cPlayer& which_pc,short how_much,eDamageType damage_type,eRace ty
 	if(damage_type == eDamageType::WEAPON && which_pc.parry < 100)
 		how_much -= which_pc.parry / 4;
 	
-	
 	if(damage_type != eDamageType::MARKED) {
 		if(univ.party.easy_mode)
 			how_much -= 3;
@@ -2333,15 +2330,18 @@ bool damage_pc(cPlayer& which_pc,short how_much,eDamageType damage_type,eRace ty
 		if(damage_type == eDamageType::WEAPON) how_much -= level;
 		else how_much = how_much / 2;
 	}
+	
 	// TODO: Do these perhaps depend on the ability strength less than they should?
 	if((level = which_pc.get_prot_level(eItemAbil::PROTECT_FROM_SPECIES,int(type_of_attacker))) > 0)
 		how_much = how_much / 2;
+		
 	if(isHumanoid(type_of_attacker) && !isHuman(type_of_attacker) && type_of_attacker != eRace::HUMANOID) {
 		// If it's a slith, nephil, vahnatai, or goblin, Protection from Humanoids also helps
 		// Humanoid is explicitly excluded here because otherwise it would help twice.
 		if((level = which_pc.get_prot_level(eItemAbil::PROTECT_FROM_SPECIES,int(eRace::HUMANOID))) > 0)
 			how_much = how_much / 2;
 	}
+	
 	if(type_of_attacker == eRace::SKELETAL) {
 		// Protection from Undead helps with both types of undead
 		if((level = which_pc.get_prot_level(eItemAbil::PROTECT_FROM_SPECIES,int(eRace::UNDEAD))) > 0)
@@ -2429,7 +2429,8 @@ bool damage_pc(cPlayer& which_pc,short how_much,eDamageType damage_type,eRace ty
 	if(which_pc.cur_health == 0 && which_pc.main_status == eMainStatus::ALIVE)
 		play_sound(3);
 	put_pc_screen();
-	return true;
+	
+	return how_much;
 }
 
 void petrify_pc(cPlayer& which_pc,int strength) {

--- a/src/game/boe.party.hpp
+++ b/src/game/boe.party.hpp
@@ -37,7 +37,7 @@ mon_num_t pick_trapped_monst();
 bool flying() ;
 void hit_party(short how_much,eDamageType damage_type,short snd_type = 0);
 void slay_party(eMainStatus mode);
-bool damage_pc(cPlayer& which_pc,short how_much,eDamageType damage_type,eRace type_of_attacker, short sound_type,bool do_print = true);
+short damage_pc(cPlayer& which_pc,short how_much,eDamageType damage_type,eRace type_of_attacker, short sound_type,bool do_print = true);
 void petrify_pc(cPlayer& which_pc,int strength);
 void kill_pc(cPlayer& which_pc,eMainStatus type);
 void set_pc_moves();

--- a/src/game/boe.specials.cpp
+++ b/src/game/boe.specials.cpp
@@ -1409,7 +1409,7 @@ void change_level(short town_num,short x,short y) {
 
 
 // Damaging and killing monsters needs to be here because several have specials attached to them.
-bool damage_monst(cCreature& victim, short who_hit, short how_much, eDamageType dam_type, short sound_type, bool do_print) {
+short damage_monst(cCreature& victim, short who_hit, short how_much, eDamageType dam_type, short sound_type, bool do_print) {
 	short r1,which_spot;
 	location where_put;
 	
@@ -1556,7 +1556,7 @@ bool damage_monst(cCreature& victim, short who_hit, short how_much, eDamageType 
 		make_town_hostile();
 	}
 	
-	return true;
+	return how_much;
 }
 
 void petrify_monst(cCreature& which_m,int strength) {

--- a/src/game/boe.specials.hpp
+++ b/src/game/boe.specials.hpp
@@ -8,7 +8,7 @@ void use_spec_item(short item);
 void use_item(short pc,short item);
 bool use_space(location where);
 bool adj_town_look(location where);
-bool damage_monst(cCreature& which_m, short who_hit, short how_much, eDamageType dam_type, short sound_type, bool do_print = true);
+short damage_monst(cCreature& which_m, short who_hit, short how_much, eDamageType dam_type, short sound_type, bool do_print = true);
 void petrify_monst(cCreature& which_m,int strength);
 void kill_monst(cCreature& which_m,short who_killed,eMainStatus type = eMainStatus::DEAD);
 void special_increase_age(long length = 1, bool queue = false);


### PR DESCRIPTION
Return actual damage done from damage_monst and damage_pc and print that instead of raw (pre-armor) values that are printed currently.

Fixes #248