### PR TITLE
Fix unclickable shop info icons

### DIFF
--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -121,11 +121,11 @@ static void advance_time(bool did_something, bool need_redraw, bool need_reprint
 // This is defined in pc.editors.cpp since the PC editor also uses it
 extern void edit_stuff_done();
 
-void init_screen_locs() {
-	rectangle startup_base = {281,1,329,302};
+static void init_shopping_rects() {
 	rectangle shop_base = {63,12,99,267};
 	
 	std::fill(shopping_rects[0].begin(), shopping_rects[0].end(), shop_base);
+
 	shopping_rects[0][SHOPRECT_ACTIVE_AREA].right -= 35;
 	shopping_rects[0][SHOPRECT_GRAPHIC].right = shopping_rects[0][SHOPRECT_GRAPHIC].left + 28;
 	shopping_rects[0][SHOPRECT_ITEM_NAME].top += 4;
@@ -139,12 +139,19 @@ void init_screen_locs() {
 	shopping_rects[0][SHOPRECT_ITEM_HELP].bottom -= 21;
 	shopping_rects[0][SHOPRECT_ITEM_HELP].right -= 19;
 	shopping_rects[0][SHOPRECT_ITEM_HELP].left = shopping_rects[0][SHOPRECT_ITEM_HELP].right - 14;
-	for(short i = 1; i < 8; i++)
+
+	for(short i = 1; i < 8; i++) {
 		for(auto& j : shopping_rects[i].keys()) {
 			shopping_rects[i][j] = shopping_rects[0][j];
 			shopping_rects[i][j].offset(0,i * 36);
 		}
+	}
+}
+
+void init_screen_locs() {
+	init_shopping_rects();
 	
+	rectangle startup_base = {281,1,329,302};
 	
 	for(auto btn : startup_button.keys()) {
 		startup_button[btn] = startup_base;

--- a/src/game/boe.consts.hpp
+++ b/src/game/boe.consts.hpp
@@ -162,4 +162,8 @@ const int NUM_PRIEST_SPELLS = 62;
 const int UI_LAYER_DEFAULT = 1000;
 const int UI_LAYER_MENUBAR = 1200;
 
+// Offset at which talk_gworld rendering target is drawn in mainPtr.
+const int talk_gword_offset_x = 19;
+const int talk_gword_offset_y = 7;
+
 #endif

--- a/src/game/boe.dlgutil.cpp
+++ b/src/game/boe.dlgutil.cpp
@@ -16,6 +16,7 @@
 #include "boe.townspec.hpp"
 #include "boe.main.hpp"
 #include "boe.items.hpp"
+#include "boe.consts.hpp"
 #include "sounds.hpp"
 #include <cstdio>
 #include "boe.newgraph.hpp"
@@ -216,22 +217,28 @@ void handle_shop_event(location p) {
 			end_shop_mode();
 		return;
 	}
-	
-	p.x -= 5;
-	p.y -= 5;
-	
+
 	for(short i = 0; i < 8; i++) {
 		unsigned long what_picked = shop_array[i + shop_sbar->getPosition()];
 		if(what_picked >= active_shop.size()) break;
 		if(active_shop.getItem(what_picked).type == eShopItemType::EMPTY)
 			break;
-		if(p.in(shopping_rects[i][SHOPRECT_ACTIVE_AREA])) {
-			click_shop_rect(shopping_rects[i][SHOPRECT_ACTIVE_AREA]);
+
+		// Since shop UI was drawn into the game window with offsets, we need to apply
+		// the same offsets to event catching areas.
+		rectangle active_rect { shopping_rects[i][SHOPRECT_ACTIVE_AREA] };
+		active_rect.offset(talk_gword_offset_x, talk_gword_offset_y);
+
+		rectangle item_help_rect { shopping_rects[i][SHOPRECT_ITEM_HELP] };
+		item_help_rect.offset(talk_gword_offset_x, talk_gword_offset_y);
+
+		if(p.in(active_rect)) {
+			play_sound(37, time_in_ticks(5));
 			handle_sale(active_shop.getItem(what_picked), what_picked);
 			set_up_shop_array();
 			draw_shop_graphics(false, {});
-		} else if(p.in(shopping_rects[i][SHOPRECT_ITEM_HELP])){
-			click_shop_rect(shopping_rects[i][SHOPRECT_ITEM_HELP]);
+		} else if(p.in(item_help_rect)){
+			play_sound(37, time_in_ticks(5));
 			handle_info_request(active_shop.getItem(what_picked));
 		}
 	}

--- a/src/game/boe.dlgutil.cpp
+++ b/src/game/boe.dlgutil.cpp
@@ -233,12 +233,12 @@ void handle_shop_event(location p) {
 		item_help_rect.offset(talk_gword_offset_x, talk_gword_offset_y);
 
 		if(p.in(active_rect)) {
-			play_sound(37, time_in_ticks(5));
+			click_shop_rect(active_rect);
 			handle_sale(active_shop.getItem(what_picked), what_picked);
 			set_up_shop_array();
 			draw_shop_graphics(false, {});
 		} else if(p.in(item_help_rect)){
-			play_sound(37, time_in_ticks(5));
+			click_shop_rect(item_help_rect);
 			handle_info_request(active_shop.getItem(what_picked));
 		}
 	}

--- a/src/game/boe.newgraph.cpp
+++ b/src/game/boe.newgraph.cpp
@@ -593,6 +593,15 @@ void do_explosion_anim(short /*sound_num*/,short special_draw, short snd) {
 			store_booms[i].boom_type = -1;
 }
 
+void click_shop_rect(rectangle area_rect) {
+
+	draw_shop_graphics(1,area_rect);
+	mainPtr.display();
+	play_sound(37, time_in_ticks(5));
+	draw_shop_graphics(0,area_rect);
+
+}
+
 graf_pos calc_item_rect(int num,rectangle& to_rect) {
 	if(num >= 1000) return spec_scen_g.find_graphic(num - 1000);
 	rectangle from_rect = {0,0,18,18};

--- a/src/game/boe.newgraph.cpp
+++ b/src/game/boe.newgraph.cpp
@@ -13,6 +13,7 @@
 #include "boe.fileio.hpp"
 #include "boe.locutils.hpp"
 #include "boe.text.hpp"
+#include "boe.consts.hpp"
 #include "sounds.hpp"
 #include "mathutil.hpp"
 #include "render_image.hpp"
@@ -592,15 +593,6 @@ void do_explosion_anim(short /*sound_num*/,short special_draw, short snd) {
 			store_booms[i].boom_type = -1;
 }
 
-void click_shop_rect(rectangle area_rect) {
-	
-	draw_shop_graphics(1,area_rect);
-	mainPtr.display();
-	play_sound(37, time_in_ticks(5));
-	draw_shop_graphics(0,area_rect);
-	
-}
-
 graf_pos calc_item_rect(int num,rectangle& to_rect) {
 	if(num >= 1000) return spec_scen_g.find_graphic(num - 1000);
 	rectangle from_rect = {0,0,18,18};
@@ -778,7 +770,6 @@ void draw_shop_graphics(bool pressed,rectangle clip_area_rect) {
 		style.pointSize = 10;
 		win_draw_string(talk_gworld,shopping_rects[i][SHOPRECT_ITEM_EXTRA],cur_info_str,eTextMode::WRAP,style);
 		rect_draw_some_item(invenbtn_gworld,item_info_from,talk_gworld,shopping_rects[i][SHOPRECT_ITEM_HELP],pressed ? sf::BlendNone : sf::BlendAlpha);
-		
 	}
 	
 	// Finally, cost info and help strs
@@ -804,9 +795,8 @@ void draw_shop_graphics(bool pressed,rectangle clip_area_rect) {
 void refresh_shopping() {
 	rectangle from_rect(talk_gworld);
 	rectangle to_rect = from_rect;
-	to_rect.offset(19,7);
+	to_rect.offset(talk_gword_offset_x, talk_gword_offset_y);
 	rect_draw_some_item(talk_gworld.getTexture(),from_rect,mainPtr,to_rect);
-	shop_sbar->draw();
 }
 
 static void place_talk_face() {

--- a/src/game/boe.newgraph.hpp
+++ b/src/game/boe.newgraph.hpp
@@ -56,7 +56,6 @@ void add_missile(location dest,miss_num_t missile_type,short path_type,short x_a
 void add_explosion(location dest,short val_to_place,short place_type,short boom_type,short x_adj,short y_adj);
 void do_missile_anim(short num_steps,location missile_origin,short sound_num) ;
 void do_explosion_anim(short sound_num,short expand,short snd = -1);
-void click_shop_rect(rectangle area_rect);
 void draw_shop_graphics(bool pressed,rectangle clip_area_rect);
 void refresh_shopping();
 std::string get_item_interesting_string(cItem item);

--- a/src/game/boe.newgraph.hpp
+++ b/src/game/boe.newgraph.hpp
@@ -56,6 +56,7 @@ void add_missile(location dest,miss_num_t missile_type,short path_type,short x_a
 void add_explosion(location dest,short val_to_place,short place_type,short boom_type,short x_adj,short y_adj);
 void do_missile_anim(short num_steps,location missile_origin,short sound_num) ;
 void do_explosion_anim(short sound_num,short expand,short snd = -1);
+void click_shop_rect(rectangle area_rect);
 void draw_shop_graphics(bool pressed,rectangle clip_area_rect);
 void refresh_shopping();
 std::string get_item_interesting_string(cItem item);


### PR DESCRIPTION
* Fixed unclickable shop icons by applying the same offset to event catching rects as is applied to the shop UI when it's being drawn in the main window.
* Removed strange adjustment of mouse click coords in shop UI by (-5, -5) px.
* Removed click_shop_rect function that was doing "click emulation" in shop UI. Rationale: 1) it was causing visual glitches, because 2) various widgets do not get to decide when .display() is called, since other drawables may not be ready
* Removed unneeded shop scrollbar redraw call which may improve performance of that UI a bit

Fixes #247