### PR TITLE
Fix debug mode (and other universe flags) being randomly set on upon load

### DIFF
--- a/src/universe/universe.hpp
+++ b/src/universe/universe.hpp
@@ -202,7 +202,9 @@ public:
 	cCurTown town;
 	cCurOut out;
 	fs::path file;
-	bool debug_mode, ghost_mode, node_step_through;
+	bool debug_mode { false };
+	bool ghost_mode { false };
+	bool node_step_through { false };
 	
 	void clear_stored_pcs();
 	void import_legacy(legacy::stored_town_maps_type& old);


### PR DESCRIPTION
Upon loading a save, a new instance of universe is default-constructed and then moved into existing universe. The problem is that several boolean flags in universe do not have initializers, so they sometimes end up with garbage values.

Fixes #198 
Fixes #200