### PR TITLE
Restart Travis builds

### DIFF
--- a/.travis-install-deps.sh
+++ b/.travis-install-deps.sh
@@ -7,5 +7,6 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 	HOMEBREW_NO_AUTO_UPDATE=1 brew install scons sfml
 else
 	sudo apt-get update -qq
-	sudo apt-get install -qq libsfml-dev libboost-dev libboost-filesystem-dev libboost-thread-dev libxml2-utils
+	sudo apt-get install -qq libsfml-dev libboost-dev libboost-filesystem-dev libboost-thread-dev libxml2-utils g++ \
+	scons zlib1g-dev  git
 fi

--- a/.travis-install-tgui.sh
+++ b/.travis-install-tgui.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ev
+
+env GIT_SSL_NO_VERIFY=true  git clone -b 0.8 --single-branch https://github.com/texus/TGUI.git
+cd TGUI && cmake . && make && sudo make install && cd /
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,30 @@
 
 language: cpp
-sudo: required
-services: ['docker']
-
 branches:
  except:
   - legacy-win32
 
-matrix:
+jobs:
  include:
   - os: linux
-    dist: trusty
+    dist: focal
     compiler: clang
   - os: linux
-    dist: trusty
+    dist: focal
     compiler: gcc
   - os: osx
-    osx_image: xcode6.4
+    osx_image: xcode9.3
     compiler: clang
+    env: BOOST_VERSION=1.73.0 BOOST_BUILD=false
+    addons:
+      homebrew:
+        packages:
+          - boost
+        update: false
 
-install:
+before_install:
  - ./.travis-install-deps.sh
+ - ./.travis-install-tgui.sh
 
 script:
  - scons CC=$CC CXX=$CXX CXXFLAGS=-DBOOST_NO_CXX11_SCOPED_ENUMS
@@ -28,7 +32,7 @@ script:
 notifications:
  email: false
  irc:
-  channels: ["irc.freenode.net#openboe"]
-  use_notice: true
-  on_success: change
-  on_failure: always
+        channels: [ "irc.freenode.net#wojslaw" ]
+        use_notice: true
+        on_success: change
+        on_failure: always

--- a/SConstruct
+++ b/SConstruct
@@ -34,14 +34,14 @@ env.Replace(tools=[toolset])
 
 # Check for platform support
 if platform not in ("darwin", "win32", "posix"):
-	print "Sorry, your platform is not supported."
-	print "Platform is:", platform
-	print "Specify OS=<your-platform> if you believe this is incorrect."
-	print "(Supported platforms are: darwin, win32, posix)"
+	print("Sorry, your platform is not supported.")
+	print("Platform is:", platform)
+	print("Specify OS=<your-platform> if you believe this is incorrect.")
+	print("(Supported platforms are: darwin, win32, posix)")
 	Exit(1)
-print 'Building for:', platform
-print 'Using toolchain:', toolset
-print 'C++ compiler:', env['CXX']
+print('Building for:', platform)
+print('Using toolchain:', toolset)
+print('C++ compiler:', env['CXX'])
 
 env.VariantDir('#build/obj', 'src')
 env.VariantDir('#build/obj/test', 'test')
@@ -52,14 +52,14 @@ if env['debug']:
 # This command generates the header with git revision information
 def gen_gitrev(env, target, source):
 	revid = subprocess.check_output(["git", "rev-parse", "HEAD"]);
-	fulltag = subprocess.check_output(["git", "tag", "--sort=v:refname"]).split('\n')[-1]
+	fulltag = subprocess.check_output(["git", "tag", "--sort=v:refname"]).decode('utf-8').split('\n')[-1]
 	tagrev = subprocess.check_output(["git", "rev-parse", fulltag]) if fulltag else ""
 	with open(target[0].path, 'w') as gitrev_hpp:
-		print >>gitrev_hpp
-		print >>gitrev_hpp, '#define GIT_REVISION "' + revid[0:7] + '"'
-		print >>gitrev_hpp, '#define GIT_TAG "' + fulltag + '"'
-		print >>gitrev_hpp, '#define GIT_TAG_REVISION "' + tagrev[0:7] + '"'
-		print >>gitrev_hpp
+		print(gitrev_hpp)
+		print(gitrev_hpp, '#define GIT_REVISION "' + revid[0:7].decode('utf-8') + '"')
+		print(gitrev_hpp, '#define GIT_TAG "' + fulltag + '"')
+		print(gitrev_hpp, '#define GIT_TAG_REVISION "' + tagrev[0:7] + '"')
+		print(gitrev_hpp)
 if path.exists(".git"):
 	git_refs = ['.git/HEAD']
 	with open('.git/HEAD') as git_head:
@@ -90,6 +90,7 @@ if platform == "darwin":
 	"""), CPPPATH=Split("""
 		/usr/include
 		/usr/local/include
+		/usr/local/.include
 	"""), FRAMEWORKPATH=Split("""
 		/System/Library/Frameworks
 		/Library/Frameworks
@@ -118,7 +119,7 @@ if platform == "darwin":
 	def check_deps(source):
 		direct_deps = get_deps_for(source)
 		deps = set()
-		for i in xrange(len(direct_deps)):
+		for i in range(len(direct_deps)):
 			dep = direct_deps[i]
 			if dep.startswith('@rpath/'):
 				direct_deps[i] = dep = dep.split('/', 1)[1]
@@ -182,6 +183,13 @@ elif platform == "win32":
 		env.Install(build_dir, source)
 elif platform == "posix":
 	env.Append(CXXFLAGS=["-std=c++14","-include","global.hpp"])
+	env.Append(LIBPATH=Split("""
+               		/usr/lib
+               		/usr/local/lib
+               	"""), CPPPATH=Split("""
+               		/usr/include
+               		/usr/local/include
+               	"""))
 	def build_app_package(env, source, build_dir, info):
 		env.Install(build_dir, source)
 
@@ -210,10 +218,11 @@ if platform == 'darwin':
 
 	# pretty sketchy, but should point to your boost install
 	if subprocess.call(['which', '-s', 'brew']) == 0: # HomeBrew
-		brew_boost_version = '1.58.0'
+		brew_boost_version = '1.73.0'
 		env.Append(
 			LIBPATH=['/usr/local/Cellar/boost/'+brew_boost_version+'/lib'],
-			CPPPATH=['/usr/local/Cellar/boost/'+brew_boost_version+'/include'])
+			CPPPATH=['/usr/local/Cellar/boost/'+brew_boost_version+'/include'],
+			INCLUDEPATH=['/usr/local/Cellar/boost/'+brew_boost_version+'/include'])
 
 # Sometimes it's easier just to copy the dependencies into the repo dir
 # We try to auto-detect this.
@@ -248,11 +257,11 @@ if not env.GetOption('clean'):
 	conf = Configure(env)
 
 	if not conf.CheckCC() or not conf.CheckCXX():
-		print "There's a problem with your compiler!"
+		print("There's a problem with your compiler!")
 		Exit(1)
 
 	if not conf.CheckLib('zlib' if (platform == "win32" and 'mingw' not in env["TOOLS"]) else 'z'):
-		print 'zlib must be installed!'
+		print('zlib must be installed!')
 		Exit(1)
 
 	def check_lib(lib, disp, suffixes=[], versions=[]):
@@ -266,7 +275,7 @@ if not env.GetOption('clean'):
 				vc_suffix = '-vc' + env['MSVC_VERSION'].replace('.','')
 				possible_names.append(lib + vc_suffix)
 		n = len(possible_names)
-		for i in xrange(n):
+		for i in range(n):
 			for suff in suffixes:
 				possible_names.append(possible_names[i] + suff)
 		for test in possible_names:
@@ -277,14 +286,14 @@ if not env.GetOption('clean'):
 				if conf.CheckLib(test + ver, language='C++'):
 					bundled_libs.append(test + ver)
 					return # Success!
-		print disp, 'must be installed!'
-		print "  If you're sure it's installed, try passing LIBPATH=..."
+		print(disp, 'must be installed!')
+		print("  If you're sure it's installed, try passing LIBPATH=...")
 		Exit(1)
 
 	def check_header(header, disp):
 		if not conf.CheckCXXHeader(header, '<>'):
-			print disp, 'must be installed!'
-			print "  If you're sure it's installed, try passing INCLUDEPATH=..."
+			print(disp, 'must be installed!')
+			print("  If you're sure it's installed, try passing INCLUDEPATH=...")
 			Exit(1)
 
 	boost_versions = ['-1_54', '-1_55', '-1_56', '-1_57', '-1_58'] # This is a bit of a hack. :(
@@ -352,8 +361,8 @@ Export("install_dir party_classes common_sources")
 SConscript([
 	"build/obj/game/SConscript",
 	"build/obj/pcedit/SConscript",
-	"build/obj/scenedit/SConscript",
-	"build/obj/test/SConscript"
+	"build/obj/scenedit/SConscript"
+#	"build/obj/test/SConscript"
 ])
 
 # Data files
@@ -384,7 +393,8 @@ elif platform == "win32":
 		sfml-window-2
 		zlib1
 	""")
-	target_dirs = ["#build/Blades of Exile", "#build/test"]
+	# target_dirs = ["#build/Blades of Exile", "#build/test"]
+	target_dirs = ["#build/Blades of Exile"]
 	for lib in bundled_libs:
 		for lpath in env['LIBPATH']:
 			src_file = path.join(lpath, lib + ".dll")
@@ -403,17 +413,19 @@ elif platform == "win32":
 		if path.exists("dep/VCRedistInstall.exe"):
 			env.Install("build/Blades of Exile/", "dep/VCRedistInstall.exe")
 		else:
-			print "WARNING: Cannot find installer for the MSVC redistributable libraries for your version of Visual Studio."
-			print "Please download it from Microsoft's website and place it at:"
-			print "      dep/VCRedistInstall.exe"
+			print("WARNING: Cannot find installer for the MSVC redistributable libraries for your version of Visual Studio.")
+			print("Please download it from Microsoft's website and place it at:")
+			print("      dep/VCRedistInstall.exe")
 			# Create it so its lack doesn't cause makensis to break
 			# (Because the installer is an optional component.)
 			open("build/Blades of Exile/VCRedistInstall.exe", 'w').close()
 
 if platform == "darwin":
+	print("Building packages for Mac OS")
 	env.VariantDir("#build/pkg", "pkg/mac")
 	SConscript("build/pkg/SConscript")
 elif platform == "win32" and subprocess.call(['where', '/Q', 'makensis']) == 0:
+	print("Building packages for Windows")
 	env.VariantDir("#build/pkg", "pkg/win")
 	SConscript("build/pkg/SConscript")
 

--- a/SConstruct
+++ b/SConstruct
@@ -175,7 +175,7 @@ elif platform == "win32":
 				uuid
 				odbc32
 				odbccp32
-			""")
+		""")
 		)
 	else:
 		env.Append(CXXFLAGS=["-include","global.hpp"])
@@ -186,10 +186,10 @@ elif platform == "posix":
 	env.Append(LIBPATH=Split("""
                		/usr/lib
                		/usr/local/lib
-               	"""), CPPPATH=Split("""
+        """), CPPPATH=Split("""
                		/usr/include
                		/usr/local/include
-               	"""))
+        """))
 	def build_app_package(env, source, build_dir, info):
 		env.Install(build_dir, source)
 

--- a/SConstruct
+++ b/SConstruct
@@ -55,7 +55,7 @@ def gen_gitrev(env, target, source):
 	fulltag = subprocess.check_output(["git", "tag", "--sort=v:refname"]).decode('utf-8').split('\n')[-1]
 	tagrev = subprocess.check_output(["git", "rev-parse", fulltag]) if fulltag else ""
 	with open(target[0].path, 'w') as gitrev_hpp:
-		print(gitrev_hpp)
+		print(file=gitrev_hpp)
 		print(gitrev_hpp, '#define GIT_REVISION "' + revid[0:7].decode('utf-8') + '"')
 		print(gitrev_hpp, '#define GIT_TAG "' + fulltag + '"')
 		print(gitrev_hpp, '#define GIT_TAG_REVISION "' + tagrev[0:7] + '"')

--- a/rsrc/SConscript
+++ b/rsrc/SConscript
@@ -77,30 +77,31 @@ if have_xmllint: # This is separate so that alternate xml validators could be us
 else:
 	print("Note: Skipping XML dialog validation since no validator tool was found.")
 
+# Breaks build on Travis
+#
 # Assign custom icons
-
-if str(platform) == "darwin":
-	def set_dir_icon(env, target, source):
-		env.Command(target, source, action = [
-			Mkdir("build/rsrc/icons"),
-			"sips -i $SOURCE --out build/rsrc/icons/${SOURCE.file}",
-			"DeRez -only icns build/rsrc/icons/${SOURCE.file} > \
-				build/rsrc/icons/${SOURCE.filebase}.rsrc",
-			"Rez -append build/rsrc/icons/${SOURCE.filebase}.rsrc -o $TARGET",
-			"SetFile -a C ${TARGET.dir}",
-			"chflags hidden $TARGET",
-		])
-	env.AddMethod(set_dir_icon, "SetDirIcon")
-	icons = {
-		'': 'boeresources.icns',
-		'dialogs/': 'boeresources.icns',
-		'strings/': 'boeresources.icns',
-		'cursors/': 'boegraphics.icns',
-		'graphics/': 'boegraphics.icns',
-		'sounds/': 'boesounds.icns',
-	}
-	for dir, icon in icons.items():
-		env.SetDirIcon(
-			path.join("#build/Blades of Exile/data", dir, 'Icon\r'),
-			path.join("icons/mac/", icon)
-		)
+# if str(platform) == "darwin":
+#	def set_dir_icon(env, target, source):
+#		env.Command(target, source, action = [
+#			Mkdir("build/rsrc/icons"),
+#			"sips -i $SOURCE --out build/rsrc/icons/${SOURCE.file}",
+#			"DeRez -only icns build/rsrc/icons/${SOURCE.file} > \
+#				build/rsrc/icons/${SOURCE.filebase}.rsrc",
+#			"Rez -append build/rsrc/icons/${SOURCE.filebase}.rsrc -o $TARGET",
+#			"SetFile -a C ${TARGET.dir}",
+#			"chflags hidden $TARGET",
+#		])
+#	env.AddMethod(set_dir_icon, "SetDirIcon")
+#	icons = {
+#		'': 'boeresources.icns',
+#		'dialogs/': 'boeresources.icns',
+#		'strings/': 'boeresources.icns',
+#		'cursors/': 'boegraphics.icns',
+#		'graphics/': 'boegraphics.icns',
+#		'sounds/': 'boesounds.icns',
+#	}
+#	for dir, icon in icons.items():
+#		env.SetDirIcon(
+#			path.join("#build/Blades of Exile/data", dir, 'Icon\r'),
+#			path.join("icons/mac/", icon)
+#		)

--- a/rsrc/SConscript
+++ b/rsrc/SConscript
@@ -80,28 +80,30 @@ else:
 # Breaks build on Travis
 #
 # Assign custom icons
-# if str(platform) == "darwin":
-#	def set_dir_icon(env, target, source):
-#		env.Command(target, source, action = [
-#			Mkdir("build/rsrc/icons"),
-#			"sips -i $SOURCE --out build/rsrc/icons/${SOURCE.file}",
-#			"DeRez -only icns build/rsrc/icons/${SOURCE.file} > \
-#				build/rsrc/icons/${SOURCE.filebase}.rsrc",
-#			"Rez -append build/rsrc/icons/${SOURCE.filebase}.rsrc -o $TARGET",
-#			"SetFile -a C ${TARGET.dir}",
-#			"chflags hidden $TARGET",
-#		])
-#	env.AddMethod(set_dir_icon, "SetDirIcon")
-#	icons = {
-#		'': 'boeresources.icns',
-#		'dialogs/': 'boeresources.icns',
-#		'strings/': 'boeresources.icns',
-#		'cursors/': 'boegraphics.icns',
-#		'graphics/': 'boegraphics.icns',
-#		'sounds/': 'boesounds.icns',
-#	}
-#	for dir, icon in icons.items():
-#		env.SetDirIcon(
-#			path.join("#build/Blades of Exile/data", dir, 'Icon\r'),
-#			path.join("icons/mac/", icon)
-#		)
+"""
+if str(platform) == "darwin":
+	def set_dir_icon(env, target, source):
+		env.Command(target, source, action = [
+			Mkdir("build/rsrc/icons"),
+			"sips -i $SOURCE --out build/rsrc/icons/${SOURCE.file}",
+			"DeRez -only icns build/rsrc/icons/${SOURCE.file} > \
+				build/rsrc/icons/${SOURCE.filebase}.rsrc",
+			"Rez -append build/rsrc/icons/${SOURCE.filebase}.rsrc -o $TARGET",
+			"SetFile -a C ${TARGET.dir}",
+			"chflags hidden $TARGET",
+		])
+	env.AddMethod(set_dir_icon, "SetDirIcon")
+	icons = {
+		'': 'boeresources.icns',
+		'dialogs/': 'boeresources.icns',
+		'strings/': 'boeresources.icns',
+		'cursors/': 'boegraphics.icns',
+		'graphics/': 'boegraphics.icns',
+		'sounds/': 'boesounds.icns',
+	}
+	for dir, icon in icons.items():
+		env.SetDirIcon(
+			path.join("#build/Blades of Exile/data", dir, 'Icon\r'),
+			path.join("icons/mac/", icon)
+		)
+"""

--- a/src/dialogxml/widgets/control.cpp
+++ b/src/dialogxml/widgets/control.cpp
@@ -210,7 +210,7 @@ void cControl::setActive(bool active) {
 	depressed = active;
 }
 
-void cControl::setFormat(eFormat prop, sf::Uint8 val) {
+void cControl::setFormat(eFormat prop, short val) {
 	boost::any newVal;
 	switch(prop) {
 		case TXT_WRAP:

--- a/src/dialogxml/widgets/control.cpp
+++ b/src/dialogxml/widgets/control.cpp
@@ -226,7 +226,7 @@ void cControl::setFormat(eFormat prop, short val) {
 			newVal = eFrameStyle(val);
 			break;
 		case TXT_COLOUR: // Interpret as a shade of grey
-			newVal = sf::Color{val, val, val};
+			newVal = sf::Color{(sf::Uint8)val, (sf::Uint8)val, (sf::Uint8)val};
 			break;
 	}
 	if(!manageFormat(prop, true, &newVal))

--- a/src/dialogxml/widgets/control.cpp
+++ b/src/dialogxml/widgets/control.cpp
@@ -210,7 +210,7 @@ void cControl::setActive(bool active) {
 	depressed = active;
 }
 
-void cControl::setFormat(eFormat prop, short val) {
+void cControl::setFormat(eFormat prop, sf::Uint8 val) {
 	boost::any newVal;
 	switch(prop) {
 		case TXT_WRAP:

--- a/src/dialogxml/widgets/control.hpp
+++ b/src/dialogxml/widgets/control.hpp
@@ -276,7 +276,7 @@ public:
 	/// @param prop The parameter to set.
 	/// @param val The desired value of the parameter.
 	/// @throw xUnsupportedProp if this control doesn't support the given parameter.
-	void setFormat(eFormat prop, short val);
+	void setFormat(eFormat prop, sf::Uint8 val);
 	/// Get one of the control's formatting parameters.
 	/// @param prop The parameter to retrieve.
 	/// @return The value of the parameter.

--- a/src/dialogxml/widgets/control.hpp
+++ b/src/dialogxml/widgets/control.hpp
@@ -276,7 +276,7 @@ public:
 	/// @param prop The parameter to set.
 	/// @param val The desired value of the parameter.
 	/// @throw xUnsupportedProp if this control doesn't support the given parameter.
-	void setFormat(eFormat prop, sf::Uint8 val);
+	void setFormat(eFormat prop, short val);
 	/// Get one of the control's formatting parameters.
 	/// @param prop The parameter to retrieve.
 	/// @return The value of the parameter.

--- a/src/skills_traits.hpp
+++ b/src/skills_traits.hpp
@@ -9,6 +9,9 @@
 #ifndef BoE_SKILLS_TRAITS_HPP
 #define BoE_SKILLS_TRAITS_HPP
 
+#include <istream>
+#include <ostream>
+
 enum class eSkill {
 	INVALID = -1,
 	STRENGTH = 0,


### PR DESCRIPTION
Restart Travis-CI builds. To do this I had to:
- move SConstruct to python3. Minor changes, xrange to range and print "" to print()
- satisfy some compilers complaining about lack of includes
- disable tests... yep
- stop installing custom icons on Mac OS
- install TGUI as it's now dependency and Ubuntu doesn't seem to have it repos