### PR TITLE
Update to TGUI 0.9.x

### DIFF
--- a/src/game/boe.menu.cpp
+++ b/src/game/boe.menu.cpp
@@ -235,7 +235,7 @@ void OpenBoEMenu::update_for_game_state(eGameMode overall_mode, bool party_in_me
 // Disconnect all spell menu items from signals and clear the menus
 void OpenBoEMenu::purge_spell_menus(tgui::MenuBar::Ptr& menubar) {
 	for(const auto& connection_id : this->spell_menus_connection_ids) {
-		if(!menubar->disconnect(connection_id))
+		if(!menubar->onMenuItemClick.disconnect(connection_id))
 			throw std::runtime_error { "BUG: attempted to disconnect menubar signal using invalid connection id" };
 	}
 

--- a/src/game/boe.menu.hpp
+++ b/src/game/boe.menu.hpp
@@ -26,11 +26,11 @@ public:
 
 private:
 
-	using MenuHierarchy = std::vector<sf::String>;
+	using MenuHierarchy = std::vector<tgui::String>;
 
 	tgui::Gui tgui;
 	cUniverse& univ;
-	const sf::String internal_menubar_widget_name { "openboe-menu" };
+	const tgui::String internal_menubar_widget_name { "openboe-menu" };
 	std::vector<unsigned int> spell_menus_connection_ids;
 
 	tgui::MenuBar::Ptr build_menubar() const;

--- a/src/pcedit/pc.menu.hpp
+++ b/src/pcedit/pc.menu.hpp
@@ -17,11 +17,11 @@ public:
 	
 private:
 	
-	using MenuHierarchy = std::vector<sf::String>;
+	using MenuHierarchy = std::vector<tgui::String>;
 	
 	tgui::Gui tgui;
 	sf::RenderWindow& mainPtr;
-	const sf::String internal_menubar_widget_name { "openboe-pcedit-menu" };
+	const tgui::String internal_menubar_widget_name { "openboe-pcedit-menu" };
 	
 	tgui::MenuBar::Ptr build_menubar() const;
 	void add_menu_placeholders(tgui::MenuBar::Ptr&) const;

--- a/src/scenedit/scen.menu.hpp
+++ b/src/scenedit/scen.menu.hpp
@@ -22,10 +22,10 @@ public:
 	
 private:
 	
-	using MenuHierarchy = std::vector<sf::String>;
+	using MenuHierarchy = std::vector<tgui::String>;
 	
 	tgui::Gui tgui;
-	const sf::String internal_menubar_widget_name { "openboe-scenedit-menu" };
+	const tgui::String internal_menubar_widget_name { "openboe-scenedit-menu" };
 
 	tgui::MenuBar::Ptr build_menubar() const;
 	void add_menu_placeholders(tgui::MenuBar::Ptr&) const;

--- a/src/tools/winutil.hpp
+++ b/src/tools/winutil.hpp
@@ -12,6 +12,7 @@
 #include <boost/filesystem/path.hpp>
 #include <SFML/Window.hpp>
 #include <SFML/Graphics/Image.hpp>
+#include <memory>
 
 char keyToChar(sf::Keyboard::Key key, bool isShift);
 


### PR DESCRIPTION
These are the changes I had to make to compile against TGUI 0.9.1 (the version available in the Arch Linux user repository, AUR).

The main thing is that TGUI uses its own String class now instead of SFML's.

This should fix #284 .

I had to trigger the build with `scons INCLUDEPATH=$HOME/repos/cboe/deps/Catch2/include`. I thought it shouldn't be necessary to pass that INCLUDEPATH manually (and as an absolute path) when Catch2 is meant to be provided as a submodule by default, but that should probably be a separate issue.

Locally, the scons build ran without error and told me All tests passed. The game launches and I've created a party and opened a scenario successfully.
