### PR TITLE
call redraw_everything() when cDialogs move

### DIFF
--- a/src/dialogxml/dialogs/dialog.hpp
+++ b/src/dialogxml/dialogs/dialog.hpp
@@ -41,6 +41,8 @@ class cDialog {
 	short bg;
 	sf::Color defTextClr;
 	sf::RenderWindow win;
+	int winLastX=-1;
+	int winLastY=-1;
 	std::string currentFocus;
 	cDialog* parent;
 	std::string generateRandomString();
@@ -49,6 +51,7 @@ class cDialog {
 	std::vector<std::pair<std::string,cTextField*>> tabOrder;
 	static cDialog* topWindow; // Tracks the frontmost dialog.
 public:
+	static void (*redraw_everything)();
 	/// Performs essential startup initialization. Generally should not be called directly.
 	static void init();
 	/// The light background pattern used by the scenario editor dialogs.

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -115,6 +115,8 @@ int main(int argc, char* argv[]) {
 	debug_oldstructs();
 #endif
 	try{
+		cDialog::redraw_everything = &redraw_everything;
+
 		init_boe(argc, argv);
 		
 		if(!get_bool_pref("GameRunBefore"))


### PR DESCRIPTION
Provides a partial fix for #208.

Based on this thread [here](https://en.sfml-dev.org/forums/index.php?topic=19658.0) it seems that SFML doesn't track an event for window movement. However, it tracks mouse movement and provides `RenderWindow.getPosition()`. So this patch tracks whether `win.getPosition()` reports a new position after a mouse movement event in cDialog. If the position has changed, it calls `redraw_everything()` and this fixes the artifacts left by dragging the dialog.

It's a little janky, but I've made a function pointer for `redraw_everything` in the cDialog class so that function can be provided in `boe.main.cpp` -- since it doesn't exist yet at cDialog's compile-time.

This is only a partial fix. It does not redraw over the artifacts left if the player drags the zenity file browser window, because that seems to be invoked as a subprocess and is not a cDialog.

If there are other dialogs that don't inherit cDialog, it also won't fix those cases.

And, as noted in the SFML forum thread, `getPosition()` won't report a window movement until the mouse has been released (very unfortunate). So the artifact will appear *while* you drag the dialogue, but at least it gets fixed when you finish dragging.

A real ideal solution would be if SFML provides a way to lock the buffer of the main window whenever a cDialog opens or the zenity subprocess is called. I haven't found such a feature yet, and wanted to share this partial fix as one option.