### PR TITLE
Fix tagfile error

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -44,6 +44,7 @@ print('C++ compiler:', env['CXX'])
 
 env.VariantDir('#build/obj', 'src')
 env.VariantDir('#build/obj/test', 'test')
+env.VariantDir('#build/obj/test/deps', 'deps')
 
 if env['debug']:
    env.Append(CCFLAGS=['-g','-o0'])

--- a/src/fileio/tagfile.hpp
+++ b/src/fileio/tagfile.hpp
@@ -14,6 +14,7 @@
 #include <functional> // for reference_wrapper
 #include <istream>
 #include <ostream>
+#include <memory>
 #include <boost/optional.hpp>
 
 class cTagFile;

--- a/src/tools/SConscript
+++ b/src/tools/SConscript
@@ -17,6 +17,7 @@ tools = Split("""
 	../fileio/map_parse.cpp
 	../fileio/special_parse.cpp
 	../fileio/tarball.cpp
+	../fileio/tagfile.cpp
 	../fileio/gzstream/gzstream.cpp
 """) + Glob("../fileio/resmgr/*.cpp") + Glob("../gfx/*.cpp") + Glob("../scenario/*.cpp")
 

--- a/test/SConscript
+++ b/test/SConscript
@@ -3,6 +3,9 @@ import subprocess
 
 Import("env platform party_classes common_sources")
 
+# Add path to scons
+env.Append(CPPPATH=['./deps/Catch2/single_include'])
+
 test_sources = Glob("""*.cpp""") + Split("""
 	#build/obj/scenedit/scen.fileio.cpp
 """)


### PR DESCRIPTION
Actually does 2 things.

1: Fix the tagfile `#include <memory>` error, and also the linker error from tagfile.cpp not copying into build/obj.
2: Fix the Scons process so it copies Catch2 into build/obj/test/deps like we discussed in IRC.