### PR TITLE
Test case for dialog XMLs

### DIFF
--- a/src/fileio/resmgr/res_dialog.cpp
+++ b/src/fileio/resmgr/res_dialog.cpp
@@ -16,15 +16,7 @@ extern std::ostream& std_fmterr(std::ostream& out);
 class DialogLoader : public ResMgr::cLoader<DialogDefn> {
 	/// Load a dialog definition from an XML file.
 	DialogDefn* operator() (const fs::path& fpath) const override {
-		TiXmlBase::SetCondenseWhiteSpace(false);
-		ticpp::Document xml(fpath.string().c_str());
-		try {
-			xml.LoadFile();
-		} catch(ticpp::Exception& e) {
-			std::cerr << "Error reading XML file: " << e.what();
-			throw ResMgr::xError(ResMgr::ERR_LOAD, "Failed to load dialog: " + fpath.string());
-		}
-		return new DialogDefn{fpath.stem().string(), std::move(xml)};
+		return load_dialog_defn(fpath);
 	}
 
 	ResourceList expand(const std::string& name) const override {
@@ -35,6 +27,18 @@ class DialogLoader : public ResMgr::cLoader<DialogDefn> {
 		return "dialog definition";
 	}
 };
+
+DialogDefn* load_dialog_defn(const fs::path& fpath) {
+	TiXmlBase::SetCondenseWhiteSpace(false);
+	ticpp::Document xml(fpath.string().c_str());
+	try {
+		xml.LoadFile();
+	} catch(ticpp::Exception& e) {
+		std::cerr << "Error reading XML file: " << e.what();
+		throw ResMgr::xError(ResMgr::ERR_LOAD, "Failed to load dialog: " + fpath.string());
+	}
+	return new DialogDefn{fpath.stem().string(), std::move(xml)};
+}
 
 // TODO: What's a good max dialogs count?
 static DialogLoader loader;

--- a/src/fileio/resmgr/res_dialog.hpp
+++ b/src/fileio/resmgr/res_dialog.hpp
@@ -19,6 +19,8 @@ struct DialogDefn {
 	/// The XML definition of the dialog.
 	ticpp::Document defn;
 };
+/// Load a dialog definition from an XML file.
+DialogDefn* load_dialog_defn(const fs::path& fpath);
 
 using DialogRsrc = ResMgr::cPointer<DialogDefn>;
 

--- a/test/dialogs.cpp
+++ b/test/dialogs.cpp
@@ -1,0 +1,30 @@
+//
+//  dialogs.cpp
+//  BoE
+//
+//  Created by Nat Nelson on 2023-01-06
+//
+
+#include "catch.hpp"
+#include <boost/filesystem.hpp>
+#include "fileio/resmgr/res_dialog.hpp"
+#include "dialogxml/dialogs/dialog.hpp"
+
+TEST_CASE("Construct each type of dialog in the engine") {
+	fs::path dialogsPath = fs::current_path()/".."/"Blades of Exile"/"data"/"dialogs";
+	fs::directory_iterator it{dialogsPath};
+	auto end = fs::directory_iterator{};
+	
+	while (it != end) {
+		fs::path path = it->path();
+		std::string filename = path.stem().string();
+		CAPTURE(filename);
+		CHECK_NOTHROW({
+			DialogDefn* defn = load_dialog_defn(path);
+			cDialog dialog(*defn);
+			delete defn;
+		});
+		
+		++it;
+	}
+}


### PR DESCRIPTION
This test case should catch potential regressions of #273.

cDialog prepends data/dialogs onto the path you pass it, so I had to add an optional flag to not do that, so the tests can pass a path relative to their cwd.