### PR TITLE
Linux handle zenity non-zero code. Close #301

### DIFF
--- a/src/tools/winutil.linux.cpp
+++ b/src/tools/winutil.linux.cpp
@@ -145,12 +145,17 @@ static std::string runFileDialog(const std::string& file, bool save) {
         if (fgets(buffer, 128, hfile) != NULL)
             filename += buffer;
     }
+	
+	// When the dialogue is canceled, return empty string.
+    int result = pclose(hfile);
+    if (result != 0) {
+        return "";
+    }
 
     // Remove possible unwanted newline included from end of popen() output
     if (filename[filename.length()-1] == '\n')
         filename.erase(filename.length()-1);
 
-    pclose(hfile);
     return filename;
 }
 


### PR DESCRIPTION
I started trying to change the return type to boost::optional, but that turned out to be a lot of work and I realized the if statements would then have to check the optional for existence AND check the value for non-emptiness, which would just be silly.