### PR TITLE
Windows file dialog return empty on cancel/error

### DIFF
--- a/src/tools/winutil.win.cpp
+++ b/src/tools/winutil.win.cpp
@@ -208,8 +208,10 @@ static std::string runFileDlog(OPENFILENAMEA& dlg, const std::string& file, bool
 	if(save) err = GetSaveFileNameA(&dlg);
 	else err = GetOpenFileNameA(&dlg);
 	if(err == 0) {
-#define CASE(x) case x: std::cerr << "File dialog failed: " #x << std::endl; break
+#define CASE(x) case x: std::cerr << "File dialog failed: " #x << std::endl; return ""
 		switch(CommDlgExtendedError()) {
+			// Code 0 means the user clicked 'Cancel'
+			case 0: std::cout << "File dialog cancelled:" #x << std::endl; return "";
 			CASE(CDERR_DIALOGFAILURE);
 			CASE(CDERR_FINDRESFAILURE);
 			CASE(CDERR_INITIALIZATION);

--- a/src/tools/winutil.win.cpp
+++ b/src/tools/winutil.win.cpp
@@ -208,7 +208,7 @@ static std::string runFileDlog(OPENFILENAMEA& dlg, const std::string& file, bool
 	if(save) err = GetSaveFileNameA(&dlg);
 	else err = GetOpenFileNameA(&dlg);
 	if(err == 0) {
-#define CASE(x) case x: std::cerr << "File dialog failed: " #x << std::endl; return ""
+#define CASE(x) case x: std::cerr << "File dialog failed: " #x << std::endl; return "";
 		switch(CommDlgExtendedError()) {
 			// Code 0 means the user clicked 'Cancel'
 			case 0: std::cout << "File dialog cancelled:" #x << std::endl; return "";


### PR DESCRIPTION
If it compiles, this should fix #268.

According to this documentation:

https://learn.microsoft.com/en-us/windows/win32/api/commdlg/nf-commdlg-getopenfilenamea
https://learn.microsoft.com/en-us/windows/win32/api/commdlg/nf-commdlg-getsavefilenamea
https://learn.microsoft.com/en-us/windows/win32/api/commdlg/nf-commdlg-commdlgextendederror

When Get{Open/Save}FileNameA() finishes with the Cancel input, the function returns false and the error code is 0.

So the code had 2 problems before: 1) not checking for the cancel code 0, and 2) not returning an empty string on error.

Someone needs to test this on Windows