### PR TITLE
Make sure lpstrFile is empty on cancel

### DIFF
--- a/src/tools/winutil.win.cpp
+++ b/src/tools/winutil.win.cpp
@@ -208,6 +208,7 @@ static std::string runFileDlog(OPENFILENAMEA& dlg, const std::string& file, bool
 	if(save) err = GetSaveFileNameA(&dlg);
 	else err = GetOpenFileNameA(&dlg);
 	if(err == 0) {
+		dlg.lpstrFile = "";
 #define CASE(x) case x: std::cerr << "File dialog failed: " #x << std::endl; break
 		switch(CommDlgExtendedError()) {
 			CASE(CDERR_DIALOGFAILURE);

--- a/src/tools/winutil.win.cpp
+++ b/src/tools/winutil.win.cpp
@@ -208,7 +208,7 @@ static std::string runFileDlog(OPENFILENAMEA& dlg, const std::string& file, bool
 	if(save) err = GetSaveFileNameA(&dlg);
 	else err = GetOpenFileNameA(&dlg);
 	if(err == 0) {
-		dlg.lpstrFile = "";
+		dlg.lpstrFile[0] = '\0';
 #define CASE(x) case x: std::cerr << "File dialog failed: " #x << std::endl; break
 		switch(CommDlgExtendedError()) {
 			CASE(CDERR_DIALOGFAILURE);


### PR DESCRIPTION
I built the game on Windows and found that I actually couldn't reproduce #268 -- because it seems that dlg.lpstrFile is actually an empty string in the case of a cancel or an error. At least, when built with Visual Studio 2017, that was the case when I debugged it a few times.

Maybe it's not guaranteed that lpstrFile will be an empty string, and random behavior caused this bug. I've added a commit that sets it to an empty string, which will guarantee that doesn't happen.

This, unlike my previous PR, also avoids leaking memory by following the same control flow as before.

This should close #268.