### PR TITLE
[WIP] Fix 244b

### DIFF
--- a/rsrc/dialogs/edit-scenario-events.xml
+++ b/rsrc/dialogs/edit-scenario-events.xml
@@ -2,27 +2,41 @@
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->
-	<field name='time1' top='133' left='130' width='67' height='16'/>
-	<field name='time2' top='161' left='130' width='67' height='16'/>
-	<field name='time3' top='189' left='130' width='67' height='16'/>
-	<field name='time4' top='217' left='130' width='67' height='16'/>
-	<field name='time5' top='245' left='130' width='67' height='16'/>
-	<field name='time6' top='273' left='130' width='67' height='16'/>
-	<field name='time7' top='301' left='130' width='67' height='16'/>
-	<field name='time8' top='329' left='130' width='67' height='16'/>
-	<field name='time9' top='357' left='130' width='67' height='16'/>
-	<field name='time10' top='385' left='130' width='67' height='16'/>
-	<field name='node1' top='133' left='270' width='39' height='16'/>
-	<field name='node2' top='161' left='270' width='39' height='16'/>
-	<field name='node3' top='189' left='270' width='39' height='16'/>
-	<field name='node4' top='217' left='270' width='39' height='16'/>
-	<field name='node5' top='245' left='270' width='39' height='16'/>
-	<field name='node6' top='273' left='270' width='39' height='16'/>
-	<field name='node7' top='301' left='270' width='39' height='16'/>
-	<field name='node8' top='329' left='270' width='39' height='16'/>
-	<field name='node9' top='357' left='270' width='39' height='16'/>
-	<field name='node10' top='385' left='270' width='39' height='16'/>
-	<button name='okay' type='regular' top='383' left='431'>OK</button>
+	<stack name='list' pages='2'>
+		<field name='time1' top='133' left='130' width='67' height='16'/>
+		<field name='time2' top='161' left='130' width='67' height='16'/>
+		<field name='time3' top='189' left='130' width='67' height='16'/>
+		<field name='time4' top='217' left='130' width='67' height='16'/>
+		<field name='time5' top='245' left='130' width='67' height='16'/>
+		<field name='time6' top='273' left='130' width='67' height='16'/>
+		<field name='time7' top='301' left='130' width='67' height='16'/>
+		<field name='time8' top='329' left='130' width='67' height='16'/>
+		<field name='time9' top='357' left='130' width='67' height='16'/>
+		<field name='time10' top='385' left='130' width='67' height='16'/>
+		<field name='node1' top='133' left='270' width='39' height='16'/>
+		<field name='node2' top='161' left='270' width='39' height='16'/>
+		<field name='node3' top='189' left='270' width='39' height='16'/>
+		<field name='node4' top='217' left='270' width='39' height='16'/>
+		<field name='node5' top='245' left='270' width='39' height='16'/>
+		<field name='node6' top='273' left='270' width='39' height='16'/>
+		<field name='node7' top='301' left='270' width='39' height='16'/>
+		<field name='node8' top='329' left='270' width='39' height='16'/>
+		<field name='node9' top='357' left='270' width='39' height='16'/>
+		<field name='node10' top='385' left='270' width='39' height='16'/>
+	</stack>
+	<button name='edit1' type='large' top='131' left='324'>Create/Edit</button>
+	<button name='edit2' type='large' top='159' left='324'>Create/Edit</button>
+	<button name='edit3' type='large' top='187' left='324'>Create/Edit</button>
+	<button name='edit4' type='large' top='215' left='324'>Create/Edit</button>
+	<button name='edit5' type='large' top='243' left='324'>Create/Edit</button>
+	<button name='edit6' type='large' top='271' left='324'>Create/Edit</button>
+	<button name='edit7' type='large' top='299' left='324'>Create/Edit</button>
+	<button name='edit8' type='large' top='327' left='324'>Create/Edit</button>
+	<button name='edit9' type='large' top='355' left='324'>Create/Edit</button>
+	<button name='edit10' type='large' top='383' left='324'>Create/Edit</button>
+	<button name='prev' type='left' def-key='left' top='411' left='130'/>
+	<button name='next' type='right' def-key='right' top='411' left='200'/>
+	<button name='okay' type='regular' top='411' left='350'>OK</button>
 	<pict type='dlog' num='16' top='8' left='8'/>
 	<text size='large' top='6' left='50' width='256' height='17'>Scenario event timers</text>
 	<text top='25' left='50' width='438' height='55'>
@@ -39,16 +53,6 @@
 		Note: If you leave the time between calls at 0, no special node is called.
 		Don't have special nodes called too often ... it slows the game down.
 	</text>
-	<button name='edit1' type='large' top='131' left='324'>Create/Edit</button>
-	<button name='edit2' type='large' top='159' left='324'>Create/Edit</button>
-	<button name='edit3' type='large' top='187' left='324'>Create/Edit</button>
-	<button name='edit4' type='large' top='215' left='324'>Create/Edit</button>
-	<button name='edit5' type='large' top='243' left='324'>Create/Edit</button>
-	<button name='edit6' type='large' top='271' left='324'>Create/Edit</button>
-	<button name='edit7' type='large' top='299' left='324'>Create/Edit</button>
-	<button name='edit8' type='large' top='327' left='324'>Create/Edit</button>
-	<button name='edit9' type='large' top='355' left='324'>Create/Edit</button>
-	<button name='edit10' type='large' top='383' left='324'>Create/Edit</button>
 	<text top='353' left='2' width='119' height='52'>
 		Also, the time between events must be a multiple of 10.
 	</text>


### PR DESCRIPTION
Still in progress--this PR will fix the second crash reported in #244 by adding an extra page of scenario event timers in the scenario editor so all 20 can be used.

The first 2 commits, cc18c56866fa0c90239789eb39c0ba4b931b0825 and 1c775da7d2fec3b711861bd4396e3a1181191cf4, fix bugs in cDialog that caused other issues which I didn't open tickets for:

1) text field controls inside stack widgets didn't become focused when clicked on. The tab key was the only way to focus them.
2) entering characters to a text field in a stack widget would cause a crash.

Those bugs could be observed by editing town details and trying to edit the 3 comment fields which are managed by a stack.