### PR TITLE
Fix visual studio build

### DIFF
--- a/proj/vs2017/Common/Common.vcxproj
+++ b/proj/vs2017/Common/Common.vcxproj
@@ -456,7 +456,7 @@
     <ClInclude Include="..\..\..\src\fileio\resmgr\res_sound.hpp" />
     <ClInclude Include="..\..\..\src\fileio\resmgr\res_strings.hpp" />
     <ClInclude Include="..\..\..\src\fileio\special_parse.hpp" />
-    <ClCompile Include="..\..\..\src\fileio\tagfile.hpp" />
+    <ClInclude Include="..\..\..\src\fileio\tagfile.hpp" />
     <ClInclude Include="..\..\..\src\fileio\tarball.hpp" />
     <ClInclude Include="..\..\..\src\fileio\xml-parser\ticpp.h" />
     <ClInclude Include="..\..\..\src\fileio\xml-parser\ticppapi.h" />

--- a/src/fileio/fileio_scen.cpp
+++ b/src/fileio/fileio_scen.cpp
@@ -317,7 +317,7 @@ bool load_scenario_v1(fs::path file_to_load, cScenario& scenario, bool only_head
 		if(info.type == eShopItemType::ITEM) {
 			int end = info.first + info.count;
 			end = min(end, scenario.scen_items.size());
-			shop.addItems(info.first, scenario.scen_items.begin() + info.first, scenario.scen_items.begin() + end, cShop::INFINITE);
+			shop.addItems(info.first, scenario.scen_items.begin() + info.first, scenario.scen_items.begin() + end, cShop::INFINITE_AMOUNT);
 		} else {
 			int max = 62;
 			if(info.type == eShopItemType::ALCHEMY)

--- a/src/fileio/xml-parser/tinyxmlparser.cpp
+++ b/src/fileio/xml-parser/tinyxmlparser.cpp
@@ -109,17 +109,17 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 			--output;
 			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
 			input >>= 6;
-			[[fallthrough]];
+			// [[fallthrough]];
 		case 3:
 			--output;
 			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
 			input >>= 6;
-			[[fallthrough]];
+			// [[fallthrough]];
 		case 2:
 			--output;
 			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
 			input >>= 6;
-			[[fallthrough]];
+			// [[fallthrough]];
 		case 1:
 			--output;
 			*output = (char)(input | FIRST_BYTE_MARK[*length]);

--- a/src/scenario/outdoors.hpp
+++ b/src/scenario/outdoors.hpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <iosfwd>
 #include <array>
+#include <bitset>
 
 #include "location.hpp"
 #include "special.hpp"

--- a/src/scenario/shop.hpp
+++ b/src/scenario/shop.hpp
@@ -15,11 +15,6 @@
 #include "item.hpp"
 #include "dialogxml/widgets/pictypes.hpp" // for pic_num_t
 
-// Windows headers are really annoying with their defined constants.
-#ifdef INFINITE
-#undef INFINITE
-#endif
-
 enum class eShopType {NORMAL, ALLOW_DEAD, RANDOM};
 
 enum class eShopPrompt {SHOPPING, HEALING, MAGE, PRIEST, SPELLS, ALCHEMY, TRAINING};
@@ -67,7 +62,7 @@ class cShop {
 	pic_num_t face;
 	size_t firstEmpty() const;
 public:
-	static const size_t INFINITE = 0;
+	static const size_t INFINITE_AMOUNT = 0;
 	cShop();
 	cShop(eShopType type, eShopPrompt prompt, pic_num_t pic, int adj, std::string name);
 	explicit cShop(std::string name);

--- a/src/universe/party.cpp
+++ b/src/universe/party.cpp
@@ -971,7 +971,7 @@ void cParty::readFrom(const cTagFile& file) {
 			}
 			
 			vector2d<int> shop_stock;
-			page["SHOPSTOCK"].extractSparse(shop_stock);
+			page["SHOPSTOCK"].extractSparse<int>(shop_stock);
 			for(size_t x = 0; x < shop_stock.width(); x++) {
 				for(size_t y = 0; y < shop_stock.height(); y++) {
 					store_limited_stock[x][y] = shop_stock[x][y];

--- a/test/tagfiles.cpp
+++ b/test/tagfiles.cpp
@@ -148,7 +148,7 @@ TEST_CASE("Complex tag file") {
 		sdf[0][0] = 12;
 		sdf[1][3] = 52;
 		sdf[5][9] = 81;
-		p3["SDF"].encodeSparse(sdf);
+		p3["SDF"].encodeSparse<int>(sdf);
 		std::map<std::string, std::string> dict{
 			{"foo", "bar"},
 			{"a b", "c d"},
@@ -269,7 +269,7 @@ TEST_CASE("Complex tag file") {
 				CHECK(records[4] == std::string(""));
 				CHECK(records[5] == std::string("Isn't it cool?"));
 				vector2d<int> sdf;
-				page["SDF"].extractSparse(sdf);
+				page["SDF"].extractSparse<int>(sdf);
 				REQUIRE(sdf.width() == 6);
 				REQUIRE(sdf.height() == 10);
 				CHECK(sdf[0][0] == 12);


### PR DESCRIPTION
- The new version of tinyxml uses [[fallthrough]] declarations that only serve to suppress a warning and require c++17 so I commented them out: https://en.cppreference.com/w/cpp/language/attributes/fallthrough
  - This modification should be fine according to Tinyxml's MIT license, which I don't think requires adding a notice that it's modified.
- For some reason the `#undef INFINITE` directive isn't working. I figured renaming the constant could be a suitable alternative.