### PR TITLE
Fix swap() double-call

### DIFF
--- a/src/universe/party.cpp
+++ b/src/universe/party.cpp
@@ -164,7 +164,6 @@ void swap(cParty& lhs, cParty& rhs) {
 	swap(lhs.total_xp_gained, rhs.total_xp_gained);
 	swap(lhs.total_dam_taken, rhs.total_dam_taken);
 	swap(lhs.scen_name, rhs.scen_name);
-	swap(lhs.adven, rhs.adven);
 	swap(lhs.setup, rhs.setup);
 	swap(lhs.stored_items, rhs.stored_items);
 	swap(lhs.summons, rhs.summons);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2584745/215221171-60be6b7f-87ae-46f6-a4b1-0a3c4ca2ef64.png)

After finding that #324 was due to swap() getting called twice, I figured out why the double-call was happening. For some reason, making the argument to the cUniverse copy constructor a reference and not a double-reference averts the bug. The double-reference looked wrong to me anyway, so maybe this is a correct solution.