### PR TITLE
Change -o0 to -O0

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -47,7 +47,7 @@ env.VariantDir('#build/obj/test', 'test')
 env.VariantDir('#build/obj/test/deps', 'deps')
 
 if env['debug']:
-   env.Append(CCFLAGS=['-g','-o0'])
+   env.Append(CCFLAGS=['-g','-O0'])
 
 # This command generates the header with git revision information
 def gen_gitrev(env, target, source):


### PR DESCRIPTION
I've only tested this change on Linux. Does CI run a debug build? If so, it'll determine whether this change works on other platforms.

Fixes #343 