### PR TITLE
Build fix redo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@
 				},
 				{
 					name: install dependencies,
-					run: 'vcpkg install',
-					working-directory: proj/vs2013
+					run: '.\.github\workflows\scripts\win\install-deps.bat x86',
+					working-directory: proj/vs2017
 				},
 				{
 					name: build,
@@ -91,7 +91,7 @@
 				},
 				{
 					name: install dependencies,
-					run: 'vcpkg install',
+					run: '.\.github\workflows\scripts\win\install-deps.bat x64',
 					working-directory: proj/vs2017
 				},
 				{

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,10 @@
 					with: { submodules: true }
 				},
 				{
+					name: build and unit test,
+					run: '.\.github\workflows\scripts\win\scons-build.bat'
+				},
+				{
 					name: install build dependencies,
 					run: 'vcpkg install libxml2 && pip install scons'
 				},
@@ -120,10 +124,6 @@
 					name: install dependencies,
 					run: '${{ github.workspace }}\.github\workflows\scripts\win\install-deps.bat x64',
 					working-directory: proj/vs2017
-				},
-				{
-					name: build and unit test,
-					run: '.\.github\workflows\scripts\win\scons-build.bat'
 				}
 			]
 		},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,10 +113,6 @@
 					with: { submodules: true }
 				},
 				{
-					name: build and unit test,
-					run: '.\.github\workflows\scripts\win\scons-build.bat'
-				},
-				{
 					name: install build dependencies,
 					run: 'vcpkg install libxml2 && pip install scons'
 				},
@@ -124,6 +120,10 @@
 					name: install dependencies,
 					run: '${{ github.workspace }}\.github\workflows\scripts\win\install-deps.bat x64',
 					working-directory: proj/vs2017
+				},
+				{
+					name: build and unit test,
+					run: '.\.github\workflows\scripts\win\scons-build.bat'
 				}
 			]
 		},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,10 @@
 					uses: actions/checkout@v2,
 					with: { submodules: true }
 				},
-				#{
-				#	name: install build dependencies,
-				#	run: 'vcpkg install libxml2 && pip install scons'
-				#},
+				{
+					name: install build dependencies,
+					run: 'vcpkg install libxml2 && pip install scons'
+				},
 				{
 					name: install dependencies,
 					run: '${{ github.workspace }}\.github\workflows\scripts\win\install-deps.bat x64',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@
 				},
 				{
 					name: install dependencies,
-					run: '.\.github\workflows\scripts\win\install-deps.bat x86',
+					run: '${{ github.workspace }}\.github\workflows\scripts\win\install-deps.bat x86',
 					working-directory: proj/vs2017
 				},
 				{
@@ -91,7 +91,7 @@
 				},
 				{
 					name: install dependencies,
-					run: '.\.github\workflows\scripts\win\install-deps.bat x64',
+					run: '${{ github.workspace }}\.github\workflows\scripts\win\install-deps.bat x64',
 					working-directory: proj/vs2017
 				},
 				{
@@ -118,7 +118,7 @@
 				},
 				{
 					name: install dependencies,
-					run: '.\.github\workflows\scripts\win\install-deps.bat x64',
+					run: '${{ github.workspace }}\.github\workflows\scripts\win\install-deps.bat x64',
 					working-directory: proj/vs2017
 				},
 				{

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,10 @@
 					uses: actions/checkout@v2,
 					with: { submodules: true }
 				},
-				{
-					name: install build dependencies,
-					run: 'vcpkg install libxml2 && pip install scons'
-				},
+				#{
+				#	name: install build dependencies,
+				#	run: 'vcpkg install libxml2 && pip install scons'
+				#},
 				{
 					name: install dependencies,
 					run: '${{ github.workspace }}\.github\workflows\scripts\win\install-deps.bat x64',
@@ -129,7 +129,12 @@
 				{
 					name: debug print vcpkg manifest install directories,
 					run: 'dir',
-					working-directory: 'C:/vcpkg/vcpkg_installed'
+					working-directory: 'C:/vcpkg/installed'
+				},
+				{
+					name: debug print vcpkg manifest install directories,
+					run: 'dir',
+					working-directory: 'C:/vcpkg/triplets'
 				},
 				{
 					name: build and unit test,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,9 +127,9 @@
 					working-directory: 'C:/vcpkg'
 				},
 				{
-					name: debug print vcpkg manifest install directories,
+					name: debug print vcpkg package install directories,
 					run: 'dir',
-					working-directory: 'C:/vcpkg/installed'
+					working-directory: 'C:/vcpkg/packages'
 				},
 				{
 					name: debug print vcpkg manifest install directories,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@
 		# 	]
 		# },
 		linux: {
-			runs-on: ubuntu-20.04,
+			runs-on: ubuntu-22.04,
 			steps: [
 				{
 					name: checkout,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@
 				},
 				{
 					name: install dependencies,
-					run: 'vcpkg install',
+					run: '.\.github\workflows\scripts\win\install-deps.bat x64',
 					working-directory: proj/vs2017
 				},
 				{

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,8 @@
 				},
 				{
 					name: install dependencies,
-					run: '.\.github\workflows\scripts\win\install-deps.bat x86'
+					run: 'vcpkg install',
+					working-directory: proj/vs2013
 				},
 				{
 					name: build,
@@ -90,7 +91,8 @@
 				},
 				{
 					name: install dependencies,
-					run: '.\.github\workflows\scripts\win\install-deps.bat x64'
+					run: 'vcpkg install',
+					working-directory: proj/vs2017
 				},
 				{
 					name: build,
@@ -116,7 +118,8 @@
 				},
 				{
 					name: install dependencies,
-					run: '.\.github\workflows\scripts\win\install-deps.bat x64'
+					run: 'vcpkg install',
+					working-directory: proj/vs2017
 				},
 				{
 					name: build and unit test,
@@ -138,7 +141,8 @@
 		# 		},
 		# 		{
 		# 			name: install dependencies,
-		# 			run: '.\.github\workflows\scripts\win\install-deps.bat x64'
+		# 			run: 'vcpkg install',
+		# 			working-directory: proj/vs2017
 		# 		},
 		# 		{
 		# 			name: build and unit test,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,99 +11,99 @@
 	},
 
 	jobs: {
-		macos-xcode: {
-			runs-on: macos-12,
-			env: {
-				DEVELOPER_DIR: /Applications/Xcode_13.4.app/Contents/Developer
-			},
-			steps: [
-				{
-					name: checkout,
-					uses: actions/checkout@v2,
-					with: { submodules: true }
-				},
-				{
-					name: install Boost,
-					run: brew install Boost
-				},
-				{
-					name: install SFML,
-					run: ./.github/workflows/scripts/mac/install-sfml.sh
-				},
-				{
-					name: patch Xcode project,
-					run: ./.github/workflows/scripts/mac/fix-xcode-proj.sh
-				},
-				{
-					name: build,
-					run: ./.github/workflows/scripts/mac/xcode-build.sh
-				},
-				{
-					name: unit tests,
-					run: ./.github/workflows/scripts/mac/run-tests.sh
-				}
-			]
-		},
-		macos-scons: {
-			runs-on: macos-12,
-			steps:  [
-				{
-					name: checkout,
-					uses: actions/checkout@v2,
-				with: { submodules: true }
-				},
-				{
-					name: install dependencies,
-					run: brew install scons SFML Boost
-				},
-				{
-					name: build and unit test,
-					run: ./.github/workflows/scripts/mac/scons-build.sh
-				}
-			]
-		},
-		win-vs32: {
-			runs-on: windows-2019,
-			steps: [
-				{
-					name: checkout,
-					uses: actions/checkout@v2,
-					with: { submodules: true }
-				},
-				{
-					name: install dependencies,
-					run: '${{ github.workspace }}\.github\workflows\scripts\win\install-deps.bat x86',
-					working-directory: proj/vs2017
-				},
-				{
-					name: build,
-					run: '.\.github\workflows\scripts\win\msvc-build.bat x86'
-				}
-			]
-		},
-		win-vs64: {
-			runs-on: windows-2019,
-			steps: [
-				{
-					name: checkout,
-					uses: actions/checkout@v2,
-					with: { submodules: true }
-				},
-				{
-					name: install dependencies,
-					run: '${{ github.workspace }}\.github\workflows\scripts\win\install-deps.bat x64',
-					working-directory: proj/vs2017
-				},
-				{
-					name: build,
-					run: '.\.github\workflows\scripts\win\msvc-build.bat x64'
-				},
-				{
-					name: unit tests,
-					run: '.\.github\workflows\scripts\win\run-tests.bat'
-				}
-			]
-		},
+#		macos-xcode: {
+#			runs-on: macos-12,
+#			env: {
+#				DEVELOPER_DIR: /Applications/Xcode_13.4.app/Contents/Developer
+#			},
+#			steps: [
+#				{
+#					name: checkout,
+#					uses: actions/checkout@v2,
+#					with: { submodules: true }
+#				},
+#				{
+#					name: install Boost,
+#					run: brew install Boost
+#				},
+#				{
+#					name: install SFML,
+#					run: ./.github/workflows/scripts/mac/install-sfml.sh
+#				},
+#				{
+#					name: patch Xcode project,
+#					run: ./.github/workflows/scripts/mac/fix-xcode-proj.sh
+#				},
+#				{
+#					name: build,
+#					run: ./.github/workflows/scripts/mac/xcode-build.sh
+#				},
+#				{
+#					name: unit tests,
+#					run: ./.github/workflows/scripts/mac/run-tests.sh
+#				}
+#			]
+#		},
+#		macos-scons: {
+#			runs-on: macos-12,
+#			steps:  [
+#				{
+#					name: checkout,
+#					uses: actions/checkout@v2,
+#				with: { submodules: true }
+#				},
+#				{
+#					name: install dependencies,
+#					run: brew install scons SFML Boost
+#				},
+#				{
+#					name: build and unit test,
+#					run: ./.github/workflows/scripts/mac/scons-build.sh
+#				}
+#			]
+#		},
+#		win-vs32: {
+#			runs-on: windows-2019,
+#			steps: [
+#				{
+#					name: checkout,
+#					uses: actions/checkout@v2,
+#					with: { submodules: true }
+#				},
+#				{
+#					name: install dependencies,
+#					run: '${{ github.workspace }}\.github\workflows\scripts\win\install-deps.bat x86',
+#					working-directory: proj/vs2017
+#				},
+#				{
+#					name: build,
+#					run: '.\.github\workflows\scripts\win\msvc-build.bat x86'
+#				}
+#			]
+#		},
+#		win-vs64: {
+#			runs-on: windows-2019,
+#			steps: [
+#				{
+#					name: checkout,
+#					uses: actions/checkout@v2,
+#					with: { submodules: true }
+#				},
+#				{
+#					name: install dependencies,
+#					run: '${{ github.workspace }}\.github\workflows\scripts\win\install-deps.bat x64',
+#					working-directory: proj/vs2017
+#				},
+#				{
+#					name: build,
+#					run: '.\.github\workflows\scripts\win\msvc-build.bat x64'
+#				},
+#				{
+#					name: unit tests,
+#					run: '.\.github\workflows\scripts\win\run-tests.bat'
+#				}
+#			]
+#		},
 		win-scons: {
 			runs-on: windows-2019,
 			steps: [
@@ -122,8 +122,14 @@
 					working-directory: proj/vs2017
 				},
 				{
-					name: make sure scons can find dependencies,
-					run: vcpkg integrate install
+					name: debug print vcpkg root directory,
+					run: 'dir',
+					working-directory: C:/vcpkg
+				},
+				{
+					name: debug print vcpkg manifest install directories,
+					run: 'dir',
+					working-directory: C:/vcpkg/vcpkg_installed
 				},
 				{
 					name: build and unit test,
@@ -154,27 +160,27 @@
 		# 		}
 		# 	]
 		# },
-		linux: {
-			runs-on: ubuntu-22.04,
-			steps: [
-				{
-					name: checkout,
-					uses: actions/checkout@v2,
-					with: { submodules: true }
-				},
-				{
-					name: install dependencies,
-					run: 'sudo apt-get install scons libxml2-utils zlib1g libsfml-dev libboost-all-dev zenity'
-				},
-				{
-					name: install TGUI,
-					run: 'sudo ./.github/workflows/scripts/linux/install-tgui.sh'
-				},
-				{
-					name: build and unit test,
-					run: CCFLAGS=-fdiagnostics-color=always scons
-				}
-			],
-		}
+#		linux: {
+#			runs-on: ubuntu-22.04,
+#			steps: [
+#				{
+#					name: checkout,
+#					uses: actions/checkout@v2,
+#					with: { submodules: true }
+#				},
+#				{
+#					name: install dependencies,
+#					run: 'sudo apt-get install scons libxml2-utils zlib1g libsfml-dev libboost-all-dev zenity'
+#				},
+#				{
+#					name: install TGUI,
+#					run: 'sudo ./.github/workflows/scripts/linux/install-tgui.sh'
+#				},
+#				{
+#					name: build and unit test,
+#					run: CCFLAGS=-fdiagnostics-color=always scons
+#				}
+#			],
+#		}
 	}
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@
 			]
 		},
 		win-vs32: {
-			runs-on: windows-2019,
+			runs-on: windows-2022,
 			steps: [
 				{
 					name: checkout,
@@ -81,7 +81,7 @@
 			]
 		},
 		win-vs64: {
-			runs-on: windows-2019,
+			runs-on: windows-2022,
 			steps: [
 				{
 					name: checkout,
@@ -103,7 +103,7 @@
 			]
 		},
 		win-scons: {
-			runs-on: windows-2019,
+			runs-on: windows-2022,
 			steps: [
 				{
 					name: checkout,
@@ -125,7 +125,7 @@
 			]
 		},
 		# win-mingw: {
-		# 	runs-on: windows-2019,
+		# 	runs-on: windows-2022,
 		# 	steps: [
 		# 		{
 		# 			name: checkout,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,10 @@
 					working-directory: proj/vs2017
 				},
 				{
+					name: make sure scons can find dependencies,
+					run: vcpkg integrate install
+				},
+				{
 					name: build and unit test,
 					run: '.\.github\workflows\scripts\win\scons-build.bat'
 				}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@
 
 	jobs: {
 		macos-xcode: {
-			runs-on: macos-10.15,
+			runs-on: macos-12,
 			env: {
 				DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
 			},
@@ -45,7 +45,7 @@
 			]
 		},
 		macos-scons: {
-			runs-on: macos-10.15,
+			runs-on: macos-12,
 			steps:  [
 				{
 					name: checkout,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,12 +124,12 @@
 				{
 					name: debug print vcpkg root directory,
 					run: 'dir',
-					working-directory: C:/vcpkg
+					working-directory: 'C:/vcpkg'
 				},
 				{
 					name: debug print vcpkg manifest install directories,
 					run: 'dir',
-					working-directory: C:/vcpkg/vcpkg_installed
+					working-directory: 'C:/vcpkg/vcpkg_installed'
 				},
 				{
 					name: build and unit test,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@
 		macos-xcode: {
 			runs-on: macos-12,
 			env: {
-				DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+				DEVELOPER_DIR: /Applications/Xcode_13.4.app/Contents/Developer
 			},
 			steps: [
 				{

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@
 			]
 		},
 		win-vs32: {
-			runs-on: windows-2022,
+			runs-on: windows-2019,
 			steps: [
 				{
 					name: checkout,
@@ -82,7 +82,7 @@
 			]
 		},
 		win-vs64: {
-			runs-on: windows-2022,
+			runs-on: windows-2019,
 			steps: [
 				{
 					name: checkout,
@@ -105,7 +105,7 @@
 			]
 		},
 		win-scons: {
-			runs-on: windows-2022,
+			runs-on: windows-2019,
 			steps: [
 				{
 					name: checkout,
@@ -128,7 +128,7 @@
 			]
 		},
 		# win-mingw: {
-		# 	runs-on: windows-2022,
+		# 	runs-on: windows-2019,
 		# 	steps: [
 		# 		{
 		# 			name: checkout,

--- a/.github/workflows/scripts/linux/install-tgui.sh
+++ b/.github/workflows/scripts/linux/install-tgui.sh
@@ -3,7 +3,7 @@
 git clone --depth 1 -b 0.9 https://github.com/texus/TGUI.git
 cd TGUI
 export CLICOLOR_FORCE=1
-cmake .
+cmake -D TGUI_CXX_STANDARD=14 .
 make
 cmake --install .
 cd .. # Probably not needed but...

--- a/.github/workflows/scripts/win/install-deps.bat
+++ b/.github/workflows/scripts/win/install-deps.bat
@@ -1,2 +1,2 @@
 
-cd C:\vcpkg && git pull && vcpkg update && vcpkg install zlib:%1-windows sfml:%1-windows opengl:%1-windows boost-any:%1-windows boost-dynamic-bitset:%1-windows boost-ptr-container:%1-windows boost-core:%1-windows boost-filesystem:%1-windows boost-system:%1-windows boost-date-time:%1-windows boost-chrono:%1-windows boost-math:%1-windows boost-spirit:%1-windows
+(cd C:\vcpkg && git pull) && vcpkg update && vcpkg install zlib:%1-windows sfml:%1-windows opengl:%1-windows boost-any:%1-windows boost-dynamic-bitset:%1-windows boost-ptr-container:%1-windows boost-core:%1-windows boost-filesystem:%1-windows boost-system:%1-windows boost-date-time:%1-windows boost-chrono:%1-windows boost-math:%1-windows boost-spirit:%1-windows

--- a/.github/workflows/scripts/win/install-deps.bat
+++ b/.github/workflows/scripts/win/install-deps.bat
@@ -1,2 +1,2 @@
 
-(cd C:\vcpkg && git pull) && vcpkg update && vcpkg install zlib:%1-windows sfml:%1-windows opengl:%1-windows boost-any:%1-windows boost-dynamic-bitset:%1-windows boost-ptr-container:%1-windows boost-core:%1-windows boost-filesystem:%1-windows boost-system:%1-windows boost-date-time:%1-windows boost-chrono:%1-windows boost-math:%1-windows boost-spirit:%1-windows
+cd C:\vcpkg && git pull && vcpkg update && vcpkg install zlib:%1-windows sfml:%1-windows opengl:%1-windows boost-any:%1-windows boost-dynamic-bitset:%1-windows boost-ptr-container:%1-windows boost-core:%1-windows boost-filesystem:%1-windows boost-system:%1-windows boost-date-time:%1-windows boost-chrono:%1-windows boost-math:%1-windows boost-spirit:%1-windows

--- a/.github/workflows/scripts/win/install-deps.bat
+++ b/.github/workflows/scripts/win/install-deps.bat
@@ -1,2 +1,2 @@
 
-vcpkg install zlib:%1-windows sfml:%1-windows opengl:%1-windows boost-any:%1-windows boost-dynamic-bitset:%1-windows boost-ptr-container:%1-windows boost-core:%1-windows boost-filesystem:%1-windows boost-system:%1-windows boost-date-time:%1-windows boost-chrono:%1-windows boost-math:%1-windows
+vcpkg install zlib:%1-windows sfml:%1-windows opengl:%1-windows boost-any:%1-windows boost-dynamic-bitset:%1-windows boost-ptr-container:%1-windows boost-core:%1-windows boost-filesystem:%1-windows boost-system:%1-windows boost-date-time:%1-windows boost-chrono:%1-windows boost-math:%1-windows boost-spirit:%1-windows

--- a/.github/workflows/scripts/win/install-deps.bat
+++ b/.github/workflows/scripts/win/install-deps.bat
@@ -1,2 +1,2 @@
 
-cd C:\vcpkg && git pull && vcpkg update && vcpkg install zlib:%1-windows sfml:%1-windows opengl:%1-windows boost-any:%1-windows boost-dynamic-bitset:%1-windows boost-ptr-container:%1-windows boost-core:%1-windows boost-filesystem:%1-windows boost-system:%1-windows boost-date-time:%1-windows boost-chrono:%1-windows boost-math:%1-windows boost-spirit:%1-windows
+vcpkg update && vcpkg install zlib:%1-windows sfml:%1-windows opengl:%1-windows boost-any:%1-windows boost-dynamic-bitset:%1-windows boost-ptr-container:%1-windows boost-core:%1-windows boost-filesystem:%1-windows boost-system:%1-windows boost-date-time:%1-windows boost-chrono:%1-windows boost-math:%1-windows boost-spirit:%1-windows

--- a/.github/workflows/scripts/win/install-deps.bat
+++ b/.github/workflows/scripts/win/install-deps.bat
@@ -1,2 +1,2 @@
 
-vcpkg update && vcpkg install zlib:%1-windows sfml:%1-windows opengl:%1-windows boost-any:%1-windows boost-dynamic-bitset:%1-windows boost-ptr-container:%1-windows boost-core:%1-windows boost-filesystem:%1-windows boost-system:%1-windows boost-date-time:%1-windows boost-chrono:%1-windows boost-math:%1-windows boost-spirit:%1-windows
+vcpkg install --feature-flags=manifests,binarycaching --triplet %1-windows

--- a/.github/workflows/scripts/win/install-deps.bat
+++ b/.github/workflows/scripts/win/install-deps.bat
@@ -1,2 +1,2 @@
 
-vcpkg install zlib:%1-windows sfml:%1-windows opengl:%1-windows boost-any:%1-windows boost-dynamic-bitset:%1-windows boost-ptr-container:%1-windows boost-core:%1-windows boost-filesystem:%1-windows boost-system:%1-windows boost-date-time:%1-windows boost-chrono:%1-windows boost-math:%1-windows boost-spirit:%1-windows
+vcpkg update && vcpkg install zlib:%1-windows sfml:%1-windows opengl:%1-windows boost-any:%1-windows boost-dynamic-bitset:%1-windows boost-ptr-container:%1-windows boost-core:%1-windows boost-filesystem:%1-windows boost-system:%1-windows boost-date-time:%1-windows boost-chrono:%1-windows boost-math:%1-windows boost-spirit:%1-windows

--- a/.github/workflows/scripts/win/install-deps.bat
+++ b/.github/workflows/scripts/win/install-deps.bat
@@ -1,2 +1,2 @@
 
-vcpkg update && vcpkg install zlib:%1-windows sfml:%1-windows opengl:%1-windows boost-any:%1-windows boost-dynamic-bitset:%1-windows boost-ptr-container:%1-windows boost-core:%1-windows boost-filesystem:%1-windows boost-system:%1-windows boost-date-time:%1-windows boost-chrono:%1-windows boost-math:%1-windows boost-spirit:%1-windows
+cd C:\vcpkg && git pull && vcpkg update && vcpkg install zlib:%1-windows sfml:%1-windows opengl:%1-windows boost-any:%1-windows boost-dynamic-bitset:%1-windows boost-ptr-container:%1-windows boost-core:%1-windows boost-filesystem:%1-windows boost-system:%1-windows boost-date-time:%1-windows boost-chrono:%1-windows boost-math:%1-windows boost-spirit:%1-windows

--- a/.github/workflows/scripts/win/msvc-build.bat
+++ b/.github/workflows/scripts/win/msvc-build.bat
@@ -4,6 +4,6 @@ vcpkg integrate install
 setlocal enabledelayedexpansion
 
 for /f "usebackq tokens=*" %%i in (`vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
-	"%%i" -clp:ForceConsoleColor -target:Build -property:Configuration=Release -property:Platform=%1 "proj/vs2017/Blades of Exile.sln"
+	"%%i" -clp:ForceConsoleColor -target:Build -property:Configuration=Release -property:Platform=%1 -property:VcpkgEnableManifest=true "proj/vs2017/Blades of Exile.sln"
 	exit /b !errorlevel!
 )

--- a/.github/workflows/scripts/win/scons-build.bat
+++ b/.github/workflows/scripts/win/scons-build.bat
@@ -5,4 +5,4 @@ for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Micros
   call "%%i" x86_amd64
 )
 
-scons
+scons -Q --debug=findlibs

--- a/.github/workflows/scripts/win/scons-build.bat
+++ b/.github/workflows/scripts/win/scons-build.bat
@@ -2,5 +2,7 @@
 setlocal enabledelayedexpansion
 
 for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find **/Auxiliary/Build/vcvarsall.bat`) do (
-  %%i x86_amd64 && scons
+  %%i x86_amd64 || exit /b 1
 )
+
+scons

--- a/.github/workflows/scripts/win/scons-build.bat
+++ b/.github/workflows/scripts/win/scons-build.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find **/Auxiliary/Build/vcvarsall.bat`) do (
-  call %%i x86_amd64
+  call "%%i x86_amd64"
 )
 
 scons

--- a/.github/workflows/scripts/win/scons-build.bat
+++ b/.github/workflows/scripts/win/scons-build.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find **/Auxiliary/Build/vcvarsall.bat`) do (
-  %%i
+  %%i x86_amd64 "" 8.1
 )
 
 scons

--- a/.github/workflows/scripts/win/scons-build.bat
+++ b/.github/workflows/scripts/win/scons-build.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find **/Auxiliary/Build/vcvarsall.bat`) do (
-  call "%%i x86_amd64"
+  call "%%i" x86_amd64
 )
 
 scons

--- a/.github/workflows/scripts/win/scons-build.bat
+++ b/.github/workflows/scripts/win/scons-build.bat
@@ -2,7 +2,5 @@
 setlocal enabledelayedexpansion
 
 for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find **/Auxiliary/Build/vcvarsall.bat`) do (
-  %%i x86_amd64 "" 8.1
+  %%i x86_amd64 8.1 && scons
 )
-
-scons

--- a/.github/workflows/scripts/win/scons-build.bat
+++ b/.github/workflows/scripts/win/scons-build.bat
@@ -2,5 +2,5 @@
 setlocal enabledelayedexpansion
 
 for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find **/Auxiliary/Build/vcvarsall.bat`) do (
-  %%i x86_amd64 8.1 && scons
+  %%i x86_amd64 && scons
 )

--- a/.github/workflows/scripts/win/scons-build.bat
+++ b/.github/workflows/scripts/win/scons-build.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find **/Auxiliary/Build/vcvarsall.bat`) do (
-  %%i x86_amd64
+  call %%i x86_amd64
 )
 
 scons

--- a/.github/workflows/scripts/win/scons-build.bat
+++ b/.github/workflows/scripts/win/scons-build.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find **/Auxiliary/Build/vcvarsall.bat`) do (
-  %%i x86_amd64 || exit /b 1
+  %%i x86_amd64
 )
 
 scons

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ If you are using the Visual Studio toolset, we recommend installing
 Use the following commands to install the required dependencies:
 For 32-bit builds:
 
-    vcpkg install zlib:x86-windows sfml:x86-windows opengl:x86-windows boost-any:x86-windows boost-dynamic-bitset:x86-windows boost-ptr-container:x86-windows boost-core:x86-windows boost-filesystem:x86-windows boost-system:x86-windows boost-date-time:x86-windows boost-chrono:x86-windows boost-math:x86-windows
+    vcpkg install zlib:x86-windows sfml:x86-windows opengl:x86-windows boost-any:x86-windows boost-dynamic-bitset:x86-windows boost-ptr-container:x86-windows boost-core:x86-windows boost-filesystem:x86-windows boost-system:x86-windows boost-date-time:x86-windows boost-chrono:x86-windows boost-math:x86-windows boost-spirit:x86-windows
 
 For 64-bit builds:
 
-    vcpkg install zlib:x64-windows sfml:x64-windows opengl:x64-windows boost-any:x64-windows boost-dynamic-bitset:x64-windows boost-ptr-container:x64-windows boost-core:x64-windows boost-filesystem:x64-windows boost-system:x64-windows boost-date-time:x64-windows boost-chrono:x64-windows boost-math:x64-windows
+    vcpkg install zlib:x64-windows sfml:x64-windows opengl:x64-windows boost-any:x64-windows boost-dynamic-bitset:x64-windows boost-ptr-container:x64-windows boost-core:x64-windows boost-filesystem:x64-windows boost-system:x64-windows boost-date-time:x64-windows boost-chrono:x64-windows boost-math:x64-windows boost-spirit:x64-windows
 
 If this is the first time installing packages with vcpkg since install you will need to run the `integrate` command:
 

--- a/SConstruct
+++ b/SConstruct
@@ -211,7 +211,7 @@ if platform == 'darwin':
 
 	# pretty sketchy, but should point to your boost install
 	if subprocess.call(['which', '-s', 'brew']) == 0: # HomeBrew
-		brew_boost_version = '1.58.0'
+		brew_boost_version = '1.85.0'
 		env.Append(
 			LIBPATH=['/usr/local/Cellar/boost/'+brew_boost_version+'/lib'],
 			CPPPATH=['/usr/local/Cellar/boost/'+brew_boost_version+'/include'])

--- a/SConstruct
+++ b/SConstruct
@@ -161,7 +161,7 @@ elif platform == "win32":
 		env.Append(
 			LINKFLAGS=['/SUBSYSTEM:WINDOWS','/ENTRY:mainCRTStartup','/MACHINE:X86'],
 			CXXFLAGS=['/EHsc','/MD','/FIglobal.hpp'],
-			LIBPATH=("C:\Program Files (x86)\Microsoft Visual Studio " + env['MSVC_VERSION'] + "\VC\lib"),
+			LIBPATH=[("C:\Program Files (x86)\Microsoft Visual Studio " + env['MSVC_VERSION'] + "\VC\lib"), "C:/vcpkg/packages"],
 			LIBS=Split("""
 				kernel32
 				user32

--- a/SConstruct
+++ b/SConstruct
@@ -158,10 +158,13 @@ if platform == "darwin":
 					break
 elif platform == "win32":
 	if 'msvc' in env['TOOLS']:
+		print("C:/vcpkg/packages/**_x" + env['bits'] + "-windows")
+		libpath = [("C:\Program Files (x86)\Microsoft Visual Studio " + env['MSVC_VERSION'] + "\VC\lib")] + Glob("C:/vcpkg/packages/**_x" + env['bits'] + "-windows") + Glob(os.environ['HOME'] + "/vcpkg/packages/**_x" + env['bits'] + "-windows")
+		print(libpath)
 		env.Append(
 			LINKFLAGS=['/SUBSYSTEM:WINDOWS','/ENTRY:mainCRTStartup','/MACHINE:X86'],
 			CXXFLAGS=['/EHsc','/MD','/FIglobal.hpp'],
-			LIBPATH=[("C:\Program Files (x86)\Microsoft Visual Studio " + env['MSVC_VERSION'] + "\VC\lib"), "C:/vcpkg/packages"],
+			LIBPATH=[("C:\Program Files (x86)\Microsoft Visual Studio " + env['MSVC_VERSION'] + "\VC\lib")] + Glob("C:/vcpkg/packages/**_x" + env['bits'] + "-windows") + Glob(os.environ['HOME'] + "/vcpkg/packages/**_x" + env['bits'] + "-windows"),
 			LIBS=Split("""
 				kernel32
 				user32

--- a/proj/vs2013/vcpkg.json
+++ b/proj/vs2013/vcpkg.json
@@ -1,18 +1,18 @@
 {
     "builtin-baseline": "cbf4a6641528cee6f172328984576f51698de726",
     "dependencies": [
-        "zlib",
-        "sfml",
-        "opengl",
-        "boost-any",
-        "boost-dynamic-bitset",
-        "boost-ptr-container",
-        "boost-core",
-        "boost-filesystem",
-        "boost-system",
-        "boost-date-time",
-        "boost-chrono",
-        "boost-math",
-        "boost-spirit"
+        "zlib:x86-windows",
+        "sfml:x86-windows",
+        "opengl:x86-windows",
+        "boost-any:x86-windows",
+        "boost-dynamic-bitset:x86-windows",
+        "boost-ptr-container:x86-windows",
+        "boost-core:x86-windows",
+        "boost-filesystem:x86-windows",
+        "boost-system:x86-windows",
+        "boost-date-time:x86-windows",
+        "boost-chrono:x86-windows",
+        "boost-math:x86-windows",
+        "boost-spirit:x86-windows"
     ]
 }

--- a/proj/vs2013/vcpkg.json
+++ b/proj/vs2013/vcpkg.json
@@ -1,18 +1,18 @@
 {
     "builtin-baseline": "bcf3d00d2116056fda0ce47615f6074ffecb7524",
     "dependencies": [
-        "zlib:x86-windows",
-        "sfml:x86-windows",
-        "opengl:x86-windows",
-        "boost-any:x86-windows",
-        "boost-dynamic-bitset:x86-windows",
-        "boost-ptr-container:x86-windows",
-        "boost-core:x86-windows",
-        "boost-filesystem:x86-windows",
-        "boost-system:x86-windows",
-        "boost-date-time:x86-windows",
-        "boost-chrono:x86-windows",
-        "boost-math:x86-windows",
-        "boost-spirit:x86-windows"
+        "zlib",
+        "sfml",
+        "opengl",
+        "boost-any",
+        "boost-dynamic-bitset",
+        "boost-ptr-container",
+        "boost-core",
+        "boost-filesystem",
+        "boost-system",
+        "boost-date-time",
+        "boost-chrono",
+        "boost-math",
+        "boost-spirit"
     ]
 }

--- a/proj/vs2013/vcpkg.json
+++ b/proj/vs2013/vcpkg.json
@@ -1,0 +1,18 @@
+{
+    "builtin-baseline": "cbf4a6641528cee6f172328984576f51698de726",
+    "dependencies": [
+        "zlib",
+        "sfml",
+        "opengl",
+        "boost-any",
+        "boost-dynamic-bitset",
+        "boost-ptr-container",
+        "boost-core",
+        "boost-filesystem",
+        "boost-system",
+        "boost-date-time",
+        "boost-chrono",
+        "boost-math",
+        "boost-spirit"
+    ]
+}

--- a/proj/vs2013/vcpkg.json
+++ b/proj/vs2013/vcpkg.json
@@ -1,5 +1,5 @@
 {
-    "builtin-baseline": "cbf4a6641528cee6f172328984576f51698de726",
+    "builtin-baseline": "bcf3d00d2116056fda0ce47615f6074ffecb7524",
     "dependencies": [
         "zlib:x86-windows",
         "sfml:x86-windows",

--- a/proj/vs2017/vcpkg.json
+++ b/proj/vs2017/vcpkg.json
@@ -1,18 +1,6 @@
 {
     "builtin-baseline": "bcf3d00d2116056fda0ce47615f6074ffecb7524",
     "dependencies": [
-        "zlib",
-        "sfml",
-        "opengl",
-        "boost-any",
-        "boost-dynamic-bitset",
-        "boost-ptr-container",
-        "boost-core",
-        "boost-filesystem",
-        "boost-system",
-        "boost-date-time",
-        "boost-chrono",
-        "boost-math",
-        "boost-spirit"
+        "zlib"
     ]
 }

--- a/proj/vs2017/vcpkg.json
+++ b/proj/vs2017/vcpkg.json
@@ -1,5 +1,5 @@
 {
-    "builtin-baseline": "cbf4a6641528cee6f172328984576f51698de726",
+    "builtin-baseline": "bcf3d00d2116056fda0ce47615f6074ffecb7524",
     "dependencies": [
         "zlib",
         "sfml",

--- a/proj/vs2017/vcpkg.json
+++ b/proj/vs2017/vcpkg.json
@@ -1,0 +1,18 @@
+{
+    "builtin-baseline": "cbf4a6641528cee6f172328984576f51698de726",
+    "dependencies": [
+        "zlib",
+        "sfml",
+        "opengl",
+        "boost-any",
+        "boost-dynamic-bitset",
+        "boost-ptr-container",
+        "boost-core",
+        "boost-filesystem",
+        "boost-system",
+        "boost-date-time",
+        "boost-chrono",
+        "boost-math",
+        "boost-spirit"
+    ]
+}

--- a/src/fileio/fileio_scen.cpp
+++ b/src/fileio/fileio_scen.cpp
@@ -9,6 +9,7 @@
 #include "fileio.hpp"
 
 #include <fstream>
+#include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/lexical_cast.hpp>
 

--- a/src/fileio/resmgr/resmgr.hpp
+++ b/src/fileio/resmgr/resmgr.hpp
@@ -15,6 +15,7 @@
 #include <unordered_map>
 #include <memory>
 #include <sstream>
+#include <vector>
 
 namespace ResMgr {
 	namespace fs = boost::filesystem;

--- a/src/scenedit/scen.core.cpp
+++ b/src/scenedit/scen.core.cpp
@@ -3592,7 +3592,7 @@ static bool edit_custom_sound_action(cDialog& me, std::string action, std::vecto
 			beep();
 			return true;
 		}
-		fs::copy_file(fpath, sndfile, fs::copy_option::overwrite_if_exists);
+		fs::copy_file(fpath, sndfile, fs::copy_options::overwrite_existing);
 		ResMgr::sounds.free(sound_to_fname(which_snd));
 		if(which_snd > max_snd)
 			max_snd = which_snd;
@@ -3603,7 +3603,7 @@ static bool edit_custom_sound_action(cDialog& me, std::string action, std::vecto
 	} else if(action == "save") {
 		fs::path fpath = nav_put_rsrc({"wav"});
 		if(fpath.empty()) return true;
-		fs::copy_file(sndfile, fpath, fs::copy_option::overwrite_if_exists);
+		fs::copy_file(sndfile, fpath, fs::copy_options::overwrite_existing);
 	}
 	return true;
 }

--- a/src/scenedit/scen.core.cpp
+++ b/src/scenedit/scen.core.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <unordered_map>
 #include <boost/lexical_cast.hpp>
+#include <boost/filesystem.hpp>
 #include "scen.global.hpp"
 #include "scenario/scenario.hpp"
 #include "scenario/town.hpp"

--- a/src/scenedit/scen.fileio.cpp
+++ b/src/scenedit/scen.fileio.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <iomanip>
 #include <boost/filesystem/operations.hpp>
+#include <boost/filesystem.hpp>
 #include "scen.fileio.hpp"
 #include "scen.keydlgs.hpp"
 #include "gfx/gfxsheets.hpp"

--- a/src/scenedit/scen.keydlgs.cpp
+++ b/src/scenedit/scen.keydlgs.cpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <numeric>
 #include <boost/lexical_cast.hpp>
+#include <boost/filesystem.hpp>
 #include "scen.global.hpp"
 #include "scenario/scenario.hpp"
 #include "gfx/gfxsheets.hpp"


### PR DESCRIPTION
This is a cleaner redo of the working build fixes from #352. I'd like to get it merged so I can rebase #351 onto it

This stops short of trying to fix the Mac library compatibility warnings, which I haven't figured out how to do yet.

Hopefully the Windows CI failure that was happening last night will go away when the CI runs today (it was a dependency download error that seemed outside of our control.)