### PR TITLE
Local build improvement redo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ test/junk/*.map
 oldstructs.txt
 src/tools/gitrev.hpp
 rsrc/**/scenario
+
+# Dependency-generated files
+deps/**/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "deps/Catch2"]
 	path = deps/Catch2
 	url = https://github.com/catchorg/Catch2.git
+[submodule "deps/TGUI"]
+	path = deps/TGUI
+	url = https://github.com/texus/TGUI.git
+	branch = 0.9

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ The following dependencies are required:
 - ZLib - This is included with the system on the Mac.
 
 For Linux builds, the following additional dependencies are required:
-- [TGUI](https://tgui.eu/) - version 0.9 or later required
+- [TGUI](https://tgui.eu/) - version 0.9, **built with C++14** as shown [here](./.github/workflows/scripts/linux/install-tgui.sh)
+  - or, if cmake is available when you call `scons`, TGUI will be built from source automatically
 - zenity command-line tools
 
 If you are using the Visual Studio toolset, we recommend installing

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The following dependencies are required:
   libraries; if you're picky, you can run scons and see it enumerate exactly which
   libraries are needed
 - ZLib - This is included with the system on the Mac.
+- Catch2 - If you want to build the unit tests, make sure to call `git submodule update --init deps/Catch2`.
 
 For Linux builds, the following additional dependencies are required:
 - [TGUI](https://tgui.eu/) - version 0.9, **built with C++14** as shown [here](./.github/workflows/scripts/linux/install-tgui.sh)

--- a/SConstruct
+++ b/SConstruct
@@ -70,7 +70,10 @@ env.VariantDir('#build/obj/test', 'test')
 env.VariantDir('#build/obj/test/deps', 'deps')
 
 if env['debug']:
-   env.Append(CCFLAGS=['-g','-o0'])
+	if platform in ['posix', 'darwin']:
+		env.Append(CCFLAGS=['-g','-O0'])
+	elif platform == 'win32':
+		env.Append(CCFLAGS=['/Zi', '/Od'])
 
 # This command generates the header with git revision information
 def gen_gitrev(env, target, source):

--- a/SConstruct
+++ b/SConstruct
@@ -325,6 +325,10 @@ if not env.GetOption('clean'):
 	check_lib('sfml-audio', 'SFML-audio')
 	check_lib('sfml-graphics', 'SFML-graphics')
 
+	# If building the tests, make sure Catch2 is cloned
+	if 'test' in targets and not path.exists('deps/Catch2/README.md'):
+		subprocess.call(["git", "submodule", "update", "--init", "deps/Catch2"])
+
 	# On Linux, build TGUI from the subtree if necessary
 	if platform == 'posix':
 		def check_tgui(conf, second_attempt=False):

--- a/SConstruct
+++ b/SConstruct
@@ -1,6 +1,7 @@
 import os.path as path
 import os
 import subprocess
+import atexit
 
 # Build options
 opts = Variables(None, ARGUMENTS)
@@ -467,3 +468,5 @@ elif platform == "win32" and subprocess.call(['where', '/Q', 'makensis']) == 0:
 
 env.Clean('.', 'build')
 env.Clean('.', Glob('.sconsign.*'))
+if env.GetOption('clean'):
+	atexit.register(lambda: print('If the build fails immediately after cleaning, delete .sconsign.dblite manually and try again.'))

--- a/SConstruct
+++ b/SConstruct
@@ -248,15 +248,15 @@ if platform == 'darwin':
 # Sometimes it's easier just to copy the dependencies into the repo dir
 # We try to auto-detect this.
 if path.exists('deps/lib'):
-	env.Append(LIBPATH=[os.getcwd() + '/deps/lib'])
+	env.Append(LIBPATH=[path.join(os.getcwd(), 'deps/lib')])
 	if platform == 'darwin':
-		env.Append(FRAMEWORKPATH=[os.getcwd() + '/deps/lib'])
+		env.Append(FRAMEWORKPATH=[path.join(os.getcwd(), 'deps/lib')])
 
 if path.exists('deps/lib64'):
-	env.Append(LIBPATH=[os.getcwd() + '/deps/lib64'])
+	env.Append(LIBPATH=[path.join(os.getcwd(), 'deps/lib64')])
 
 if path.exists('deps/include'):
-	env.Append(CPPPATH=[os.getcwd() + '/deps/include'])
+	env.Append(CPPPATH=[path.join(os.getcwd(), '/deps/include')])
 
 # Include directories
 
@@ -349,7 +349,7 @@ if not env.GetOption('clean'):
 					subprocess.call(["make", "install"], cwd="deps/TGUI")
 
 					env = conf.Finish()
-					env.Append(CPPPATH=[os.getcwd() + '/deps/include'], LIBPATH=[os.getcwd() + '/deps/lib', os.getcwd() + '/deps/lib64'])
+					env.Append(CPPPATH=[path.join(os.getcwd(), 'deps/include')], LIBPATH=[path.join(os.getcwd(), 'deps/lib'), path.join(os.getcwd(), 'deps/lib64')])
 					conf = Configure(env)
 					return check_tgui(conf, True)
 		conf = check_tgui(conf)


### PR DESCRIPTION
This is the last PR, with submodules instead of subtrees, and a few more things:

* add Catch2 dependency to the README
* partial build options
* correct debug flags on all platforms
* when scons -c is called, print a note about deleting .sconsign.dblite (this addresses #330, which I still can't reliably fix, but deleting the file manually works every time)