### PR TITLE
Fix silent crash on Windows & Standardize command line arguments

### DIFF
--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -460,11 +460,14 @@ void cDialog::recalcRect(){
 	winRect.bottom *= ui_scale();
 }
 
+bool cDialog::initCalled = false;
+
 void cDialog::init(){
 	cButton::init();
 	cLed::init();
 	cPict::init();
 	cScrollbar::init();
+	initCalled = true;
 }
 
 cDialog::~cDialog(){

--- a/src/dialogxml/dialogs/dialog.hpp
+++ b/src/dialogxml/dialogs/dialog.hpp
@@ -69,10 +69,12 @@ class cDialog {
 	template<typename Iter> void handleTabOrder(std::string& itemHit, Iter begin, Iter end);
 	std::vector<std::pair<std::string,cTextField*>> tabOrder;
 	static cDialog* topWindow; // Tracks the frontmost dialog.
+	static bool initCalled;
 public:
 	static void (*redraw_everything)();
 	/// Performs essential startup initialization. Generally should not be called directly.
 	static void init();
+	static bool wasInitCalled() { return initCalled; };
 	/// The light background pattern used by the scenario editor dialogs.
 	static const short BG_LIGHT, BG_DARK; ///< The dark background pattern used by the game dialogs.
 	/// The default background pattern for newly created dialogs.

--- a/src/dialogxml/dialogs/strdlog.cpp
+++ b/src/dialogxml/dialogs/strdlog.cpp
@@ -75,7 +75,15 @@ void cStrDlog::show(){
 	dlg.run();
 }
 
+extern bool finished_init;
+
 static void giveError(pic_num_t pic, std::string title, std::string str1, std::string str2, cDialog* parent) {
+	// If giveError() is called before UI is initialized, print to console
+	if (!finished_init) {
+		std::cout << title << std::endl << str1 << std::endl << str2 << std::endl;
+		return;
+	}
+
 	cStrDlog error(str1,str2,title,pic,PIC_DLOG,parent);
 	error->getControl("record").setText("Copy");
 	error.setRecordHandler([](cDialog& me) {

--- a/src/dialogxml/dialogs/strdlog.cpp
+++ b/src/dialogxml/dialogs/strdlog.cpp
@@ -75,11 +75,9 @@ void cStrDlog::show(){
 	dlg.run();
 }
 
-extern bool finished_init;
-
 static void giveError(pic_num_t pic, std::string title, std::string str1, std::string str2, cDialog* parent) {
 	// If giveError() is called before UI is initialized, print to console
-	if (!finished_init) {
+	if (!cDialog::wasInitCalled()) {
 		std::cout << title << std::endl << str1 << std::endl << str2 << std::endl;
 		return;
 	}

--- a/src/game/boe.appleevents.mm
+++ b/src/game/boe.appleevents.mm
@@ -30,8 +30,8 @@ typedef NSAppleEventDescriptor AEDescr;
 -(NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication*) sender;
 @end
 
-void set_up_apple_events(int argc, char* argv[]); // Suppress "no prototype" warning
-void set_up_apple_events(int, char*[]) {
+void set_up_apple_events(); // Suppress "no prototype" warning
+void set_up_apple_events() {
 	AppleEventHandler* aeHandler = [[AppleEventHandler alloc] init];
 	[[NSApplication sharedApplication] setDelegate: aeHandler];
 }

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -238,7 +238,7 @@ void process_args(int argc, char* argv[]) {
 }
 
 void init_boe(int argc, char* argv[]) {
-	set_up_apple_events(argc, argv);
+	set_up_apple_events();
 	init_directories(argv[0]);
 	check_for_intel();
 	process_args(argc, argv);

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -215,7 +215,30 @@ static void init_ui() {
 	init_buttons();
 }
 
+void process_args(int argc, char* argv[]) {
+	// Command line usage:
+	//  "Blades of Exile"                               # basic launch
+	//  "Blades of Exile" <save file>                   # launch and load save file
+
+	if (argc > 1) {
+		if(!load_party(argv[1], univ)) {
+			std::cout << "Failed to load save file: " << argv[1] << std::endl;
+			return;
+		}
+
+		if(!finished_init) {
+			ae_loading = true;
+			overall_mode = MODE_STARTUP;
+		} else finish_load_party();
+		if(overall_mode != MODE_STARTUP)
+			end_startup();
+		if(overall_mode != MODE_STARTUP)
+			post_load();
+	}
+}
+
 void init_boe(int argc, char* argv[]) {
+	process_args(argc, argv);
 	set_up_apple_events(argc, argv);
 	init_directories(argv[0]);
 #ifdef __APPLE__

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -238,9 +238,10 @@ void process_args(int argc, char* argv[]) {
 }
 
 void init_boe(int argc, char* argv[]) {
-	process_args(argc, argv);
 	set_up_apple_events(argc, argv);
 	init_directories(argv[0]);
+	check_for_intel();
+	process_args(argc, argv);
 #ifdef __APPLE__
 	init_menubar(); // Do this first of all because otherwise a default File and Window menu will be seen
 #endif
@@ -258,7 +259,6 @@ void init_boe(int argc, char* argv[]) {
 	
 	set_cursor(watch_curs);
 	init_buf();
-	check_for_intel();
 	srand(time(nullptr));
 	init_screen_locs();	
 	init_startup();

--- a/src/game/boe.main.hpp
+++ b/src/game/boe.main.hpp
@@ -11,7 +11,7 @@ void redraw_everything();
 void Mouse_Pressed(const sf::Event&);
 void close_program();
 void change_cursor(location where_curs);
-void set_up_apple_events(int argc, char* argv[]);
+void set_up_apple_events();
 void move_sound(ter_num_t ter,short step);
 void incidental_noises(bool on_surface);
 void pause(short length);

--- a/src/game/boe.menus.linux.cpp
+++ b/src/game/boe.menus.linux.cpp
@@ -49,6 +49,6 @@ void hideMenuBar() {
 void showMenuBar() {
 }
 
-void set_up_apple_events(int argc, char* argv[]) {
+void set_up_apple_events() {
 
 }

--- a/src/game/boe.menus.win.cpp
+++ b/src/game/boe.menus.win.cpp
@@ -313,11 +313,6 @@ LRESULT CALLBACK menuProc(HWND handle, UINT message, WPARAM wParam, LPARAM lPara
 	return CallWindowProc(reinterpret_cast<WNDPROC>(mainProc), handle, message, wParam, lParam);
 }
 
-#include "fileio.hpp"
-#include "boe.graphics.hpp"
-#include "boe.actions.hpp"
-#include "boe.fileio.hpp"
-
-void set_up_apple_events(int argc, char* argv[]) {
+void set_up_apple_events() {
 
 }

--- a/src/game/boe.menus.win.cpp
+++ b/src/game/boe.menus.win.cpp
@@ -318,19 +318,6 @@ LRESULT CALLBACK menuProc(HWND handle, UINT message, WPARAM wParam, LPARAM lPara
 #include "boe.actions.hpp"
 #include "boe.fileio.hpp"
 
-extern bool ae_loading, finished_init;
 void set_up_apple_events(int argc, char* argv[]) {
-	if(argc > 1) {
-		if(!load_party(argv[1], univ))
-			return;
 
-		if(!finished_init) {
-			ae_loading = true;
-			overall_mode = MODE_STARTUP;
-		} else finish_load_party();
-		if(overall_mode != MODE_STARTUP)
-			end_startup();
-		if(overall_mode != MODE_STARTUP)
-			post_load();
-	}
 }

--- a/src/pcedit/pc.appleevents.mm
+++ b/src/pcedit/pc.appleevents.mm
@@ -23,8 +23,8 @@ extern fs::path file_in_mem;
 -(NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication*) sender;
 @end
 
-void set_up_apple_events(int argc, char* argv[]); // Suppress "no prototype" warning
-void set_up_apple_events(int, char*[]) {
+void set_up_apple_events(); // Suppress "no prototype" warning
+void set_up_apple_events() {
 	AppleEventHandler* aeHandler = [[AppleEventHandler alloc] init];
 	[[NSApplication sharedApplication] setDelegate: aeHandler];
 }

--- a/src/pcedit/pc.main.cpp
+++ b/src/pcedit/pc.main.cpp
@@ -69,7 +69,7 @@ void Mouse_Pressed(const sf::Event&);
 void adjust_window(sf::RenderWindow&, sf::View&);
 sf::FloatRect compute_viewport(const sf::RenderWindow&, float ui_scale);
 bool verify_restore_quit(std::string dlog);
-void set_up_apple_events(int argc, char* argv[]);
+void set_up_apple_events();
 
 void pick_preferences();
 void save_prefs();
@@ -101,7 +101,7 @@ int main(int argc, char* argv[]) {
 		check_for_intel();
 		srand(time(nullptr));
 		
-		set_up_apple_events(argc, argv);
+		set_up_apple_events();
 		
 		cDialog::init();
 		redraw_screen();

--- a/src/pcedit/pc.main.cpp
+++ b/src/pcedit/pc.main.cpp
@@ -80,6 +80,21 @@ extern fs::path progDir;
 short specials_res_id;
 char start_name[256];
 
+void process_args(int argc, char* argv[]) {
+	if(argc > 1) {
+		if(load_party(argv[1], univ)) {
+			file_in_mem = argv[1];
+			party_in_scen = !univ.party.scen_name.empty();
+			if(!party_in_scen) load_base_item_defs();
+			scen_items_loaded = true;
+			menu_activate();
+		} else {
+			std::cout << "Failed to load save file: " << argv[1] << std::endl;
+			return;
+		}
+	}
+}
+
 //MW specified return type was 'void', changed to ISO C style for Carbonisation -jmr
 int main(int argc, char* argv[]) {
 	try {
@@ -102,6 +117,7 @@ int main(int argc, char* argv[]) {
 		srand(time(nullptr));
 		
 		set_up_apple_events();
+		process_args(argc, argv);
 		
 		cDialog::init();
 		redraw_screen();

--- a/src/pcedit/pc.menus.linux.cpp
+++ b/src/pcedit/pc.menus.linux.cpp
@@ -27,5 +27,5 @@ void drawMenuBar() {
 	menu_ptr->draw();
 }
 
-void set_up_apple_events(int argc, char* argv[]) {
+void set_up_apple_events() {
 }

--- a/src/pcedit/pc.menus.win.cpp
+++ b/src/pcedit/pc.menus.win.cpp
@@ -153,19 +153,5 @@ bool menuBarProcessEvent(const sf::Event&) {
 void drawMenuBar() {
 }
 
-#include "fileio.hpp"
-#include "pc.fileio.hpp"
-
-extern bool party_in_scen, scen_items_loaded;
-extern fs::path file_in_mem;
-void set_up_apple_events(int argc, char* argv[]) {
-	if(argc > 1) {
-		if(load_party(argv[1], univ)) {
-			file_in_mem = argv[1];
-			party_in_scen = !univ.party.scen_name.empty();
-			if(!party_in_scen) load_base_item_defs();
-			scen_items_loaded = true;
-			menu_activate();
-		}
-	}
+void set_up_apple_events() {
 }

--- a/src/scenedit/scen.appleevents.mm
+++ b/src/scenedit/scen.appleevents.mm
@@ -27,8 +27,8 @@ extern bool change_made, ae_loading;
 //-(NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication*) sender;
 @end
 
-void set_up_apple_events(int argc, char* argv[]); // Suppress "no prototype" warning
-void set_up_apple_events(int, char*[]) {
+void set_up_apple_events(); // Suppress "no prototype" warning
+void set_up_apple_events() {
 	AppleEventHandler* aeHandler = [[AppleEventHandler alloc] init];
 	[[NSApplication sharedApplication] setDelegate: aeHandler];
 }

--- a/src/scenedit/scen.main.cpp
+++ b/src/scenedit/scen.main.cpp
@@ -197,6 +197,21 @@ void adjust_windows (sf::RenderWindow & mainPtr, sf::View & mainView) {
 	init_menubar();
 }
 
+void process_args(int argc, char* argv[]) {
+	if(argc > 1) {
+		if(load_scenario(argv[1], scenario)) {
+			set_current_town(scenario.last_town_edited);
+			cur_out = scenario.last_out_edited;
+			current_terrain = scenario.outdoors[cur_out.x][cur_out.y];
+			change_made = false;
+			ae_loading = true;
+			set_up_main_screen();
+		} else {
+			std::cout << "Failed to load scenario: " << argv[1] << std::endl;
+		}
+	}
+}
+
 void init_scened(int argc, char* argv[]) {
 	init_directories(argv[0]);
 	sync_prefs();
@@ -233,6 +248,7 @@ void init_scened(int argc, char* argv[]) {
 	cDialog::defaultBackground = cDialog::BG_LIGHT;
 	cDialog::doAnimations = true;
 	set_up_apple_events();
+	process_args(argc, argv);
 	init_fileio();
 }
 

--- a/src/scenedit/scen.main.cpp
+++ b/src/scenedit/scen.main.cpp
@@ -78,7 +78,7 @@ cScenario scenario;
 rectangle right_sbar_rect;
 extern rectangle terrain_buttons_rect;
 
-extern void set_up_apple_events(int argc, char* argv[]);
+extern void set_up_apple_events();
 
 // TODO: these should be members of some global entity instead of being here
 std::unordered_map<std::string, std::shared_ptr <iEventListener>> event_listeners;
@@ -232,7 +232,7 @@ void init_scened(int argc, char* argv[]) {
 	
 	cDialog::defaultBackground = cDialog::BG_LIGHT;
 	cDialog::doAnimations = true;
-	set_up_apple_events(argc, argv);
+	set_up_apple_events();
 	init_fileio();
 }
 

--- a/src/scenedit/scen.menus.linux.cpp
+++ b/src/scenedit/scen.menus.linux.cpp
@@ -31,5 +31,5 @@ void update_edit_menu() {
 	menu_ptr->update_edit_menu(undo_list);
 }
 
-void set_up_apple_events(int argc, char* argv[]) {
+void set_up_apple_events() {
 }

--- a/src/scenedit/scen.menus.win.cpp
+++ b/src/scenedit/scen.menus.win.cpp
@@ -234,22 +234,5 @@ LRESULT CALLBACK menuProc(HWND handle, UINT message, WPARAM wParam, LPARAM lPara
 	return CallWindowProc(reinterpret_cast<WNDPROC>(mainProc), handle, message, wParam, lParam);
 }
 
-#include "fileio.hpp"
-#include "scen.actions.hpp"
-#include "scen.townout.hpp"
-
-extern location cur_out;
-extern cOutdoors* current_terrain;
-extern bool change_made, ae_loading;
-void set_up_apple_events(int argc, char* argv[]) {
-	if(argc > 1) {
-		if(load_scenario(argv[1], scenario)) {
-			set_current_town(scenario.last_town_edited);
-			cur_out = scenario.last_out_edited;
-			current_terrain = scenario.outdoors[cur_out.x][cur_out.y];
-			change_made = false;
-			ae_loading = true;
-			set_up_main_screen();
-		}
-	}
+void set_up_apple_events() {
 }


### PR DESCRIPTION
It turns out that on Windows, you could launch with a save file loaded by passing that save file as a command-line argument. But only on Windows, because this functionality was implemented in a platform-specific implementation of `set_up_apple_events()` which seems wrong on many levels.

It turns out, this could also lead to a silent crash if you tried to launch BoE with a party file, and the loading failed. `load_party()` would try to call `showError()`, which relies on the UI being initialized. This would crash.

So I modified `showError()` to check if UI is initialized. If it's not, it just prints the error to console instead.

Once that was fixed, I figure we want all platforms to support the same command-line launch arguments, so I moved that logic out of the Windows-only file and into boe.main.cpp