### PR TITLE
Fix fullscreen window sizing on MacOS HighDPI display

### DIFF
--- a/pkg/mac/BoE-Info.plist
+++ b/pkg/mac/BoE-Info.plist
@@ -239,5 +239,7 @@
 			</dict>
 		</dict>
 	</array>
+	<key>NSHighResolutionCapable</key>
+	<false/>
 </dict>
 </plist>

--- a/pkg/mac/BoECharEd-Info.plist
+++ b/pkg/mac/BoECharEd-Info.plist
@@ -69,5 +69,7 @@
 			</dict>
 		</dict>
 	</array>
+	<key>NSHighResolutionCapable</key>
+	<false/>
 </dict>
 </plist>

--- a/pkg/mac/BoEScenEd-Info.plist
+++ b/pkg/mac/BoEScenEd-Info.plist
@@ -71,5 +71,7 @@
 			</dict>
 		</dict>
 	</array>
+	<key>NSHighResolutionCapable</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #369 in a counterintuitive way.

I would have thought that we would want the flag that says High DPI displays *are* supported (which was even something [Fosnola](https://github.com/calref/cboe/pull/346/commits/ff05298ebec161cded8b8aa0821b4879bd0b9954) had done and I tried cherry-picking to fix this.)

But this [very old SFML forum thread](https://en.sfml-dev.org/forums/index.php?topic=17241.msg124542#msg124542) suggested setting the very same flag to false. Which I did, and it fixed both parts of the issue--the fullscreen window size, and the positioning of dialog windows.