### PR TITLE
fix #368

### DIFF
--- a/src/game/boe.graphics.cpp
+++ b/src/game/boe.graphics.cpp
@@ -173,6 +173,11 @@ void adjust_window_mode() {
 	mainPtr.setIcon(icon->getSize().x, icon->getSize().y, icon->copyToImage().getPixelsPtr());
 #endif
 
+#ifdef SFML_SYSTEM_WINDOWS
+	// On windows, the file dialogs are constructed with mainPtr as a parent,
+	// so they need to be reconstructed after mainPtr is.
+	init_fileio();
+#endif
 	init_menubar();
 	showMenuBar();
 }


### PR DESCRIPTION
A simple fix for a simple problem.

`init_fileio()` only *needs* to be called again on Windows, so I wrapped the call in `#ifdef SFML_SYSTEM_WINDOWS`. It probably wouldn't *hurt* to call it again on Mac or Linux but there's no reason to.