### PR TITLE
Mac prefs

### DIFF
--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -540,11 +540,13 @@ void cDialog::handle_events() {
 			if(next_action_type() == "control_click"){
 				Element& next_action = pop_next_action();
 				auto info = info_from_action(next_action);
+				if(info["id"].empty()) continue;
 				eKeyMod mods = static_cast<eKeyMod>(atoi(info["mods"].c_str()));
 				controls[info["id"]]->triggerClickHandler(*this, info["id"], mods);
 			}else if(next_action_type() == "control_focus"){
 				Element& next_action = pop_next_action();
 				auto info = info_from_action(next_action);
+				if(info["id"].empty()) continue;
 				bool losing;
 				istringstream sstr(info["losing"]);
 				sstr >> losing;

--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -543,14 +543,6 @@ void cDialog::handle_events() {
 				if(info["id"].empty()) continue;
 				eKeyMod mods = static_cast<eKeyMod>(atoi(info["mods"].c_str()));
 				controls[info["id"]]->triggerClickHandler(*this, info["id"], mods);
-			}else if(next_action_type() == "control_focus"){
-				Element& next_action = pop_next_action();
-				auto info = info_from_action(next_action);
-				if(info["id"].empty()) continue;
-				bool losing;
-				istringstream sstr(info["losing"]);
-				sstr >> losing;
-				controls[info["id"]]->triggerFocusHandler(*this, info["id"], losing);
 			}
 		}else{
 			while(win.pollEvent(currentEvent)) handle_one_event(currentEvent);

--- a/src/dialogxml/widgets/control.cpp
+++ b/src/dialogxml/widgets/control.cpp
@@ -359,12 +359,6 @@ bool cControl::triggerClickHandler(cDialog& dlg, std::string id, eKeyMod mods){
 }
 
 bool cControl::triggerFocusHandler(cDialog& dlg, std::string id, bool losing){
-	if(recording){
-		std::stringstream sstr;
-		sstr << losing;
-		std::map<std::string, std::string> action_info = {{"id", id}, {"losing", sstr.str()}};
-		record_action("control_focus", action_info);
-	}
 	if(losing) return triggerEvent<EVT_DEFOCUS>(dlg, id);
 	triggerEvent<EVT_FOCUS>(dlg, id);
 	return true;

--- a/src/dialogxml/widgets/ledgroup.cpp
+++ b/src/dialogxml/widgets/ledgroup.cpp
@@ -13,6 +13,8 @@
 
 #include "dialogxml/dialogs/dialog.hpp"
 
+#include "replay.hpp"
+
 cLedGroup::cLedGroup(cDialog& parent) :
 	cContainer(CTRL_GROUP,parent),
 	fromList("none") {}
@@ -69,6 +71,12 @@ bool cLedGroup::handleClick(location where) {
 }
 
 void cLedGroup::callHandler(event_fcn<EVT_CLICK>::type onClick, cDialog& me, std::string id, eKeyMod mods) {
+	// When replaying, a click event for the specifically clicked led comes next
+	if(replaying){
+		auto led_click_action = pop_next_action("control_click");
+		auto info = info_from_action(led_click_action);
+		clicking = info["id"];
+	}
 	std::string which_clicked = clicking;
 	clicking = "";
 	

--- a/src/game/boe.appleevents.mm
+++ b/src/game/boe.appleevents.mm
@@ -14,6 +14,7 @@
 #include "fileio/fileio.hpp"
 #include "boe.global.hpp"
 #include "dialogxml/dialogs/choicedlog.hpp"
+#include "replay.hpp"
 
 extern void finish_load_party();
 extern void end_startup();
@@ -53,6 +54,10 @@ void set_up_apple_events() {
 	std::string fileName;
 	std::copy(msg.get(), msg.get() + len, std::inserter(fileName, fileName.begin()));
 	
+	if(replaying || recording){
+		return FALSE;
+	}
+
 	if(!load_party(fileName, univ))
 		return FALSE;
 	

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -286,7 +286,6 @@ void init_boe(int argc, char* argv[]) {
 	init_menubar(); // Do this first of all because otherwise a default File and Window menu will be seen
 #endif
 
-	// TODO preferences need to be recorded in the action log for deterministic replay
 	sync_prefs();
 	init_shaders();
 	init_tiling();

--- a/src/tools/prefs.mac.mm
+++ b/src/tools/prefs.mac.mm
@@ -49,7 +49,7 @@ static NSString* convertKey(std::string keypath) {
 	return key;
 }
 
-NSUserDefaults* getCurrentDefaults() {
+static NSUserDefaults* getCurrentDefaults() {
 	if(replaying){
 		return replayUserDefaults;
 	}else{

--- a/src/tools/prefs.mac.mm
+++ b/src/tools/prefs.mac.mm
@@ -11,6 +11,8 @@
 #include <unordered_map>
 #include "replay.hpp"
 #include <sstream>
+#include <boost/lexical_cast.hpp>
+#include "ticpp.h"
 
 //static const CFStringRef prefsID = CFSTR("com.spidweb.bladesofexile");
 typedef NS_ENUM(NSInteger) {
@@ -40,52 +42,62 @@ NSDictionary* prefsToRecord = @{
 	@"UIScaleMap": @(kFloat)
 };
 
+bool prefsLoaded = false;
+
 static NSString* convertKey(std::string keypath) {
 	NSString* key = [NSString stringWithCString: keypath.c_str() encoding: NSASCIIStringEncoding];
 	return key;
 }
 
+NSUserDefaults* getCurrentDefaults() {
+	if(replaying){
+		return replayUserDefaults;
+	}else{
+		return [NSUserDefaults standardUserDefaults];
+	}
+}
+
 void set_pref(std::string keypath, bool value) {
-	[[NSUserDefaults standardUserDefaults] setBool: value forKey: convertKey(keypath)];
+	[getCurrentDefaults() setBool: value forKey: convertKey(keypath)];
 }
 
 bool get_bool_pref(std::string keypath, bool fallback) {
-	id val = [[NSUserDefaults standardUserDefaults] objectForKey: convertKey(keypath)];
+	id val = [getCurrentDefaults() objectForKey: convertKey(keypath)];
 	if([val isKindOfClass: [NSNumber class]]) return [val boolValue];
 	return fallback;
 }
 
 void set_pref(std::string keypath, int value) {
-	[[NSUserDefaults standardUserDefaults] setInteger: value forKey: convertKey(keypath)];
+	[getCurrentDefaults() setInteger: value forKey: convertKey(keypath)];
 }
 
 int get_int_pref(std::string keypath, int fallback) {
-	id val = [[NSUserDefaults standardUserDefaults] objectForKey: convertKey(keypath)];
+	id val = [getCurrentDefaults() objectForKey: convertKey(keypath)];
 	if([val isKindOfClass: [NSNumber class]]) return [val intValue];
 	return fallback;
 }
 
 void set_pref(std::string keypath, double value) {
-	[[NSUserDefaults standardUserDefaults] setDouble: value forKey: convertKey(keypath)];
+	[getCurrentDefaults() setDouble: value forKey: convertKey(keypath)];
 }
 
 double get_float_pref(std::string keypath, double fallback) {
-	id val = [[NSUserDefaults standardUserDefaults] objectForKey: convertKey(keypath)];
+	id val = [getCurrentDefaults() objectForKey: convertKey(keypath)];
 	if([val isKindOfClass: [NSNumber class]]) return [val doubleValue];
 	return fallback;
 }
 
 void append_iarray_pref(std::string keypath, int value) {
 	NSString* key = convertKey(keypath);
-	NSArray* list = [[NSUserDefaults standardUserDefaults] arrayForKey: key];
+	NSArray* list = [getCurrentDefaults() arrayForKey: key];
 	NSNumber* num = [NSNumber numberWithInt: value];
 	if(list == nil)
-		[[NSUserDefaults standardUserDefaults] setObject: [NSArray arrayWithObject: num] forKey: key] ;
-	else [[NSUserDefaults standardUserDefaults] setObject: [list arrayByAddingObject: num] forKey: key];
+		[getCurrentDefaults() setObject: [NSArray arrayWithObject: num] forKey: key] ;
+	else [getCurrentDefaults() setObject: [list arrayByAddingObject: num] forKey: key];
 }
 
 std::vector<int> get_iarray_pref(std::string keypath) {
-	NSArray* list = [[NSUserDefaults standardUserDefaults] arrayForKey: convertKey(keypath)];
+	NSArray* list = [getCurrentDefaults() arrayForKey: convertKey(keypath)];
 	if(list == nil) return {};
 	std::vector<int> result;
 	for(size_t i = 0; i < [list count]; i++)
@@ -94,11 +106,65 @@ std::vector<int> get_iarray_pref(std::string keypath) {
 }
 
 void clear_pref(std::string keypath) {
-	[[NSUserDefaults standardUserDefaults] setValue: nil forKey: convertKey(keypath)];
+	[getCurrentDefaults() setValue: nil forKey: convertKey(keypath)];
+}
+
+// When replaying, load the preferences from the action log into a
+// non-synchronized UserDefaults object
+static bool load_prefs(std::istream& istream) {
+	std::string line;
+	while(std::getline(istream, line)) {
+		if(!istream) {
+			perror("Error reading preferences");
+			return false;
+		}
+		if(line[0] == '#') continue;
+		int eq = line.find_first_of('=');
+		if(eq == std::string::npos) {
+			printf("Error reading preferences: line is not a comment and lacks an = sign:\n\t%s\n", line.c_str());
+			return false;
+		}
+		int key_end = line.find_last_not_of(' ', eq - 1), val_beg = line.find_first_not_of(' ', eq + 1);
+		if(val_beg == std::string::npos) {
+			printf("Error reading preferences: line is missing value:\n\t%s\n", line.c_str());
+			return false;
+		}
+		if(key_end == std::string::npos) {
+			printf("Error reading preferences: line is missing key:\n\t%s\n", line.c_str());
+			return false;
+		}
+
+		std::string key = line.substr(0, key_end + 1), val = line.substr(val_beg);
+		NSInteger type = [prefsToRecord[[NSString stringWithUTF8String: key.c_str()]] integerValue];
+		switch((int)type) {
+			case kBool:
+				if(val == "true") set_pref(key, true);
+				else if(val == "false") set_pref(key, false);
+				break;
+			case kIArray:
+				if(val[0] == '[') {
+					int arr_end = val.find_first_of(']');
+					std::istringstream arr_vals(val.substr(1, arr_end - 1));
+					int i = 0;
+					clear_pref(key);
+					while(arr_vals >> i) append_iarray_pref(key, i);
+				}
+				break;
+			case kFloat:
+				set_pref(key, boost::lexical_cast<double>(val));
+				break;
+			case kInt:
+				set_pref(key, boost::lexical_cast<int>(val));
+				break;
+		}
+	}
+
+	prefsLoaded = true;
+	return true;
 }
 
 bool sync_prefs() {
-	if(recording){
+	if(recording && !prefsLoaded){
 		std::ostringstream prefs_recording;
 		NSUserDefaults* standard = [NSUserDefaults standardUserDefaults];
 		for(id pref in prefsToRecord) {
@@ -108,7 +174,7 @@ bool sync_prefs() {
 				NSInteger type = [prefsToRecord[pref] integerValue];
 				bool bvalue;
 				int ivalue;
-				float fvalue;
+				double fvalue;
 				int count;
 				int c;
 				NSArray* arrayValue;
@@ -139,16 +205,20 @@ bool sync_prefs() {
 						prefs_recording << "]";
 						break;
 					case kFloat:
-						fvalue = (float)[standard floatForKey: pref];
+						fvalue = (double)[standard doubleForKey: pref];
 						prefs_recording << fvalue;
 						break;
 				}
 				prefs_recording << std::endl;
 			}
 		}
-		record_action("sync_prefs", prefs_recording.str());
-	}else if(replaying){
-		replayUserDefaults = [NSUserDefaults init];
+		record_action("load_prefs", prefs_recording.str());
+		prefsLoaded = true;
+	}else if(replaying && !prefsLoaded){
+		replayUserDefaults = [[NSUserDefaults alloc] init];
+		Element& prefs_action = pop_next_action("load_prefs");
+		std::istringstream istream(prefs_action.GetText());
+		return load_prefs(istream);
 	}
 	return [[NSUserDefaults standardUserDefaults] synchronize];
 }

--- a/src/tools/prefs.mac.mm
+++ b/src/tools/prefs.mac.mm
@@ -9,8 +9,36 @@
 #include "prefs.hpp"
 #include <Foundation/Foundation.h>
 #include <unordered_map>
+#include "replay.hpp"
+#include <sstream>
 
 //static const CFStringRef prefsID = CFSTR("com.spidweb.bladesofexile");
+typedef NS_ENUM(NSInteger) {
+	kInt = 0,
+	kBool = 1,
+	kFloat = 2,
+	kIArray = 3
+} PrefType;
+
+NSUserDefaults* replayUserDefaults = nil;
+NSDictionary* prefsToRecord = @{
+	@"DisplayMode": @(kInt),
+	@"DrawTerrainAnimation": @(kBool),
+	@"DrawTerrainFrills": @(kBool),
+	@"DrawTerrainShoreFrills": @(kBool),
+	@"EasyMode": @(kBool),
+	@"GameRunBefore": @(kBool),
+	@"GameSpeed": @(kInt),
+	@"GiveIntroHint": @(kBool),
+	@"LessWanderingMonsters": @(kBool),
+	@"PlaySounds": @(kBool),
+	@"ReceivedHelp": @(kIArray),
+	@"RepeatRoomDescriptions": @(kBool),
+	@"ShowInstantHelp": @(kBool),
+	@"ShowStartupFlash": @(kBool),
+	@"UIScale": @(kFloat),
+	@"UIScaleMap": @(kFloat)
+};
 
 static NSString* convertKey(std::string keypath) {
 	NSString* key = [NSString stringWithCString: keypath.c_str() encoding: NSASCIIStringEncoding];
@@ -70,6 +98,58 @@ void clear_pref(std::string keypath) {
 }
 
 bool sync_prefs() {
+	if(recording){
+		std::ostringstream prefs_recording;
+		NSUserDefaults* standard = [NSUserDefaults standardUserDefaults];
+		for(id pref in prefsToRecord) {
+			id object = [standard objectForKey: pref];
+			if(object != nil){
+				prefs_recording << [pref UTF8String] << " = ";
+				NSInteger type = [prefsToRecord[pref] integerValue];
+				bool bvalue;
+				int ivalue;
+				float fvalue;
+				int count;
+				int c;
+				NSArray* arrayValue;
+				switch((int)type) {
+					case kBool:
+						bvalue = [standard boolForKey: pref];
+						if(bvalue == true){
+							prefs_recording << "true";
+						}else{
+							prefs_recording << "false";
+						}
+						break;
+					case kInt:
+						ivalue = (int)[standard integerForKey: pref];
+						prefs_recording << ivalue;
+						break;
+					case kIArray:
+						arrayValue = [standard arrayForKey: pref];
+						prefs_recording << "[";
+						count = [arrayValue count];
+						c = 0;
+						for(id num in arrayValue){
+							prefs_recording << [num integerValue];
+							if (c < count - 1)
+								prefs_recording << " ";
+							++c;
+						}
+						prefs_recording << "]";
+						break;
+					case kFloat:
+						fvalue = (float)[standard floatForKey: pref];
+						prefs_recording << fvalue;
+						break;
+				}
+				prefs_recording << std::endl;
+			}
+		}
+		record_action("sync_prefs", prefs_recording.str());
+	}else if(replaying){
+		replayUserDefaults = [NSUserDefaults init];
+	}
 	return [[NSUserDefaults standardUserDefaults] synchronize];
 }
 

--- a/src/tools/prefs.mac.mm
+++ b/src/tools/prefs.mac.mm
@@ -172,30 +172,24 @@ bool sync_prefs() {
 			if(object != nil){
 				prefs_recording << [pref UTF8String] << " = ";
 				NSInteger type = [prefsToRecord[pref] integerValue];
-				bool bvalue;
-				int ivalue;
-				double fvalue;
-				int count;
-				int c;
-				NSArray* arrayValue;
 				switch((int)type) {
-					case kBool:
-						bvalue = [standard boolForKey: pref];
+					case kBool: {
+						bool bvalue = [standard boolForKey: pref];
 						if(bvalue == true){
 							prefs_recording << "true";
 						}else{
 							prefs_recording << "false";
 						}
-						break;
-					case kInt:
-						ivalue = (int)[standard integerForKey: pref];
+					} break;
+					case kInt: {
+						int ivalue = (int)[standard integerForKey: pref];
 						prefs_recording << ivalue;
-						break;
-					case kIArray:
-						arrayValue = [standard arrayForKey: pref];
+					} break;
+					case kIArray: {
+						NSArray* arrayValue = [standard arrayForKey: pref];
 						prefs_recording << "[";
-						count = [arrayValue count];
-						c = 0;
+						int count = [arrayValue count];
+						int c = 0;
 						for(id num in arrayValue){
 							prefs_recording << [num integerValue];
 							if (c < count - 1)
@@ -203,11 +197,11 @@ bool sync_prefs() {
 							++c;
 						}
 						prefs_recording << "]";
-						break;
-					case kFloat:
-						fvalue = (double)[standard doubleForKey: pref];
+					} break;
+					case kFloat: {
+						double fvalue = (double)[standard doubleForKey: pref];
 						prefs_recording << fvalue;
-						break;
+					} break;
 				}
 				prefs_recording << std::endl;
 			}

--- a/src/tools/replay.cpp
+++ b/src/tools/replay.cpp
@@ -113,7 +113,7 @@ std::map<std::string,std::string> info_from_action(Element& action) {
 	std::map<std::string,std::string> info = {};
 	Element* next_child = action.FirstChildElement(false);
 	while(next_child){
-		info[next_child->Value()] = next_child->GetText();
+		info[next_child->Value()] = next_child->GetTextOrDefault("");
 		next_child = next_child->NextSiblingElement(false);
 	}
 	return info;


### PR DESCRIPTION
Part 2 of the replay system work/with a focus on getting MacOS replay functionality caught up.

* On Mac, when passing command-line arguments, the apple events function is still called, and it tries to load "replay" and "replayFile.xml" both as exg files, throwing an error message. I fixed that
* I dug into the scary Objective-C++ for mac preferences and wrote some rough code to record the relevant BoE preferences to the action logs and load it back out.
    * I have not tested whether a Mac can replay a log from Windows and vice-versa, but I tried to make it so that will work.
    * Should Objective-C++ code follow naming and style conventions of the C++ codebase, or the conventions of the existing Objective-C++ it's added to?
* Trying to replay every control_focus event was proving a nightmare when accounting for controls that are within containers. I also think it was a mistake to record and replay focus events in the first place, because it looks like they're triggered as side-effects of triggerClickEvent() anyway, meaning that in the current state of things the focus events might be replaying twice. So I reverted adding the `control_focus` as a logged event.
* made led groups work with click replays
    * I've recorded and replayed a session where the game launches, preferences are opened, and window size changes from fullscreen to windowed mode. pretty cool. (That's not included in the PR)