### PR TITLE
Replay System part 3

### DIFF
--- a/src/dialogxml/widgets/container.cpp
+++ b/src/dialogxml/widgets/container.cpp
@@ -14,6 +14,7 @@
 #include "dialogxml/widgets/message.hpp"
 #include "dialogxml/widgets/pict.hpp"
 #include "dialogxml/widgets/scrollbar.hpp"
+#include "replay.hpp"
 
 bool cContainer::parseChildControl(ticpp::Element& elem, std::map<std::string,cControl*>& controls, std::string& id) {
 	std::string tag = elem.Value();
@@ -67,6 +68,12 @@ bool cContainer::handleClick(location where) {
 }
 
 void cContainer::callHandler(event_fcn<EVT_CLICK>::type onClick, cDialog& me, std::string id, eKeyMod mods) {
+	// When replaying, a click event for the specifically child control comes next
+	if(replaying){
+		auto child_click_action = pop_next_action("control_click");
+		auto info = info_from_action(child_click_action);
+		clicking = info["id"];
+	}
 	std::string which_clicked = clicking;
 	clicking = "";
 	

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -820,7 +820,11 @@ void handle_use_item(short item_hit, bool& did_something, bool& need_redraw) {
 	need_redraw = true;
 }
 
-static void handle_give_item(short item_hit, bool& did_something, bool& need_redraw) {
+void handle_give_item(short item_hit, bool& did_something, bool& need_redraw) {
+	if(recording){
+		record_action("handle_give_item", std::to_string(item_hit));
+	}
+
 	if(!prime_time()) {
 		add_string_to_buf("Give item: Finish what you're doing first.");
 		return;

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -644,7 +644,13 @@ static void handle_target_space(location destination, bool& did_something, bool&
 	put_item_screen(stat_window);
 }
 
-static void handle_drop_item(location destination, bool& need_redraw) {
+void handle_drop_item(location destination, bool& need_redraw) {
+	if(recording){
+		std::ostringstream sstr;
+		sstr << destination;
+		record_action("handle_drop_item_location", sstr.str());
+	}
+
 	if(overall_mode == MODE_DROP_COMBAT) {
 		if(!adjacent(univ.current_pc().combat_pos,destination))
 			add_string_to_buf("Drop: must be adjacent.");
@@ -825,7 +831,11 @@ static void handle_give_item(short item_hit, bool& did_something, bool& need_red
 	take_ap(1);
 }
 
-static void handle_drop_item(short item_hit, bool& need_redraw) {
+void handle_drop_item(short item_hit, bool& need_redraw) {
+	if(recording){
+		record_action("handle_drop_item_id", std::to_string(item_hit));
+	}
+
 	if(overall_mode == MODE_DROP_TOWN || overall_mode == MODE_DROP_COMBAT) {
 		add_string_to_buf("Drop item: Cancelled");
 		overall_mode = is_town() ? MODE_TOWN : MODE_COMBAT;

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -40,6 +40,7 @@
 #include "tools/prefs.hpp"
 #include "gfx/render_shapes.hpp"
 #include "tools/enum_map.hpp"
+#include <string>
 
 rectangle item_screen_button_rects[9] = {
 	{125,10,141,28},{125,40,141,58},{125,68,141,86},{125,98,141,116},{125,126,141,144},{125,156,141,174},
@@ -721,7 +722,11 @@ static void handle_bash_pick(location destination, bool& did_something, bool& ne
 	put_item_screen(stat_window);
 }
 
-static void handle_switch_pc(short which_pc, bool& need_redraw, bool& need_reprint) {
+void handle_switch_pc(short which_pc, bool& need_redraw, bool& need_reprint) {
+	if(recording){
+		record_action("handle_switch_pc", std::to_string(which_pc));
+	}
+
 	cPlayer& pc = univ.party[which_pc];
 	if(!prime_time() && overall_mode != MODE_SHOPPING && overall_mode != MODE_TALKING)
 		add_string_to_buf("Set active: Finish what you're doing first.");

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -750,7 +750,11 @@ void handle_switch_pc(short which_pc, bool& need_redraw, bool& need_reprint) {
 	need_reprint = true;
 }
 
-static void handle_switch_pc_items(short which_pc, bool& need_redraw) {
+void handle_switch_pc_items(short which_pc, bool& need_redraw) {
+	if(recording){
+		record_action("handle_switch_pc_items", std::to_string(which_pc));
+	}
+
 	cPlayer& pc = univ.party[which_pc];
 	if(!prime_time() && overall_mode != MODE_TALKING && overall_mode != MODE_SHOPPING)
 		add_string_to_buf("Set active: Finish what you're doing first.");
@@ -773,7 +777,11 @@ static void handle_switch_pc_items(short which_pc, bool& need_redraw) {
 	}
 }
 
-static void handle_equip_item(short item_hit, bool& need_redraw) {
+void handle_equip_item(short item_hit, bool& need_redraw) {
+	if(recording){
+		record_action("handle_equip_item", std::to_string(item_hit));
+	}
+
 	if(overall_mode == MODE_USE_TOWN) {
 		// TODO: Uh, this looks wrong somehow.
 		add_string_to_buf("Note: Clicking 'U' button by item uses the item.", 2);
@@ -790,7 +798,11 @@ static void handle_equip_item(short item_hit, bool& need_redraw) {
 	} else add_string_to_buf("Equip: Finish what you're doing first.");
 }
 
-static void handle_use_item(short item_hit, bool& did_something, bool& need_redraw) {
+void handle_use_item(short item_hit, bool& did_something, bool& need_redraw) {
+	if(recording){
+		record_action("handle_use_item", std::to_string(item_hit));
+	}
+
 	if(!prime_time()) {
 		add_string_to_buf("Use item: Finish what you're doing first.");
 		return;
@@ -829,7 +841,11 @@ static void handle_drop_item(short item_hit, bool& need_redraw) {
 	}
 }
 
-static void handle_item_shop_action(short item_hit) {
+void handle_item_shop_action(short item_hit) {
+	if(recording){
+		record_action("handle_item_shop_action", std::to_string(item_hit));
+	}
+
 	long i = item_hit - item_sbar->getPosition();
 	cPlayer& shopper = univ.party[stat_window];
 	cItem& target = shopper.items[item_hit];
@@ -867,7 +883,11 @@ static void handle_item_shop_action(short item_hit) {
 	}
 }
 
-static void handle_alchemy(bool& need_redraw, bool& need_reprint) {
+void handle_alchemy(bool& need_redraw, bool& need_reprint) {
+	if(recording){
+		record_action("handle_alchemy", "");
+	}
+
 	need_reprint = true;
 	need_redraw = true;
 	if(overall_mode == MODE_TOWN)
@@ -875,7 +895,11 @@ static void handle_alchemy(bool& need_redraw, bool& need_reprint) {
 	else add_string_to_buf("Alchemy: Only in town.");
 }
 
-static void handle_town_wait(bool& need_redraw, bool& need_reprint) {
+void handle_town_wait(bool& need_redraw, bool& need_reprint) {
+	if(recording){
+		record_action("handle_town_wait", "");
+	}
+
 	std::vector<short> store_hp;
 	sf::Event dummy_evt;
 	need_reprint = true;
@@ -918,7 +942,11 @@ static void handle_town_wait(bool& need_redraw, bool& need_reprint) {
 	put_pc_screen();
 }
 
-static void handle_combat_switch(bool& did_something, bool& need_redraw, bool& need_reprint) {
+void handle_combat_switch(bool& did_something, bool& need_redraw, bool& need_reprint) {
+	if(recording){
+		record_action("handle_combat_switch", "");
+	}
+
 	if(overall_mode == MODE_TOWN) {
 		if(univ.party.in_boat >= 0) {
 			need_reprint = true;
@@ -969,7 +997,11 @@ static void handle_combat_switch(bool& did_something, bool& need_redraw, bool& n
 	}
 }
 
-static void handle_missile(bool& need_redraw, bool& need_reprint) {
+void handle_missile(bool& need_redraw, bool& need_reprint) {
+	if(recording){
+		record_action("handle_missile", "");
+	}
+
 	if(overall_mode == MODE_COMBAT) {
 		load_missile();
 		need_reprint = true;
@@ -983,7 +1015,11 @@ static void handle_missile(bool& need_redraw, bool& need_reprint) {
 	}
 }
 
-static void handle_get_items(bool& did_something, bool& need_redraw, bool& need_reprint) {
+void handle_get_items(bool& did_something, bool& need_redraw, bool& need_reprint) {
+	if(recording){
+		record_action("handle_get_items", "");
+	}
+
 	int j = 0;
 	if(univ.party.in_boat >= 0)
 		add_string_to_buf("Get: Not while in boat.");

--- a/src/game/boe.actions.hpp
+++ b/src/game/boe.actions.hpp
@@ -36,4 +36,19 @@ short count_walls(location loc);
 bool is_sign(ter_num_t ter);
 bool check_for_interrupt();
 
+void handle_startup_button_click(eStartButton btn);
+void handle_switch_pc(short which_pc, bool& need_redraw, bool& need_reprint);
+void handle_switch_pc_items(short which_pc, bool& need_redraw);
+void handle_equip_item(short item_hit, bool& need_redraw);
+void handle_use_item(short item_hit, bool& did_something, bool& need_redraw);
+void handle_item_shop_action(short item_hit);
+void handle_alchemy(bool& need_redraw, bool& need_reprint);
+void handle_town_wait(bool& need_redraw, bool& need_reprint);
+void handle_combat_switch(bool& did_something, bool& need_redraw, bool& need_reprint);
+void handle_missile(bool& need_redraw, bool& need_reprint);
+void handle_get_items(bool& did_something, bool& need_redraw, bool& need_reprint);
+void handle_drop_item(short item_hit, bool& need_redraw);
+void handle_drop_item(location destination, bool& need_redraw);
+void handle_give_item(short item_hit, bool& did_something, bool& need_redraw);
+
 #endif

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -132,6 +132,7 @@ void handle_missile(bool& need_redraw, bool& need_reprint);
 void handle_get_items(bool& did_something, bool& need_redraw, bool& need_reprint);
 void handle_drop_item(short item_hit, bool& need_redraw);
 void handle_drop_item(location destination, bool& need_redraw);
+void handle_give_item(short item_hit, bool& did_something, bool& need_redraw);
 
 #ifdef __APPLE__
 eMenuChoice menuChoice=eMenuChoice::MENU_CHOICE_NONE;
@@ -315,6 +316,9 @@ void replay_next_action() {
 	}else if(t == "handle_drop_item_location"){
 		location destination = location_from_action(next_action);
 		handle_drop_item(destination, need_redraw);
+	}else if(t == "handle_give_item"){
+		short item_hit = short_from_action(next_action);
+		handle_give_item(item_hit, did_something, need_redraw);
 	}
 
 	advance_time(did_something, need_redraw, need_reprint);

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -324,6 +324,8 @@ void replay_next_action() {
 	}else if(t == "handle_give_item"){
 		short item_hit = short_from_action(next_action);
 		handle_give_item(item_hit, did_something, need_redraw);
+	}else if(t == "close_window"){
+		handle_quit_event();
 	}
 
 	advance_time(did_something, need_redraw, need_reprint);
@@ -459,6 +461,9 @@ void handle_events() {
 }
 
 void handle_quit_event() {
+	if(recording){
+		record_action("close_window", "");
+	}
 	if(overall_mode == MODE_STARTUP) {
 		if(party_in_memory) {
 			std::string choice = cChoiceDlog("quit-confirm-save", {"save","quit","cancel"}).show();

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -64,7 +64,7 @@ cUniverse univ;
 bool flushingInput = false, ae_loading = false;
 long start_time;
 
-std::deque<const sf::Event> fake_event_queue;
+std::deque<sf::Event> fake_event_queue;
 
 short on_spell_menu[2][62];
 short on_monst_menu[256];

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -269,14 +269,10 @@ void replay_next_action() {
 		load_party(tempDir / "temp.exg", univ);
 		finish_load_party();
 	}else if(t == "move"){
-		location l;
-		std::istringstream sstr(next_action.GetText());
-		sstr >> l;
+		location l = location_from_action(next_action);
 		handle_move(l, did_something, need_redraw, need_reprint);
 	}else if(t == "handle_switch_pc"){
-		short which_pc;
-		std::istringstream sstr(next_action.GetText());
-		sstr >> which_pc;
+		short which_pc = short_from_action(next_action);
 		handle_switch_pc(which_pc, need_redraw, need_reprint);
 	}
 

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -118,6 +118,7 @@ static void init_boe(int, char*[]);
 static void showWelcome();
 
 void handle_startup_button_click(eStartButton btn);
+void handle_switch_pc(short which_pc, bool& need_redraw, bool& need_reprint);
 
 #ifdef __APPLE__
 eMenuChoice menuChoice=eMenuChoice::MENU_CHOICE_NONE;
@@ -272,6 +273,11 @@ void replay_next_action() {
 		std::istringstream sstr(next_action.GetText());
 		sstr >> l;
 		handle_move(l, did_something, need_redraw, need_reprint);
+	}else if(t == "handle_switch_pc"){
+		short which_pc;
+		std::istringstream sstr(next_action.GetText());
+		sstr >> which_pc;
+		handle_switch_pc(which_pc, need_redraw, need_reprint);
 	}
 
 	advance_time(did_something, need_redraw, need_reprint);

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -120,23 +120,6 @@ extern long anim_ticks;
 static void init_boe(int, char*[]);
 static void showWelcome();
 
-// TODO all these forward declarations of boe.actions.cpp functions might be less
-// than ideal. Maybe they could be moved to boe.actions.hpp and #included here instead
-void handle_startup_button_click(eStartButton btn);
-void handle_switch_pc(short which_pc, bool& need_redraw, bool& need_reprint);
-void handle_switch_pc_items(short which_pc, bool& need_redraw);
-void handle_equip_item(short item_hit, bool& need_redraw);
-void handle_use_item(short item_hit, bool& did_something, bool& need_redraw);
-void handle_item_shop_action(short item_hit);
-void handle_alchemy(bool& need_redraw, bool& need_reprint);
-void handle_town_wait(bool& need_redraw, bool& need_reprint);
-void handle_combat_switch(bool& did_something, bool& need_redraw, bool& need_reprint);
-void handle_missile(bool& need_redraw, bool& need_reprint);
-void handle_get_items(bool& did_something, bool& need_redraw, bool& need_reprint);
-void handle_drop_item(short item_hit, bool& need_redraw);
-void handle_drop_item(location destination, bool& need_redraw);
-void handle_give_item(short item_hit, bool& did_something, bool& need_redraw);
-
 void handle_quit_event();
 
 #ifdef __APPLE__

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -130,6 +130,8 @@ void handle_town_wait(bool& need_redraw, bool& need_reprint);
 void handle_combat_switch(bool& did_something, bool& need_redraw, bool& need_reprint);
 void handle_missile(bool& need_redraw, bool& need_reprint);
 void handle_get_items(bool& did_something, bool& need_redraw, bool& need_reprint);
+void handle_drop_item(short item_hit, bool& need_redraw);
+void handle_drop_item(location destination, bool& need_redraw);
 
 #ifdef __APPLE__
 eMenuChoice menuChoice=eMenuChoice::MENU_CHOICE_NONE;
@@ -307,8 +309,13 @@ void replay_next_action() {
 		handle_missile(need_redraw, need_reprint);
 	}else if(t == "handle_get_items"){
 		handle_get_items(did_something, need_redraw, need_reprint);
+	}else if(t == "handle_drop_item_id"){
+		short item_hit = short_from_action(next_action);
+		handle_drop_item(item_hit, need_redraw);
+	}else if(t == "handle_drop_item_location"){
+		location destination = location_from_action(next_action);
+		handle_drop_item(destination, need_redraw);
 	}
-	// void handle_drop_item(short item_hit, bool& need_redraw);
 
 	advance_time(did_something, need_redraw, need_reprint);
 }

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -339,12 +339,6 @@ void init_boe(int argc, char* argv[]) {
 	init_mini_map();
 	redraw_screen(REFRESH_NONE);
 	showMenuBar();
-
-	if(replaying){
-		while(has_next_action()){
-			replay_next_action();
-		}
-	}
 }
 
 void showWelcome() {
@@ -361,32 +355,36 @@ void handle_events() {
 	cFramerateLimiter fps_limiter;
 
 	while(!All_Done) {
+		if(replaying && has_next_action()){
+			replay_next_action();
+		}else{
 #ifdef __APPLE__
-		if (menuChoiceId>=0) {
-			eMenuChoice aMenuChoice=menuChoice;
-			menuChoice=eMenuChoice::MENU_CHOICE_NONE;
-			switch(aMenuChoice) {
-				case eMenuChoice::MENU_CHOICE_GENERIC:
-					handle_menu_choice(eMenu(menuChoiceId));
-					break;
-				case eMenuChoice::MENU_CHOICE_SPELL:
-					handle_menu_spell(eSpell(menuChoiceId));
-					break;
-				case eMenuChoice::MENU_CHOICE_MONSTER_INFO:
-					handle_monster_info_menu(menuChoiceId);
-					break;
-				case eMenuChoice::MENU_CHOICE_NONE:
-					break;
+			if (menuChoiceId>=0) {
+				eMenuChoice aMenuChoice=menuChoice;
+				menuChoice=eMenuChoice::MENU_CHOICE_NONE;
+				switch(aMenuChoice) {
+					case eMenuChoice::MENU_CHOICE_GENERIC:
+						handle_menu_choice(eMenu(menuChoiceId));
+						break;
+					case eMenuChoice::MENU_CHOICE_SPELL:
+						handle_menu_spell(eSpell(menuChoiceId));
+						break;
+					case eMenuChoice::MENU_CHOICE_MONSTER_INFO:
+						handle_monster_info_menu(menuChoiceId);
+						break;
+					case eMenuChoice::MENU_CHOICE_NONE:
+						break;
+				}
+				menuChoiceId=-1;
 			}
-			menuChoiceId=-1;
-		}
 #endif
-		while(mainPtr.pollEvent(currentEvent)) handle_one_event(currentEvent);
+			while(mainPtr.pollEvent(currentEvent)) handle_one_event(currentEvent);
 
-		// It would be nice to have minimap inside the main game window (we have lots of screen space in fullscreen mode).
-		// Alternatively, minimap could live on its own thread.
-		// But for now we just handle events from both windows on this thread.
-		while(map_visible && mini_map.pollEvent(currentEvent)) handle_one_minimap_event(currentEvent);
+			// It would be nice to have minimap inside the main game window (we have lots of screen space in fullscreen mode).
+			// Alternatively, minimap could live on its own thread.
+			// But for now we just handle events from both windows on this thread.
+			while(map_visible && mini_map.pollEvent(currentEvent)) handle_one_minimap_event(currentEvent);
+		}
 
 		if(changed_display_mode) {
 			changed_display_mode = false;

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -117,8 +117,19 @@ extern long anim_ticks;
 static void init_boe(int, char*[]);
 static void showWelcome();
 
+// TODO all these forward declarations of boe.actions.cpp functions might be less
+// than ideal. Maybe they could be moved to boe.actions.hpp and #included here instead
 void handle_startup_button_click(eStartButton btn);
 void handle_switch_pc(short which_pc, bool& need_redraw, bool& need_reprint);
+void handle_switch_pc_items(short which_pc, bool& need_redraw);
+void handle_equip_item(short item_hit, bool& need_redraw);
+void handle_use_item(short item_hit, bool& did_something, bool& need_redraw);
+void handle_item_shop_action(short item_hit);
+void handle_alchemy(bool& need_redraw, bool& need_reprint);
+void handle_town_wait(bool& need_redraw, bool& need_reprint);
+void handle_combat_switch(bool& did_something, bool& need_redraw, bool& need_reprint);
+void handle_missile(bool& need_redraw, bool& need_reprint);
+void handle_get_items(bool& did_something, bool& need_redraw, bool& need_reprint);
 
 #ifdef __APPLE__
 eMenuChoice menuChoice=eMenuChoice::MENU_CHOICE_NONE;
@@ -274,7 +285,30 @@ void replay_next_action() {
 	}else if(t == "handle_switch_pc"){
 		short which_pc = short_from_action(next_action);
 		handle_switch_pc(which_pc, need_redraw, need_reprint);
+	}else if(t == "handle_switch_pc_items"){
+		short which_pc = short_from_action(next_action);
+		handle_switch_pc_items(which_pc, need_redraw);
+	}else if(t == "handle_equip_item"){
+		short item_hit = short_from_action(next_action);
+		handle_equip_item(item_hit, need_redraw);
+	}else if(t == "handle_use_item"){
+		short item_hit = short_from_action(next_action);
+		handle_use_item(item_hit, did_something, need_redraw);
+	}else if(t == "handle_item_shop_action"){
+		short item_hit = short_from_action(next_action);
+		handle_item_shop_action(item_hit);
+	}else if(t == "handle_alchemy"){
+		handle_alchemy(need_redraw, need_reprint);
+	}else if(t == "handle_town_wait"){
+		handle_town_wait(need_redraw, need_reprint);
+	}else if(t == "handle_combat_switch"){
+		handle_combat_switch(did_something, need_redraw, need_reprint);
+	}else if(t == "handle_missile"){
+		handle_missile(need_redraw, need_reprint);
+	}else if(t == "handle_get_items"){
+		handle_get_items(did_something, need_redraw, need_reprint);
 	}
+	// void handle_drop_item(short item_hit, bool& need_redraw);
 
 	advance_time(did_something, need_redraw, need_reprint);
 }

--- a/src/game/boe.main.hpp
+++ b/src/game/boe.main.hpp
@@ -23,5 +23,6 @@ void update_terrain_animation();
 void update_startup_animation();
 void handle_events();
 void handle_one_event(const sf::Event&);
+void queue_fake_event(const sf::Event&);
 void handle_one_minimap_event(const sf::Event &);
 

--- a/src/tools/replay.cpp
+++ b/src/tools/replay.cpp
@@ -6,6 +6,7 @@
 #include <ctime>
 #include <iomanip>
 #include <fstream>
+#include <sstream>
 #include <boost/algorithm/string/predicate.hpp>
 #include <cppcodec/base64_rfc4648.hpp>
 using base64 = cppcodec::base64_rfc4648;
@@ -136,4 +137,18 @@ void decode_file(std::string data, fs::path file) {
 	std::vector<uint8_t> bytes = base64::decode(data.c_str(), strlen(data.c_str()) * sizeof(char));
 	char* bytes_as_c_str = reinterpret_cast<char*>(bytes.data());
 	ofs.write(bytes_as_c_str, bytes.size() / sizeof(char));
+}
+
+location location_from_action(Element& action) {
+	location l;
+	std::istringstream sstr(action.GetText());
+	sstr >> l;
+	return l;
+}
+
+short short_from_action(Element& action) {
+	short s;
+	std::istringstream sstr(action.GetText());
+	sstr >> s;
+	return s;
 }

--- a/src/tools/replay.hpp
+++ b/src/tools/replay.hpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <map>
 #include <boost/filesystem.hpp>
+#include "location.hpp"
 
 // Input recording system
 namespace ticpp { class Element; }
@@ -22,5 +23,7 @@ extern Element& pop_next_action(std::string expected_action_type="");
 extern std::map<std::string,std::string> info_from_action(Element& action);
 extern std::string encode_file(fs::path file);
 extern void decode_file(std::string data, fs::path file);
+extern location location_from_action(Element& action);
+extern short short_from_action(Element& action);
 
 #endif


### PR DESCRIPTION
2 core changes:
* I moved the replay_next_action() call into the actual game loop and only process one action per frame, so things actually redraw in between actions.
* Fixed replaying control clicks inside subclasses of cContainer (so cStack and cScrollPane), which had the same problem that led groups previously had

Aside from that, added recording and replay for several relatively trivial actions.