### PR TITLE
Fix #318

### DIFF
--- a/src/game/boe.items.cpp
+++ b/src/game/boe.items.cpp
@@ -42,6 +42,8 @@ extern sf::Texture pc_gworld;
 extern sf::RenderTexture map_gworld;
 extern cUniverse univ;
 
+extern void draw_map(bool need_refresh);
+
 short selected;
 
 bool GTP(short item_num) {
@@ -692,7 +694,7 @@ void init_mini_map() {
 		play_sound(2);
 		throw std::string("Failed to initialized automap!");
 	} else {
-		map_gworld.clear(sf::Color::White);
+		draw_map(true);
 	}
 }
 


### PR DESCRIPTION
The minimap code is very scary and weird, distributed across source files that don't make a lot of sense. I haven't figured out why init_mini_map() ends up called in the sequence that causes #318 to happen, but #318 is definitely caused because init_mini_map() clears the minimap texture to white (no other place in the code does that.)

So this fixes the problem by redrawing the map instead of clearing it to white. If the map isn't visible, it won't redraw, so I don't think this would cause other problems.