### PR TITLE
fix #240

### DIFF
--- a/src/game/boe.fileio.cpp
+++ b/src/game/boe.fileio.cpp
@@ -246,12 +246,22 @@ void build_outdoors() {
 	for(short i = 0; i < 48; i++)
 		for(short j = 0; j < 48; j++) {
 			univ.out[i][j] = univ.scenario.outdoors[x][y]->terrain[i][j];
+			// Even in a 1x1 outdoors, draw_terrain() will sometimes access the extra 3 quadrants
+			// when the party is close to going out-of-bounds. So those values can't be left as junk
 			if(x + 1 < univ.scenario.outdoors.width())
 				univ.out[48 + i][j] = univ.scenario.outdoors[x+1][y]->terrain[i][j];
+			else
+				univ.out[48 + i][j] = univ.scenario.outdoors[x][y]->terrain[47][j];
+
 			if(y + 1 < univ.scenario.outdoors.height())
 				univ.out[i][48 + j] = univ.scenario.outdoors[x][y+1]->terrain[i][j];
+			else
+				univ.out[i][48 + j] = univ.scenario.outdoors[x][y]->terrain[i][47];
+
 			if(x + 1 < univ.scenario.outdoors.width() && y + 1 < univ.scenario.outdoors.height())
 				univ.out[48 + i][48 + j] = univ.scenario.outdoors[x+1][y+1]->terrain[i][j];
+			else
+				univ.out[48 + i][48 + j] = univ.scenario.outdoors[x][y]->terrain[47][47];
 		}
 	
 	add_outdoor_maps();

--- a/src/game/boe.graphics.cpp
+++ b/src/game/boe.graphics.cpp
@@ -709,6 +709,14 @@ void draw_terrain(short	mode) {
 	
 	mainPtr.setActive();
 	
+	int max_dim_x, max_dim_y;
+	if(is_out()){
+		max_dim_x = min(96, 48 * univ.scenario.outdoors.width());
+		max_dim_y = min(96, 48 * univ.scenario.outdoors.height());
+	}else {
+		max_dim_x = max_dim_y = univ.town->max_dim;
+	}
+
 	for(short i = 0; i < 13; i++)
 		for(short j = 0; j < 13; j++) {
 			light_area[i][j] = 0;
@@ -729,6 +737,8 @@ void draw_terrain(short	mode) {
 			where_draw =  (is_out()) ? univ.party.out_loc : center;
 			where_draw.x += i - 6;
 			where_draw.y += j - 6;
+			if (where_draw.x < 0 || where_draw.y < 0 || where_draw.x >= max_dim_x || where_draw.y >= max_dim_y)
+				continue;
 			if(!(is_out()))
 				light_area[i][j] = (is_town()) ? pt_in_light(view_loc,where_draw) : combat_pt_in_light(where_draw);
 			if(!is_out() && !univ.town.is_on_map(where_draw.x, where_draw.y))
@@ -743,7 +753,8 @@ void draw_terrain(short	mode) {
 			where_draw.x += q - 4;
 			where_draw.y += r - 4;
 			off_terrain = false;
-			
+			if (where_draw.x < 0 || where_draw.y < 0 || where_draw.x >= max_dim_x || where_draw.y >= max_dim_y)
+				continue;
 			draw_frills = true;
 			if(!is_out() && !univ.town.is_on_map(where_draw.x, where_draw.y)) {
 				draw_frills = false;


### PR DESCRIPTION
This protects against the out-of-bounds access that I think was causing #240 -- I've verified that Mac and Windows now share this behavior: at the outdoor boundaries, the last terrain is repeated visually in all four directions, and if you try to move past the boundary the buffer tells you you've hit the world's edge. In towns of any size, the last terrain repeats visually in all four directions, and you can walk along the widest possible town boundary line without causing a crash.

There is one problem remaining here: The distinction between a 1x2 outdoor size and a 2x1 outdoor size is significant in one place where I simply made a guess at determining which axis was which. I need to test whether I guessed right.