### PR TITLE
fix xmllint check in SConscript

### DIFF
--- a/rsrc/SConscript
+++ b/rsrc/SConscript
@@ -55,6 +55,8 @@ else:
 
 if have_xmllint:
 	xmllint_command = ('xmllint', '--nonet', '--noout', '--schema', '../schemas/dialog.xsd')
+else:
+	print('xmllint not found! skipping xmllint step')
 
 if have_xmllint: # This is separate so that alternate xml validators could be used
 	def validate_dialog(target, source, env):

--- a/rsrc/SConscript
+++ b/rsrc/SConscript
@@ -47,11 +47,13 @@ env.Install(path.join(install_dir, "Blades of Exile Base"), Glob("#build/rsrc/ba
 
 have_xmllint = False
 
-nulldev = open(os.devnull, 'w')
+if str(platform) == "win32":
+	have_xmllint = (subprocess.call(['where', '/Q', 'xmllint']) == 0)
+else:
+	check_xmllint = subprocess.run(['which', 'xmllint'], capture_output=True)
+	have_xmllint = (check_xmllint.returncode == 0 and len(check_xmllint.stdout) != 0)
 
-if ((str(platform) != "win32" and subprocess.call(['which', 'xmllint'], stdout=nulldev, stderr=nulldev) == 0) or
-		(str(platform) == "win32" and subprocess.call(['where', '/Q', 'xmllint'])) == 0):
-	have_xmllint = True
+if have_xmllint:
 	xmllint_command = ('xmllint', '--nonet', '--noout', '--schema', '../schemas/dialog.xsd')
 
 if have_xmllint: # This is separate so that alternate xml validators could be used


### PR DESCRIPTION
On my linux installation `which xmllint` returns 0 but the output is empty (because I don't have xmllint). This PR fixes the logic so scons won't keep trying to lint the xml when I do my linux builds