### PR TITLE
record and replay mods on startup buttons. fix #394

### DIFF
--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -669,11 +669,7 @@ void cDialog::handle_one_event(const sf::Event& currentEvent) {
 			}
 			break;
 		case sf::Event::MouseButtonPressed:
-			key.mod = mod_none;
-			if(kb.isCtrlPressed()) key.mod += mod_ctrl;
-			if(kb.isMetaPressed()) key.mod += mod_ctrl;
-			if(kb.isAltPressed()) key.mod += mod_alt;
-			if(kb.isShiftPressed()) key.mod += mod_shift;
+			key.mod = current_key_mod();
 			where = {(int)(currentEvent.mouseButton.x / ui_scale()), (int)(currentEvent.mouseButton.y / ui_scale())};
 			process_click(where, key.mod);
 			break;

--- a/src/dialogxml/keycodes.cpp
+++ b/src/dialogxml/keycodes.cpp
@@ -16,6 +16,7 @@
 //#include "mathutil.hpp"
 //#include "prefs.hpp"
 //#include "cursors.hpp"
+#include "keymods.hpp"
 
 eKeyMod operator + (eKeyMod lhs, eKeyMod rhs){
 	if(lhs == rhs) return lhs;
@@ -115,4 +116,13 @@ unsigned char removeShift(unsigned char c){
 		'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '[', '\\',']', '`',
 	};
 	return afterUnShift[c - ' '];
+}
+
+eKeyMod current_key_mod() {
+	eKeyMod mod = mod_none;
+	if(kb.isCtrlPressed()) mod += mod_ctrl;
+	if(kb.isMetaPressed()) mod += mod_ctrl;
+	if(kb.isAltPressed()) mod += mod_alt;
+	if(kb.isShiftPressed()) mod += mod_shift;
+	return mod;
 }

--- a/src/dialogxml/keycodes.hpp
+++ b/src/dialogxml/keycodes.hpp
@@ -91,4 +91,6 @@ unsigned char applyShift(unsigned char c);
 /// Removes the shift key from the given character (assumes US keyboard layout)
 unsigned char removeShift(unsigned char c);
 
+eKeyMod current_key_mod();
+
 #endif

--- a/src/game/boe.actions.hpp
+++ b/src/game/boe.actions.hpp
@@ -4,6 +4,7 @@
 
 #include <SFML/Window/Event.hpp>
 #include "location.hpp"
+#include "dialogxml/keycodes.hpp"
 
 void init_screen_locs();
 bool prime_time();
@@ -36,7 +37,7 @@ short count_walls(location loc);
 bool is_sign(ter_num_t ter);
 bool check_for_interrupt();
 
-void handle_startup_button_click(eStartButton btn);
+void handle_startup_button_click(eStartButton btn, eKeyMod mods);
 void handle_switch_pc(short which_pc, bool& need_redraw, bool& need_reprint);
 void handle_switch_pc_items(short which_pc, bool& need_redraw);
 void handle_equip_item(short item_hit, bool& need_redraw);

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -264,8 +264,10 @@ void replay_next_action() {
 	std::string t = next_action.Value();
 	
 	if(overall_mode == MODE_STARTUP && t == "startup_button_click"){
-		eStartButton btn = static_cast<eStartButton>(std::stoi(next_action.GetText()));
-		handle_startup_button_click(btn);
+		auto info = info_from_action(next_action);
+		eStartButton btn = static_cast<eStartButton>(std::stoi(info["btn"]));
+		eKeyMod mods = static_cast<eKeyMod>(std::stoi(info["mods"]));
+		handle_startup_button_click(btn, mods);
 	}else if(t == "load_party"){
 		decode_file(next_action.GetText(), tempDir / "temp.exg");
 		load_party(tempDir / "temp.exg", univ);

--- a/src/game/boe.main.hpp
+++ b/src/game/boe.main.hpp
@@ -9,6 +9,7 @@ int main(int argc, char* argv[]);
 void update_everything();
 void redraw_everything();
 void Mouse_Pressed(const sf::Event&);
+eKeyMod current_key_mod();
 void close_program();
 void change_cursor(location where_curs);
 void set_up_apple_events();

--- a/src/game/boe.startup.cpp
+++ b/src/game/boe.startup.cpp
@@ -40,11 +40,19 @@ extern sf::View mainView;
 
 enum_map(eStartButton, rectangle) startup_button;
 
-void handle_startup_button_click(eStartButton btn) {
+void handle_startup_button_click(eStartButton btn, eKeyMod mods) {
 	if(recording){
+		std::map<std::string, std::string> info;
+
 		std::ostringstream sstr;
 		sstr << btn;
-		record_action("startup_button_click", sstr.str());
+		info["btn"] = sstr.str();
+
+		sstr.str("");
+		sstr << mods;
+		info["mods"] = sstr.str();
+
+		record_action("startup_button_click", info);
 	}
 
 	std::string scen_name;
@@ -78,7 +86,7 @@ void handle_startup_button_click(eStartButton btn) {
 			
 		case STARTBTN_JOIN:
 			if(!party_in_memory) {
-				if(kb.isAltPressed()) {
+				if(mod_contains(mods, mod_alt)) {
 					force_party = true;
 					start_new_game(true);
 				} else {
@@ -114,7 +122,7 @@ bool handle_startup_press(location the_point) {
 	for(auto btn : startup_button.keys()) {
 		if(btn == eStartButton::STARTBTN_SCROLL) continue;
 		if(the_point.in(startup_button[btn])) {
-			handle_startup_button_click(btn);
+			handle_startup_button_click(btn, current_key_mod());
 		}
 	}
 	return false;


### PR DESCRIPTION
Since there is the one case where a modifier key is relevant in the startup menu, I figure we should handle the modifier keys in the same way dialogs do, because this makes it easier to record and replay that edge case.