### PR TITLE
Fix CPU usage

### DIFF
--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -544,7 +544,7 @@ void cDialog::handle_events() {
 			eKeyMod mods = static_cast<eKeyMod>(std::stoi(info["mods"]));
 			controls[info["id"]]->triggerClickHandler(*this, info["id"], mods);
 		}else{
-			while(win.pollEvent(currentEvent)) handle_one_event(currentEvent);
+			while(win.pollEvent(currentEvent)) handle_one_event(currentEvent, fps_limiter);
 		}
 
 		// Ideally, this should be the only draw call that is done in a cycle.
@@ -556,7 +556,7 @@ void cDialog::handle_events() {
 }
 
 // This method handles one event received by the dialog.
-void cDialog::handle_one_event(const sf::Event& currentEvent) {
+void cDialog::handle_one_event(const sf::Event& currentEvent, cFramerateLimiter& fps_limiter) {
 	using Key = sf::Keyboard::Key;
 
 	cKey key;
@@ -671,7 +671,7 @@ void cDialog::handle_one_event(const sf::Event& currentEvent) {
 		case sf::Event::MouseButtonPressed:
 			key.mod = current_key_mod();
 			where = {(int)(currentEvent.mouseButton.x / ui_scale()), (int)(currentEvent.mouseButton.y / ui_scale())};
-			process_click(where, key.mod);
+			process_click(where, key.mod, fps_limiter);
 			break;
 		default: // To silence warning of unhandled enum values
 			break;
@@ -874,13 +874,13 @@ void cDialog::process_keystroke(cKey keyHit){
 	}
 }
 
-void cDialog::process_click(location where, eKeyMod mods){
+void cDialog::process_click(location where, eKeyMod mods, cFramerateLimiter& fps_limiter){
 	// TODO: Return list of all controls whose bounding rect contains the clicked point.
 	// Then the return value of the click handler can mean "Don't pass this event on to other things below me".
 	ctrlIter iter = controls.begin();
 	while(iter != controls.end()){
 		if(iter->second->isVisible() && iter->second->isClickable() && where.in(iter->second->getBounds())){
-			if(iter->second->handleClick(where))
+			if(iter->second->handleClick(where, fps_limiter))
 				break;
 			else return;
 		}

--- a/src/dialogxml/dialogs/dialog.hpp
+++ b/src/dialogxml/dialogs/dialog.hpp
@@ -29,6 +29,7 @@
 #include <boost/any.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include "tools/prefs.hpp"
+#include "tools/framerate_limiter.hpp"
 
 class cControl;
 class cTextField;
@@ -250,9 +251,9 @@ private:
 	inline double ui_scale() { return get_float_pref("UIScale", 1.0); };
 	void draw();
 	void handle_events();
-	void handle_one_event(const sf::Event&);
+	void handle_one_event(const sf::Event&, cFramerateLimiter& fps_limiter);
 	void process_keystroke(cKey keyHit);
-	void process_click(location where, eKeyMod mods);
+	void process_click(location where, eKeyMod mods, cFramerateLimiter& fps_limiter);
 	bool dialogNotToast, didAccept;
 	rectangle winRect;
 	boost::any result;

--- a/src/dialogxml/widgets/container.cpp
+++ b/src/dialogxml/widgets/container.cpp
@@ -51,12 +51,12 @@ bool cContainer::parseChildControl(ticpp::Element& elem, std::map<std::string,cC
 	return true;
 }
 
-bool cContainer::handleClick(location where) {
+bool cContainer::handleClick(location where, cFramerateLimiter& fps_limiter) {
 	std::string which_clicked;
 	bool success = false;
 	forEach([&](std::string id, cControl& ctrl) {
 		if(!success && ctrl.isClickable() && ctrl.getBounds().contains(where)) {
-			if(ctrl.handleClick(where)){
+			if(ctrl.handleClick(where, fps_limiter)){
 				success = true;
 				which_clicked = id;
 			}

--- a/src/dialogxml/widgets/container.hpp
+++ b/src/dialogxml/widgets/container.hpp
@@ -48,7 +48,7 @@ public:
 	cControl& operator[](std::string id) {return getChild(id);}
 	const cControl& operator[](std::string id) const {return const_cast<cContainer&>(*this).getChild(id);}
 	bool isContainer() const override {return true;}
-	bool handleClick(location where) override;
+	bool handleClick(location where, cFramerateLimiter& fps_limiter) override;
 };
 
 #endif

--- a/src/dialogxml/widgets/control.cpp
+++ b/src/dialogxml/widgets/control.cpp
@@ -221,26 +221,28 @@ void cControl::playClickSound(){
 	else sf::sleep(time_in_ticks(14));
 }
 
-bool cControl::handleClick(location){
+bool cControl::handleClick(location, cFramerateLimiter& fps_limiter){
 	sf::Event e;
 	bool done = false, clicked = false;
 	inWindow->setActive();
 	depressed = true;
 	while(!done){
 		redraw();
-		if(!inWindow->pollEvent(e)) continue;
-		if(e.type == sf::Event::MouseButtonReleased){
-			done = true;
-			location clickPos(e.mouseButton.x, e.mouseButton.y);
-			clickPos = inWindow->mapPixelToCoords(clickPos);
-			clicked = frame.contains(clickPos);
-			depressed = false;
-		} else if(e.type == sf::Event::MouseMoved){
-			restore_cursor();
-			location toPos(e.mouseMove.x, e.mouseMove.y);
-			toPos = inWindow->mapPixelToCoords(toPos);
-			depressed = frame.contains(toPos);
+		while(inWindow->pollEvent(e)){
+			if(e.type == sf::Event::MouseButtonReleased){
+				done = true;
+				location clickPos(e.mouseButton.x, e.mouseButton.y);
+				clickPos = inWindow->mapPixelToCoords(clickPos);
+				clicked = frame.contains(clickPos);
+				depressed = false;
+			} else if(e.type == sf::Event::MouseMoved){
+				restore_cursor();
+				location toPos(e.mouseMove.x, e.mouseMove.y);
+				toPos = inWindow->mapPixelToCoords(toPos);
+				depressed = frame.contains(toPos);
+			}
 		}
+		fps_limiter.frame_finished();
 	}
 	playClickSound();
 	

--- a/src/dialogxml/widgets/control.hpp
+++ b/src/dialogxml/widgets/control.hpp
@@ -21,6 +21,7 @@
 #include <map>
 #include <boost/any.hpp>
 #include "dialogxml/dialogs/dlogevt.hpp"
+#include "tools/framerate_limiter.hpp"
 
 #include "location.hpp"
 
@@ -328,7 +329,7 @@ public:
 	/// The default implementation works for a simple clickable object such as a button that
 	/// should be hilited in some way while pressed and is cancelled by releasing the mouse
 	/// button outside the control's bounds.
-	virtual bool handleClick(location where);
+	virtual bool handleClick(location where, cFramerateLimiter& fps_limiter);
 	/// Specifies that another control acts as a label for this one.
 	/// The practical effect of this is that hiding or showing this control automatically hides or shows the label as well.
 	/// @param label A pointer to the control that acts as a label.

--- a/src/dialogxml/widgets/field.cpp
+++ b/src/dialogxml/widgets/field.cpp
@@ -117,7 +117,7 @@ void cTextField::set_ip(location clickLoc, int cTextField::* insertionPoint) {
 	}
 }
 
-bool cTextField::handleClick(location clickLoc) {
+bool cTextField::handleClick(location clickLoc, cFramerateLimiter& fps_limiter) {
 	if(!haveFocus && parent && !parent->setFocus(this)) return true;
 	haveFocus = true;
 	redraw(); // This ensures the snippets array is populated.
@@ -141,26 +141,28 @@ bool cTextField::handleClick(location clickLoc) {
 	int initial_ip = insertionPoint, initial_sp = selectionPoint;
 	while(!done) {
 		redraw();
-		if(!inWindow->pollEvent(e)) continue;
-		if(e.type == sf::Event::MouseButtonReleased){
-			done = true;
-		} else if(e.type == sf::Event::MouseMoved){
-			restore_cursor();
-			location newLoc(e.mouseMove.x, e.mouseMove.y);
-			newLoc = inWindow->mapPixelToCoords(newLoc);
-			set_ip(newLoc, &cTextField::selectionPoint);
-			if(is_double) {
-				if(selectionPoint > initial_ip) {
-					insertionPoint = initial_sp;
-					while(selectionPoint < contents.length() && contents[selectionPoint] != ' ')
-						selectionPoint++;
-				} else {
-					insertionPoint = initial_ip;
-					while(selectionPoint > 0 && contents[selectionPoint - 1] != ' ')
-						selectionPoint--;
+		while(inWindow->pollEvent(e)){
+			if(e.type == sf::Event::MouseButtonReleased){
+				done = true;
+			} else if(e.type == sf::Event::MouseMoved){
+				restore_cursor();
+				location newLoc(e.mouseMove.x, e.mouseMove.y);
+				newLoc = inWindow->mapPixelToCoords(newLoc);
+				set_ip(newLoc, &cTextField::selectionPoint);
+				if(is_double) {
+					if(selectionPoint > initial_ip) {
+						insertionPoint = initial_sp;
+						while(selectionPoint < contents.length() && contents[selectionPoint] != ' ')
+							selectionPoint++;
+					} else {
+						insertionPoint = initial_ip;
+						while(selectionPoint > 0 && contents[selectionPoint - 1] != ' ')
+							selectionPoint--;
+					}
 				}
 			}
 		}
+		fps_limiter.frame_finished();
 	}
 	redraw();
 	return true;

--- a/src/dialogxml/widgets/field.hpp
+++ b/src/dialogxml/widgets/field.hpp
@@ -42,7 +42,7 @@ public:
 	std::set<eDlogEvt> getSupportedHandlers() const override {
 		return {EVT_FOCUS, EVT_DEFOCUS};
 	}
-	bool handleClick(location where) override;
+	bool handleClick(location where, cFramerateLimiter& fps_limiter) override;
 	void setText(std::string to) override;
 	storage_t store() const override;
 	void restore(storage_t to) override;

--- a/src/dialogxml/widgets/ledgroup.cpp
+++ b/src/dialogxml/widgets/ledgroup.cpp
@@ -51,12 +51,12 @@ void cLedGroup::addChoice(cLed* ctrl, std::string key) {
 		setSelected(key);
 }
 
-bool cLedGroup::handleClick(location where) {
+bool cLedGroup::handleClick(location where, cFramerateLimiter& fps_limiter) {
 	std::string which_clicked;
 	ledIter iter = choices.begin();
 	while(iter != choices.end()){
 		if(iter->second->isVisible() && where.in(iter->second->getBounds())){
-			if(iter->second->handleClick(where)) {
+			if(iter->second->handleClick(where, fps_limiter)) {
 				which_clicked = iter->first;
 				break;
 			}

--- a/src/dialogxml/widgets/ledgroup.hpp
+++ b/src/dialogxml/widgets/ledgroup.hpp
@@ -83,7 +83,7 @@ public:
 	bool isClickable() const override;
 	bool isFocusable() const override;
 	bool isScrollable() const override;
-	bool handleClick(location where) override;
+	bool handleClick(location where, cFramerateLimiter& fps_limiter) override;
 	virtual ~cLedGroup();
 	/// Get one of the LEDs in this group.
 	/// @param id The unique key of the choice.

--- a/src/dialogxml/widgets/message.cpp
+++ b/src/dialogxml/widgets/message.cpp
@@ -115,6 +115,7 @@ void cTextMsg::calculate_layout() {
 		text_mode = eTextMode::WRAP;
 		break_info = calculate_line_wrapping(to_rect, msg, style);
 	}
+	calculated = true;
 }
 
 void cTextMsg::recalcRect() {
@@ -183,7 +184,6 @@ cTextMsg::cTextMsg(cDialog& parent) :
 	color(parent.getDefTextClr()),
 	fromList("none") {
 	setFormat(TXT_FRAME, FRM_NONE);
-	calculate_layout();
 }
 
 cTextMsg::cTextMsg(sf::RenderWindow& parent) :
@@ -193,7 +193,6 @@ cTextMsg::cTextMsg(sf::RenderWindow& parent) :
 	color(cDialog::defaultBackground == cDialog::BG_DARK ? sf::Color::White : sf::Color::Black),
 	fromList("none") {
 	setFormat(TXT_FRAME, FRM_NONE);
-	calculate_layout();
 }
 
 bool cTextMsg::isClickable() const {
@@ -222,6 +221,7 @@ void cTextMsg::draw(){
 			draw_color.b = 256 - draw_color.b;
 		}
 		style.colour = draw_color;
+		if (!calculated) calculate_layout();
 		win_draw_string(*inWindow,to_rect,msg,text_mode,style,break_info);
 	}
 }

--- a/src/dialogxml/widgets/message.hpp
+++ b/src/dialogxml/widgets/message.hpp
@@ -55,5 +55,11 @@ private:
 	std::vector<boost::optional<std::string>> keyRefs;
 	std::string fromList;
 	bool underlined = false, fixedWidth = false, fixedHeight = false;
+	TextStyle style;
+	rectangle to_rect;
+	break_info_t break_info;
+	eTextMode text_mode;
+	std::string msg;
+	void calculate_layout();
 };
 #endif

--- a/src/dialogxml/widgets/message.hpp
+++ b/src/dialogxml/widgets/message.hpp
@@ -61,5 +61,6 @@ private:
 	eTextMode text_mode;
 	std::string msg;
 	void calculate_layout();
+	bool calculated = false;
 };
 #endif

--- a/src/dialogxml/widgets/scrollbar.hpp
+++ b/src/dialogxml/widgets/scrollbar.hpp
@@ -73,7 +73,7 @@ public:
 	/// Create a new scrollbar.
 	/// @param parent The parent dialog.
 	explicit cScrollbar(cDialog& parent);
-	bool handleClick(location where) override;
+	bool handleClick(location where, cFramerateLimiter& fps_limiter) override;
 	storage_t store() const override;
 	void restore(storage_t to) override;
 	bool isClickable() const override;

--- a/src/dialogxml/widgets/scrollpane.cpp
+++ b/src/dialogxml/widgets/scrollpane.cpp
@@ -20,11 +20,11 @@ cScrollPane::cScrollPane(cDialog& parent) : cContainer(CTRL_PANE, parent), scrol
 	recalcRect();
 }
 
-bool cScrollPane::handleClick(location where) {
+bool cScrollPane::handleClick(location where, cFramerateLimiter& fps_limiter) {
 	if(scroll.getBounds().contains(where))
-		return scroll.handleClick(where);
+		return scroll.handleClick(where, fps_limiter);
 	where.y += scroll.getPosition();
-	return cContainer::handleClick(where);
+	return cContainer::handleClick(where, fps_limiter);
 }
 
 void cScrollPane::recalcRect() {

--- a/src/dialogxml/widgets/scrollpane.hpp
+++ b/src/dialogxml/widgets/scrollpane.hpp
@@ -28,7 +28,7 @@ public:
 	bool parseAttribute(ticpp::Attribute& attr, std::string tagName, std::string fname) override;
 	bool parseContent(ticpp::Node& content, int n, std::string tagName, std::string fname, std::string& text) override;
 	void validatePostParse(ticpp::Element& who, std::string fname, const std::set<std::string>& attrs, const std::multiset<std::string>& nodes) override;
-	bool handleClick(location where) override;
+	bool handleClick(location where, cFramerateLimiter& fps_limiter) override;
 	bool hasChild(std::string id) const override;
 	cControl& getChild(std::string id) override;
 	storage_t store() const override;

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -1102,7 +1102,7 @@ static void handle_party_death() {
 	}
 }
 
-bool handle_action(const sf::Event& event) {
+bool handle_action(const sf::Event& event, cFramerateLimiter& fps_limiter) {
 	long item_hit;
 	bool are_done = false;
 	bool need_redraw = false, did_something = false, need_reprint = false;
@@ -1129,12 +1129,12 @@ bool handle_action(const sf::Event& event) {
 	
 	// Now split off the extra stuff, like talking and shopping.
 	if(overall_mode == MODE_TALKING) {
-		handle_talk_event(the_point);
+		handle_talk_event(the_point, fps_limiter);
 		if(overall_mode != MODE_TALKING)
 			return false;
 	}
 	if(overall_mode == MODE_SHOPPING) {
-		handle_shop_event(the_point);
+		handle_shop_event(the_point, fps_limiter);
 		if(overall_mode != MODE_SHOPPING)
 			return false;
 	}
@@ -1630,7 +1630,7 @@ void initiate_outdoor_combat(short i) {
 	draw_terrain();
 }
 
-bool handle_keystroke(const sf::Event& event){
+bool handle_keystroke(const sf::Event& event, cFramerateLimiter& fps_limiter){
 	bool are_done = false;
 	location pass_point; // TODO: This isn't needed
 	std::ostringstream sout;
@@ -1708,7 +1708,7 @@ bool handle_keystroke(const sf::Event& event){
 				pass_point = mainPtr.mapCoordsToPixel(pass_point, mainView);
 				pass_event.mouseButton.x = pass_point.x;
 				pass_event.mouseButton.y = pass_point.y;
-				are_done = handle_action(pass_event);
+				are_done = handle_action(pass_event, fps_limiter);
 			}
 	}
 	else if(overall_mode == MODE_SHOPPING) { // shopping keystrokes
@@ -1725,7 +1725,7 @@ bool handle_keystroke(const sf::Event& event){
 				pass_point = mainPtr.mapCoordsToPixel(pass_point, mainView);
 				pass_event.mouseButton.x = pass_point.x;
 				pass_event.mouseButton.y = pass_point.y;
-				are_done = handle_action(pass_event);
+				are_done = handle_action(pass_event, fps_limiter);
 			}
 	} else {
 		for(short i = 0; i < 10; i++)
@@ -1737,7 +1737,7 @@ bool handle_keystroke(const sf::Event& event){
 					pass_point = mainPtr.mapCoordsToPixel(terrain_click[i], mainView);
 					pass_event.mouseButton.x = pass_point.x;
 					pass_event.mouseButton.y = pass_point.y;
-					are_done = handle_action(pass_event);
+					are_done = handle_action(pass_event, fps_limiter);
 					return are_done;
 				}
 			}

--- a/src/game/boe.actions.hpp
+++ b/src/game/boe.actions.hpp
@@ -5,17 +5,18 @@
 #include <SFML/Window/Event.hpp>
 #include "location.hpp"
 #include "dialogxml/keycodes.hpp"
+#include "tools/framerate_limiter.hpp"
 
 void init_screen_locs();
 bool prime_time();
-bool handle_action(const sf::Event& event);
+bool handle_action(const sf::Event& event, cFramerateLimiter& fps_limiter);
 void advance_time(bool did_something, bool need_redraw, bool need_reprint);
 void handle_move(location destination, bool& did_something, bool& need_redraw, bool& need_reprint);
 void handle_monster_actions(bool& need_redraw, bool& need_reprint);
 bool someone_awake();
 void handle_menu_spell(short spell_picked,short spell_type) ;
 void initiate_outdoor_combat(short i);
-bool handle_keystroke(const sf::Event& event);
+bool handle_keystroke(const sf::Event& event, cFramerateLimiter& fps_limiter);
 bool handle_scroll(const sf::Event& event);
 void do_load();
 void post_load();

--- a/src/game/boe.dlgutil.cpp
+++ b/src/game/boe.dlgutil.cpp
@@ -206,16 +206,16 @@ void end_shop_mode() {
 	}
 }
 
-void handle_shop_event(location p) {
+void handle_shop_event(location p, cFramerateLimiter& fps_limiter) {
 	if(p.in(talk_help_rect)) {
-		if(!help_btn->handleClick(p))
+		if(!help_btn->handleClick(p, fps_limiter))
 			return;
 		give_help(226,27);
 		return;
 	}
 	
 	if(p.in(shop_done_rect)) {
-		if(done_btn->handleClick(p))
+		if(done_btn->handleClick(p, fps_limiter))
 			end_shop_mode();
 		return;
 	}
@@ -706,7 +706,7 @@ static void show_job_bank(int which_bank, std::string title) {
 	job_dlg.run();
 }
 
-void handle_talk_event(location p) {
+void handle_talk_event(location p, cFramerateLimiter& fps_limiter) {
 	short get_pc,s1 = -1,s2 = -1;
 	char asked[4];
 	
@@ -714,7 +714,7 @@ void handle_talk_event(location p) {
 	eTalkNode ttype;
 	
 	if(p.in(talk_help_rect)) {
-		if(!help_btn->handleClick(p))
+		if(!help_btn->handleClick(p, fps_limiter))
 			return;
 		give_help(205,6);
 		return;

--- a/src/game/boe.dlgutil.hpp
+++ b/src/game/boe.dlgutil.hpp
@@ -7,13 +7,13 @@
 
 void start_shop_mode(short which,short cost_adj,std::string store_name);
 void end_shop_mode();
-void handle_shop_event(location p);
+void handle_shop_event(location p, cFramerateLimiter& fps_limiter);
 void handle_sale(cShopItem item, int i);
 void handle_info_request(cShopItem item);
 void set_up_shop_array();
 void start_talk_mode(short m_num,short personality,mon_num_t monst_type,short store_face_pic);
 void end_talk_mode();
-void handle_talk_event(location p);
+void handle_talk_event(location p, cFramerateLimiter& fps_limiter);
 void handle_talk_spec(short ttype,char* place_string1,char* place_string2);
 void store_responses();
 void do_sign(short town_num, short which_sign, short sign_type);

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -2,6 +2,7 @@
 #include "boe.global.hpp"
 #include "tools/replay.hpp"
 #include "universe/universe.hpp"
+#include "utility.hpp"
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/lexical_cast.hpp>

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -397,7 +397,7 @@ void handle_events() {
 				menuChoice=eMenuChoice::MENU_CHOICE_NONE;
 				switch(aMenuChoice) {
 					case eMenuChoice::MENU_CHOICE_GENERIC:
-						handle_menu_choice(eMenu(menuChoiceId), fps_limiter);
+						handle_menu_choice(eMenu(menuChoiceId));
 						break;
 					case eMenuChoice::MENU_CHOICE_SPELL:
 						handle_menu_spell(eSpell(menuChoiceId));
@@ -607,7 +607,7 @@ void close_program() {
 }
 
 extern fs::path progDir;
-void handle_menu_choice(eMenu item_hit, cFramerateLimiter& fps_limiter) {
+void handle_menu_choice(eMenu item_hit) {
 	std::string dialogToShow;
 	sf::Event dummyEvent = {sf::Event::KeyPressed};
 	short choice;
@@ -772,11 +772,11 @@ void handle_menu_choice(eMenu item_hit, cFramerateLimiter& fps_limiter) {
 		case eMenu::ACTIONS_ALCHEMY:
 			dummyEvent.key.code = sf::Keyboard::A;
 			dummyEvent.key.shift = true;
-			handle_keystroke(dummyEvent, fps_limiter);
+			queue_fake_event(dummyEvent);
 			break;
 		case eMenu::ACTIONS_WAIT:
 			dummyEvent.key.code = sf::Keyboard::W;
-			handle_keystroke(dummyEvent, fps_limiter);
+			queue_fake_event(dummyEvent);
 			break;
 		case eMenu::ACTIONS_AUTOMAP:
 			if(!prime_time()) {

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -412,6 +412,8 @@ void handle_events() {
 				menuChoiceId=-1;
 			}
 #endif
+			update_event_sleeping();
+
 			while(!fake_event_queue.empty()){
 				const sf::Event& next_event = fake_event_queue.front();
 				fake_event_queue.pop_front();

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -42,7 +42,6 @@
 #include "tools/prefs.hpp"
 #include "dialogxml/widgets/button.hpp"
 #include "tools/enum_map.hpp"
-#include "tools/framerate_limiter.hpp"
 #include "tools/event_listener.hpp"
 #include "tools/drawable_manager.hpp"
 bool All_Done = false;
@@ -358,12 +357,13 @@ void init_boe(int argc, char* argv[]) {
 	init_screen_locs();	
 	init_startup();
 	flushingInput = true;
+	cFramerateLimiter fps_limiter;
 	// Hidden preference to hide the startup logo - should be kept hidden
 	if(get_bool_pref("ShowStartupLogo", true))
-		show_logo();
+		show_logo(fps_limiter);
 	// The preference to hide the startup splash is exposed however.
 	if(get_bool_pref("ShowStartupSplash", true))
-		plop_fancy_startup();
+		plop_fancy_startup(fps_limiter);
 	
 	cUniverse::print_result = iLiving::print_result = add_string_to_buf;
 	cPlayer::give_help = give_help;

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -397,7 +397,7 @@ void handle_events() {
 				menuChoice=eMenuChoice::MENU_CHOICE_NONE;
 				switch(aMenuChoice) {
 					case eMenuChoice::MENU_CHOICE_GENERIC:
-						handle_menu_choice(eMenu(menuChoiceId));
+						handle_menu_choice(eMenu(menuChoiceId), fps_limiter);
 						break;
 					case eMenuChoice::MENU_CHOICE_SPELL:
 						handle_menu_spell(eSpell(menuChoiceId));
@@ -414,9 +414,9 @@ void handle_events() {
 			while(!fake_event_queue.empty()){
 				const sf::Event& next_event = fake_event_queue.front();
 				fake_event_queue.pop_front();
-				handle_one_event(next_event);
+				handle_one_event(next_event, fps_limiter);
 			}
-			while(mainPtr.pollEvent(currentEvent)) handle_one_event(currentEvent);
+			while(mainPtr.pollEvent(currentEvent)) handle_one_event(currentEvent, fps_limiter);
 
 			// It would be nice to have minimap inside the main game window (we have lots of screen space in fullscreen mode).
 			// Alternatively, minimap could live on its own thread.
@@ -474,7 +474,7 @@ void handle_quit_event() {
 	All_Done = true;
 }
 
-void handle_one_event(const sf::Event& event) {
+void handle_one_event(const sf::Event& event, cFramerateLimiter& fps_limiter) {
 
 	// What does this do and should it be here?
 	through_sending();
@@ -493,12 +493,12 @@ void handle_one_event(const sf::Event& event) {
 	switch(event.type) {
 		case sf::Event::KeyPressed:
 			if(flushingInput) return;
-			if(!(event.key.*systemKey)) handle_keystroke(event);
+			if(!(event.key.*systemKey)) handle_keystroke(event, fps_limiter);
 			break;
 			
 		case sf::Event::MouseButtonPressed:
 			if(flushingInput) return;
-			Mouse_Pressed(event);
+			Mouse_Pressed(event, fps_limiter);
 			break;
 			
 		case sf::Event::MouseLeft:
@@ -581,7 +581,7 @@ void redraw_everything() {
 	if(map_visible) draw_map(false);
 }
 
-void Mouse_Pressed(const sf::Event& event) {
+void Mouse_Pressed(const sf::Event& event, cFramerateLimiter& fps_limiter) {
 
 	// What is this stuff? Why is it here?
 	if(had_text_freeze > 0) {
@@ -592,7 +592,7 @@ void Mouse_Pressed(const sf::Event& event) {
 	if(overall_mode == MODE_STARTUP) {
 		All_Done = handle_startup_press({event.mouseButton.x, event.mouseButton.y});
 	} else {
-		All_Done = handle_action(event);
+		All_Done = handle_action(event, fps_limiter);
 	}
 	
 	// Why does every mouse click activate a menu?
@@ -607,7 +607,7 @@ void close_program() {
 }
 
 extern fs::path progDir;
-void handle_menu_choice(eMenu item_hit) {
+void handle_menu_choice(eMenu item_hit, cFramerateLimiter& fps_limiter) {
 	std::string dialogToShow;
 	sf::Event dummyEvent = {sf::Event::KeyPressed};
 	short choice;
@@ -772,11 +772,11 @@ void handle_menu_choice(eMenu item_hit) {
 		case eMenu::ACTIONS_ALCHEMY:
 			dummyEvent.key.code = sf::Keyboard::A;
 			dummyEvent.key.shift = true;
-			handle_keystroke(dummyEvent);
+			handle_keystroke(dummyEvent, fps_limiter);
 			break;
 		case eMenu::ACTIONS_WAIT:
 			dummyEvent.key.code = sf::Keyboard::W;
-			handle_keystroke(dummyEvent);
+			handle_keystroke(dummyEvent, fps_limiter);
 			break;
 		case eMenu::ACTIONS_AUTOMAP:
 			if(!prime_time()) {

--- a/src/game/boe.main.hpp
+++ b/src/game/boe.main.hpp
@@ -1,5 +1,6 @@
 
 #include <SFML/Graphics.hpp>
+#include "tools/framerate_limiter.hpp"
 
 #ifdef __APPLE__
 extern eMenuChoice menuChoice;
@@ -18,8 +19,8 @@ void incidental_noises(bool on_surface);
 void pause(short length);
 bool handle_startup_press(location the_point);
 void handle_splash_events();
-void show_logo();
-void plop_fancy_startup();
+void show_logo(cFramerateLimiter& framerate_limiter);
+void plop_fancy_startup(cFramerateLimiter& framerate_limiter);
 void update_terrain_animation();
 void update_startup_animation();
 void handle_events();

--- a/src/game/boe.main.hpp
+++ b/src/game/boe.main.hpp
@@ -1,6 +1,5 @@
 
 #include <SFML/Graphics.hpp>
-#include "tools/framerate_limiter.hpp"
 
 #ifdef __APPLE__
 extern eMenuChoice menuChoice;
@@ -9,8 +8,8 @@ extern short menuChoiceId;
 int main(int argc, char* argv[]);
 void update_everything();
 void redraw_everything();
-void Mouse_Pressed(const sf::Event&);
 eKeyMod current_key_mod();
+void Mouse_Pressed(const sf::Event&, cFramerateLimiter& fps_limiter);
 void close_program();
 void change_cursor(location where_curs);
 void set_up_apple_events();
@@ -19,12 +18,12 @@ void incidental_noises(bool on_surface);
 void pause(short length);
 bool handle_startup_press(location the_point);
 void handle_splash_events();
-void show_logo(cFramerateLimiter& framerate_limiter);
-void plop_fancy_startup(cFramerateLimiter& framerate_limiter);
+void show_logo(cFramerateLimiter& fps_limiter);
+void plop_fancy_startup(cFramerateLimiter& fps_limiter);
 void update_terrain_animation();
 void update_startup_animation();
 void handle_events();
-void handle_one_event(const sf::Event&);
+void handle_one_event(const sf::Event&, cFramerateLimiter& fps_limiter);
 void queue_fake_event(const sf::Event&);
 void handle_one_minimap_event(const sf::Event &);
 

--- a/src/game/boe.menus.hpp
+++ b/src/game/boe.menus.hpp
@@ -38,7 +38,7 @@ enum class eMenu {
 
 enum class eSpell;
 
-void handle_menu_choice(eMenu item_hit, cFramerateLimiter& fps_limiter);
+void handle_menu_choice(eMenu item_hit);
 void handle_menu_spell(eSpell spell_picked);
 void handle_monster_info_menu(int item_hit);
 

--- a/src/game/boe.menus.hpp
+++ b/src/game/boe.menus.hpp
@@ -6,6 +6,8 @@
 //
 //
 
+#include "tools/framerate_limiter.hpp"
+
 #ifndef BoE_boe_menus_h
 #define BoE_boe_menus_h
 
@@ -36,7 +38,7 @@ enum class eMenu {
 
 enum class eSpell;
 
-void handle_menu_choice(eMenu item_hit);
+void handle_menu_choice(eMenu item_hit, cFramerateLimiter& fps_limiter);
 void handle_menu_spell(eSpell spell_picked);
 void handle_monster_info_menu(int item_hit);
 

--- a/src/game/boe.startup.cpp
+++ b/src/game/boe.startup.cpp
@@ -128,12 +128,13 @@ bool handle_startup_press(location the_point) {
 	return false;
 }
 
-void handle_splash_events() {
+void handle_splash_events(cFramerateLimiter& framerate_limiter) {
 	sf::Event event;
 	while(mainPtr.pollEvent(event)) {
 		if(event.type == sf::Event::GainedFocus || event.type == sf::Event::MouseMoved)
 			set_cursor(sword_curs);
 	}
+	framerate_limiter.frame_finished();
 }
 
 static rectangle view_rect() {
@@ -141,7 +142,7 @@ static rectangle view_rect() {
 	return rectangle(0, 0, size.y, size.x);
 }
 
-void show_logo() {
+void show_logo(cFramerateLimiter& framerate_limiter) {
 	rectangle whole_window = view_rect();
 	
 	if(get_int_pref("DisplayMode") != 5)
@@ -156,17 +157,17 @@ void show_logo() {
 	play_sound(-95);
 	while(sound_going(95)) {
 		draw_splash(pict_to_draw, mainPtr, logo_from);
-		handle_splash_events();
+		handle_splash_events(framerate_limiter);
 	}
 	if(!get_int_pref("ShowStartupSplash", true)) {
 		sf::Time delay = time_in_ticks(60);
 		sf::Clock timer;
 		while(timer.getElapsedTime() < delay)
-			handle_splash_events();
+			handle_splash_events(framerate_limiter);
 	}
 }
 
-void plop_fancy_startup() {
+void plop_fancy_startup(cFramerateLimiter& framerate_limiter) {
 	rectangle whole_window = view_rect();
 
 	float ui_scale = get_float_pref("UIScale", 1.0);
@@ -182,7 +183,7 @@ void plop_fancy_startup() {
 	
 	while(timer.getElapsedTime() < delay) {
 		draw_splash(pict_to_draw, mainPtr, intro_from);
-		handle_splash_events();
+		handle_splash_events(framerate_limiter);
 	}
 }
 

--- a/src/game/boe.startup.cpp
+++ b/src/game/boe.startup.cpp
@@ -128,13 +128,13 @@ bool handle_startup_press(location the_point) {
 	return false;
 }
 
-void handle_splash_events(cFramerateLimiter& framerate_limiter) {
+void handle_splash_events(cFramerateLimiter& fps_limiter) {
 	sf::Event event;
 	while(mainPtr.pollEvent(event)) {
 		if(event.type == sf::Event::GainedFocus || event.type == sf::Event::MouseMoved)
 			set_cursor(sword_curs);
 	}
-	framerate_limiter.frame_finished();
+	fps_limiter.frame_finished();
 }
 
 static rectangle view_rect() {
@@ -142,7 +142,7 @@ static rectangle view_rect() {
 	return rectangle(0, 0, size.y, size.x);
 }
 
-void show_logo(cFramerateLimiter& framerate_limiter) {
+void show_logo(cFramerateLimiter& fps_limiter) {
 	rectangle whole_window = view_rect();
 	
 	if(get_int_pref("DisplayMode") != 5)
@@ -157,17 +157,17 @@ void show_logo(cFramerateLimiter& framerate_limiter) {
 	play_sound(-95);
 	while(sound_going(95)) {
 		draw_splash(pict_to_draw, mainPtr, logo_from);
-		handle_splash_events(framerate_limiter);
+		handle_splash_events(fps_limiter);
 	}
 	if(!get_int_pref("ShowStartupSplash", true)) {
 		sf::Time delay = time_in_ticks(60);
 		sf::Clock timer;
 		while(timer.getElapsedTime() < delay)
-			handle_splash_events(framerate_limiter);
+			handle_splash_events(fps_limiter);
 	}
 }
 
-void plop_fancy_startup(cFramerateLimiter& framerate_limiter) {
+void plop_fancy_startup(cFramerateLimiter& fps_limiter) {
 	rectangle whole_window = view_rect();
 
 	float ui_scale = get_float_pref("UIScale", 1.0);
@@ -183,7 +183,7 @@ void plop_fancy_startup(cFramerateLimiter& framerate_limiter) {
 	
 	while(timer.getElapsedTime() < delay) {
 		draw_splash(pict_to_draw, mainPtr, intro_from);
-		handle_splash_events(framerate_limiter);
+		handle_splash_events(fps_limiter);
 	}
 }
 

--- a/src/gfx/render_text.hpp
+++ b/src/gfx/render_text.hpp
@@ -37,6 +37,9 @@ struct TextStyle {
 	void applyTo(sf::Text& text);
 };
 
+// elements: std::make_pair(last_line_break, last_word_break)
+typedef std::vector<std::pair<unsigned short, unsigned short>> break_info_t;
+
 struct snippet_t {
 	std::string text;
 	location at;
@@ -53,6 +56,8 @@ enum class eTextMode {
 std::vector<rectangle> draw_string_hilite(sf::RenderTarget& dest_window,rectangle dest_rect,std::string str,TextStyle style,std::vector<hilite_t> hilites,sf::Color hiliteClr);
 std::vector<snippet_t> draw_string_sel(sf::RenderTarget& dest_window,rectangle dest_rect,std::string str,TextStyle style,std::vector<hilite_t> hilites,sf::Color hiliteClr);
 void win_draw_string(sf::RenderTarget& dest_window,rectangle dest_rect,std::string str,eTextMode mode,TextStyle style);
+void win_draw_string(sf::RenderTarget& dest_window,rectangle dest_rect,std::string str,eTextMode mode,TextStyle style, break_info_t break_info);
+break_info_t calculate_line_wrapping(rectangle dest_rect, std::string str, TextStyle style);
 size_t string_length(std::string str, TextStyle style, short* height = nullptr);
 
 #endif

--- a/src/pcedit/pc.main.cpp
+++ b/src/pcedit/pc.main.cpp
@@ -79,6 +79,7 @@ extern bool cur_scen_is_mac;
 extern fs::path progDir;
 short specials_res_id;
 char start_name[256];
+bool flushingInput = false;
 
 static void process_args(int argc, char* argv[]) {
 	if(argc > 1) {

--- a/src/scenedit/scen.main.cpp
+++ b/src/scenedit/scen.main.cpp
@@ -54,7 +54,7 @@ short mode_count = 0;
 cOutdoors* current_terrain;
 
 std::string scenario_temp_dir_name = "ed_scenario";
-bool change_made = false, ae_loading = false;
+bool change_made = false, ae_loading = false, flushingInput = false;
 
 // Numbers of current areas being edited
 short cur_town;

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -18,6 +18,7 @@
 #include "fileio/resmgr/res_sound.hpp"
 #include "mathutil.hpp"
 #include "tools/prefs.hpp"
+#include "utility.hpp"
 
 struct SoundChannel {
 	std::shared_ptr<sf::Sound> player;
@@ -86,7 +87,7 @@ void play_sound(snd_num_t which, sf::Time delay) { // if < 0, play asynch
 	std::shared_ptr<const sf::SoundBuffer> sndhandle;
 	if(!get_bool_pref("PlaySounds", true)) {
 		if(which >= 0)
-			sf::sleep(delay);
+			event_sleep(delay);
 		return;
 	}
 	
@@ -117,7 +118,7 @@ void play_sound(snd_num_t which, sf::Time delay) { // if < 0, play asynch
 		snd_played[channel] = abs(which);
 	}
 	if(which < 0)
-		sf::sleep(time_in_ticks(sound_delay[-1 * which]));
+		event_sleep(time_in_ticks(sound_delay[-1 * which]));
 }
 
 void one_sound(snd_num_t which) {

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -72,11 +72,9 @@ void event_sleep(sf::Time time) {
 	flushingInput = true;
 }
 
-bool update_event_sleeping() {
+void update_event_sleeping() {
 	if(event_sleep_clock.getElapsedTime().asMicroseconds() >= event_sleep_time.asMicroseconds()){
 		event_sleep_time = sf::microseconds(0);
 		flushingInput = false;
 	}	
-
-	return event_sleep_time.asMicroseconds() == 0;
 }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -10,6 +10,8 @@
 
 #include "fileio/resmgr/res_strings.hpp"
 
+extern bool flushingInput;
+
 std::string get_str(std::string list, short j){
 	if(j == 0) return list;
 	const StringList& strings = *ResMgr::strings.get(list);
@@ -59,4 +61,22 @@ short can_see(location p1,location p2,std::function<short(short,short)> get_obsc
 		}
 	}
 	return storage;
+}
+
+sf::Clock event_sleep_clock;
+sf::Time event_sleep_time;
+
+void event_sleep(sf::Time time) {
+	event_sleep_time = time;
+	event_sleep_clock.restart();
+	flushingInput = true;
+}
+
+bool update_event_sleeping() {
+	if(event_sleep_clock.getElapsedTime().asMicroseconds() >= event_sleep_time.asMicroseconds()){
+		event_sleep_time = sf::microseconds(0);
+		flushingInput = false;
+	}	
+
+	return event_sleep_time.asMicroseconds() == 0;
 }

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -34,6 +34,6 @@ std::string get_str(std::string list, short j);
 // Any instance where sf::sleep() could be called for more than a few frames,
 // event_sleep() should be used instead.
 void event_sleep(sf::Time time);
-bool update_event_sleeping();
+void update_event_sleeping();
 
 #endif

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -27,4 +27,13 @@ std::string get_str(std::string list, short j);
 #error Missing strnicmp / strncasecmp
 #endif
 
+// Various parts of the code, like play_sound(), have used sf::sleep() to pause
+// the game for long durations, but this causes the program to hang. event_sleep()
+// accomplishes the same purpose by ignoring input events for the given duration,
+// while allowing the game loop to continue through normal-length frames.
+// Any instance where sf::sleep() could be called for more than a few frames,
+// event_sleep() should be used instead.
+void event_sleep(sf::Time time);
+bool update_event_sleeping();
+
 #endif

--- a/test/catch.cpp
+++ b/test/catch.cpp
@@ -19,3 +19,4 @@ short cur_town;
 cScenario scenario;
 bool change_made;
 cUndoList undo_list;
+bool flushingInput;


### PR DESCRIPTION
We have 3 open issues that reference unreasonably high CPU usage. Using XCode to debug CPU usage, I believe I found all the cases that have been reported and fixed them.

#227 - DialogXMLs with wrapped text are doing all of their processing every time `draw()` is called. So whenever such a dialog is onscreen, CPU usage jumps to about 90% for me until it's closed. I fixed this by only calling `draw()` on frames where an input event occurs. This still will be drawing more than necessary, probably, and a fix could go further by passing a `need_redraw` flag to the event handlers instead of treating any event as a reason to redraw.

#321 and #372 - these issues were more vague about which specific game states were using 100% CPU, and asked for a total overhaul of the game loop. From what I can tell, though, CPU spikes in the intro splash screen, when clicking on controls, and when dialogxmls are wrapping text, are the real problems. Theoretically it would be ideal to convert the whole game to an event-responsive code style where CPU usage stays near 0 in between player turns, but I don't think that's really warranted as long as I've actually found the aberrant cases and fixed them.

To fix the mini event loops that every control has in its `handleClick()` method I added an fps_limiter to the method signature and have them finish their frames with it. This required changing an absurd number of function signatures, and at first I thought just making one `fps_limiter` global would be better, but I realized one advantage of changing all these function signatures is that it becomes more clear in the code when a subcomponent is expecting to spawn its own internal event loop.