### PR TITLE
fix #405 and fix #225

### DIFF
--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -1641,6 +1641,8 @@ bool handle_keystroke(const sf::Event& event, cFramerateLimiter& fps_limiter){
 		Key::Numpad4,Key::Numpad5,Key::Numpad6,
 		Key::Numpad7,Key::Numpad8,Key::Numpad9
 	};
+	// Terrain map coordinates to simulate a click for 8-directional movement/waiting
+	// ordered to correspond with keypad keys
 	location terrain_click[10] = {
 		{150,185},{120,215},{150,215},{180,215},
 		{120,185},{150,185},{180,185},

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -1671,23 +1671,7 @@ bool handle_keystroke(const sf::Event& event, cFramerateLimiter& fps_limiter){
 	if(chr2 == Key::LShift || chr2 == Key::LAlt || chr2 == Key::LControl || chr2 == Key::LSystem) return false;
 	if(chr2 == Key::RShift || chr2 == Key::RAlt || chr2 == Key::RControl || chr2 == Key::RSystem) return false;
 	
-	if(chr2 == Key::Up && !kb.isDownPressed()) {
-		if(kb.isLeftPressed()) chr2 = Key::Numpad7;
-		else if(kb.isRightPressed()) chr2 = Key::Numpad9;
-		else chr2 = Key::Numpad8;
-	} else if(chr2 == Key::Down && !kb.isUpPressed()) {
-		if(kb.isLeftPressed()) chr2 = Key::Numpad1;
-		else if(kb.isRightPressed()) chr2 = Key::Numpad3;
-		else chr2 = Key::Numpad2;
-	} else if(chr2 == Key::Left && !kb.isRightPressed()) {
-		if(kb.isUpPressed()) chr2 = Key::Numpad7;
-		else if(kb.isDownPressed()) chr2 = Key::Numpad1;
-		else chr2 = Key::Numpad4;
-	} else if(chr2 == Key::Right && !kb.isLeftPressed()) {
-		if(kb.isUpPressed()) chr2 = Key::Numpad9;
-		else if(kb.isDownPressed()) chr2 = Key::Numpad3;
-		else chr2 = Key::Numpad6;
-	} else if(chr2 == Key::Home) chr2 = Key::Numpad7;
+	if(chr2 == Key::Home) chr2 = Key::Numpad7;
 	else if(chr2 == Key::End) chr2 = Key::Numpad1;
 	else if(chr2 == Key::PageUp) chr2 = Key::Numpad9;
 	else if(chr2 == Key::PageDown) chr2 = Key::Numpad3;

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -387,19 +387,17 @@ using Key = sf::Keyboard::Key;
 std::map<Key,int> delayed_keys;
 const int ARROW_SIMUL_FRAMES = 3;
 
-// Terrain map coordinates to simulate a click for 8-directional movement/waiting
-const int SOUTHWEST = 1;
-const int SOUTH = 2;
-const int SOUTHEAST = 3;
-const int WEST = 4;
-const int EAST = 6;
-const int NORTHWEST = 7;
-const int NORTH = 8;
-const int NORTHEAST = 9;
+// Terrain map coordinates to simulate a click for 8-directional movement/waiting,
+// ordered to correspond with eDirection
 location terrain_click[10] = {
-	{150,185},{120,215},{150,215},{180,215},
-	{120,185},{150,185},{180,185},
-	{120,155},{150,155},{180,135}
+	{150,155}, // north
+	{180,135}, // northeast
+	{180,185}, // east
+	{180,215}, // southeast
+	{150,215}, // south
+	{120,215}, // southwest
+	{120,185}, // west
+	{120,155}, // northwest
 };
 
 void fire_delayed_key(Key code) {
@@ -416,21 +414,21 @@ void fire_delayed_key(Key code) {
 	int dir = -1;
 
 	if(code == Key::Up && !isDownPressed) {
-		if(isLeftPressed){ dir = NORTHWEST; diagonal = true; }
-		else if(isRightPressed){ dir = NORTHEAST; diagonal = true; }
-		else dir = NORTH;
+		if(isLeftPressed){ dir = DIR_NW; diagonal = true; }
+		else if(isRightPressed){ dir = DIR_NE; diagonal = true; }
+		else dir = DIR_N;
 	} else if(code == Key::Down && !isUpPressed) {
-		if(isLeftPressed){ dir = SOUTHWEST; diagonal = true; }
-		else if(isRightPressed){ dir = SOUTHEAST; diagonal = true; }
-		else dir = SOUTH;
+		if(isLeftPressed){ dir = DIR_SW; diagonal = true; }
+		else if(isRightPressed){ dir = DIR_SE; diagonal = true; }
+		else dir = DIR_S;
 	} else if(code == Key::Left && !isRightPressed) {
-		if(isUpPressed){ dir = NORTHWEST; diagonal = true; }
-		else if(isDownPressed){ dir = SOUTHWEST; diagonal = true; }
-		else dir = WEST;
+		if(isUpPressed){ dir = DIR_NW; diagonal = true; }
+		else if(isDownPressed){ dir = DIR_SW; diagonal = true; }
+		else dir = DIR_W;
 	} else if(code == Key::Right && !isLeftPressed) {
-		if(isUpPressed){ dir = NORTHEAST; diagonal = true; }
-		else if(isDownPressed){ dir = SOUTHEAST; diagonal = true; }
-		else dir = EAST;
+		if(isUpPressed){ dir = DIR_NE; diagonal = true; }
+		else if(isDownPressed){ dir = DIR_SE; diagonal = true; }
+		else dir = DIR_E;
 	} else {
 		return;
 	}

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -387,6 +387,21 @@ using Key = sf::Keyboard::Key;
 std::map<Key,int> delayed_keys;
 const int ARROW_SIMUL_FRAMES = 3;
 
+// Terrain map coordinates to simulate a click for 8-directional movement/waiting
+const int SOUTHWEST = 1;
+const int SOUTH = 2;
+const int SOUTHEAST = 3;
+const int WEST = 4;
+const int EAST = 6;
+const int NORTHWEST = 7;
+const int NORTH = 8;
+const int NORTHEAST = 9;
+location terrain_click[10] = {
+	{150,185},{120,215},{150,215},{180,215},
+	{120,185},{150,185},{180,185},
+	{120,155},{150,155},{180,135}
+};
+
 void fire_delayed_key(Key code) {
 	bool isUpPressed = delayed_keys[Key::Up] > 0;
 	bool isDownPressed = delayed_keys[Key::Down] > 0;
@@ -397,35 +412,41 @@ void fire_delayed_key(Key code) {
 	delayed_keys[Key::Left] = 0;
 	delayed_keys[Key::Right] = 0;
 
-	Key new_code;
 	bool diagonal = false;
+	int dir = -1;
 
 	if(code == Key::Up && !isDownPressed) {
-		if(isLeftPressed){ new_code = Key::Numpad7; diagonal = true; }
-		else if(isRightPressed){ new_code = Key::Numpad9; diagonal = true; }
-		else new_code = Key::Numpad8;
+		if(isLeftPressed){ dir = NORTHWEST; diagonal = true; }
+		else if(isRightPressed){ dir = NORTHEAST; diagonal = true; }
+		else dir = NORTH;
 	} else if(code == Key::Down && !isUpPressed) {
-		if(isLeftPressed){ new_code = Key::Numpad1; diagonal = true; }
-		else if(isRightPressed){ new_code = Key::Numpad3; diagonal = true; }
-		else new_code = Key::Numpad2;
+		if(isLeftPressed){ dir = SOUTHWEST; diagonal = true; }
+		else if(isRightPressed){ dir = SOUTHEAST; diagonal = true; }
+		else dir = SOUTH;
 	} else if(code == Key::Left && !isRightPressed) {
-		if(isUpPressed){ new_code = Key::Numpad7; diagonal = true; }
-		else if(isDownPressed){ new_code = Key::Numpad1; diagonal = true; }
-		else new_code = Key::Numpad4;
+		if(isUpPressed){ dir = NORTHWEST; diagonal = true; }
+		else if(isDownPressed){ dir = SOUTHWEST; diagonal = true; }
+		else dir = WEST;
 	} else if(code == Key::Right && !isLeftPressed) {
-		if(isUpPressed){ new_code = Key::Numpad9; diagonal = true; }
-		else if(isDownPressed){ new_code = Key::Numpad3; diagonal = true; }
-		else new_code = Key::Numpad6;
+		if(isUpPressed){ dir = NORTHEAST; diagonal = true; }
+		else if(isDownPressed){ dir = SOUTHEAST; diagonal = true; }
+		else dir = EAST;
 	} else {
 		return;
 	}
 	if(diagonal){
 		mainPtr.setKeyRepeatEnabled(false);
+	}else{
+		mainPtr.setKeyRepeatEnabled(true);
 	}
 
-	sf::Event dummyEvent = {sf::Event::KeyPressed};
-	dummyEvent.key.code = new_code;
-	queue_fake_event(dummyEvent);
+	if(dir != -1){
+		sf::Event pass_event = {sf::Event::MouseButtonPressed};
+		location pass_point = mainPtr.mapCoordsToPixel(terrain_click[dir], mainView);
+		pass_event.mouseButton.x = pass_point.x;
+		pass_event.mouseButton.y = pass_point.y;
+		queue_fake_event(pass_event);
+	}
 }
 
 void handle_delayed_key(Key code) {

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -387,9 +387,10 @@ using Key = sf::Keyboard::Key;
 std::map<Key,int> delayed_keys;
 const int ARROW_SIMUL_FRAMES = 3;
 
-// Terrain map coordinates to simulate a click for 8-directional movement/waiting,
+// Terrain map coordinates to simulate a click for 8-directional movement
 // ordered to correspond with eDirection
-location terrain_click[10] = {
+// TODO terrain_click is duplicated (with different ordering) in boe.actions.cpp
+location terrain_click[8] = {
 	{150,155}, // north
 	{180,135}, // northeast
 	{180,185}, // east


### PR DESCRIPTION
Partly implemented fix for arrow key handling on mac, which also introduces a frame buffer for arrow key combinations that would solve #225.

The problem now is that diagonals formed by two arrow keys, don't repeat properly. So I'm trying to disable key repeating when diagonals are used, and turn it back on in other cases. Which is just messy and not good. Needs more tinkering.