### PR TITLE
Change framework bundling

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -173,7 +173,7 @@ if platform == "darwin":
 		deps = check_deps(source[0].path)
 		for dep in deps:
 			if dep.endswith('.framework'):
-				paths = Split(env["FRAMEWORKPATH"])
+				paths = Split(env["FRAMEWORKPATH"]) + env["LIBPATH"]
 			else:
 				paths = env["LIBPATH"]
 			for search_path in paths:

--- a/SConstruct
+++ b/SConstruct
@@ -172,7 +172,7 @@ if platform == "darwin":
 			Execute(Mkdir(target))
 		deps = check_deps(source[0].path)
 		for dep in deps:
-			if 'framework' in dep:
+			if dep.endswith('.framework'):
 				paths = Split(env["FRAMEWORKPATH"])
 			else:
 				paths = env["LIBPATH"]


### PR DESCRIPTION
The first commit here is probably superfluous, but technically makes SConstruct more correct.

The second commit fixes a bug where `.framework` libraries in `deps/lib` wouldn't be copied into the app bundle.