### PR TITLE
forward the args from platform-specific scons scripts

### DIFF
--- a/.github/workflows/scripts/mac/scons-build.sh
+++ b/.github/workflows/scripts/mac/scons-build.sh
@@ -4,4 +4,4 @@ export CC="$(brew --prefix llvm)/bin/clang"
 export CXX="$(brew --prefix llvm)/bin/clang++"
 export SDKROOT="$(xcrun --show-sdk-path)"
 
-scons CXXFLAGS="-I/usr/local/opt/zlib/include" LINKFLAGS="-L/usr/local/opt/zlib/lib"
+scons CXXFLAGS="-I/usr/local/opt/zlib/include" LINKFLAGS="-L/usr/local/opt/zlib/lib" $@

--- a/.github/workflows/scripts/win/scons-build.bat
+++ b/.github/workflows/scripts/win/scons-build.bat
@@ -12,4 +12,4 @@ REM )
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
 
-scons bits=64
+scons bits=64 %*


### PR DESCRIPTION
In my release build github action, the workflow yaml file calls `scons-build.sh` and `scons-build.bat` with additional arguments that we don't want in those files directly. To enable this, I've modified the two scripts to forward all of their arguments to `scons` itself. This should change nothing in the upstream CI, but will make my life easier maintaining a release build branch that's easy to rebase with the upstream.