### PR TITLE
Fix rpaths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "deps/cppcodec"]
 	path = deps/cppcodec
 	url = https://github.com/tplgy/cppcodec
+[submodule "deps/fix-rpaths"]
+	path = deps/fix-rpaths
+	url = https://gist.github.com/NQNStudios/7145bcf6621891f5176c8caa165d6b93

--- a/SConstruct
+++ b/SConstruct
@@ -469,6 +469,13 @@ if platform == "darwin":
 		target_dir = path.join(install_dir, targ + '.app', 'Contents/Frameworks')
 		binary = path.join(install_dir, targ + '.app', 'Contents/MacOS', targ)
 		env.Command(Dir(target_dir), binary, [Delete(target_dir), bundle_libraries_for])
+		def fix_target_rpaths():
+			if not path.exists('deps/fix-rpaths/fix-rpaths.py'):
+				subprocess.call(["git", "submodule", "update", "--init", "deps/fix-rpaths"])
+			print(f'build/Blades of Exile/{targ}.app')
+			subprocess.call(["deps/fix-rpaths/fix-rpaths.py", f'build/Blades of Exile/{targ}.app'])
+		if not env.GetOption('clean'):
+			atexit.register(fix_target_rpaths)
 elif platform == "win32":
 	bundled_libs += Split("""
 		libsndfile-1

--- a/pkg/mac/fix_dylibs.sh
+++ b/pkg/mac/fix_dylibs.sh
@@ -6,24 +6,5 @@
 #  Created by Celtic Minstrel on 14-04-17.
 #
 
-echo Fixing boost dylib install names...
-
-EXEPATH=@executable_path/../Frameworks
 BOEPATH="$BUILT_PRODUCTS_DIR/$EXECUTABLE_PATH"
-
-cd "$BUILT_PRODUCTS_DIR/$FRAMEWORKS_FOLDER_PATH"
-
-FSPATH=libboost_filesystem*.dylib
-SYSPATH=libboost_system*.dylib
-
-echo $FSPATH $SYSPATH
-
-# Update references in the executable file
-install_name_tool -change "$SYSPATH" "$EXEPATH/libboost_system.dylib" "$BOEPATH"
-install_name_tool -change "$FSPATH" "$EXEPATH/libboost_filesystem.dylib" "$BOEPATH"
-
-# Update references within Boost
-install_name_tool -id "$SYSPATH" $SYSPATH
-install_name_tool -id "$FSPATH" $FSPATH
-install_name_tool -change "$SYSPATH" "$EXEPATH/libboost_system-mt.dylib" $FSPATH
-
+python3 "$SOURCE_ROOT/../../deps/fix-rpaths/fix-rpaths.py" "$BOEPATH"


### PR DESCRIPTION
This adds a 1-file submodule which just contains my python script that detects and fixes broken rpath/dependency references in the app bundles. And extends SConstruct to make sure the submodule is cloned, and call the script automatically.

This theoretically would have fixed the problems behind #192 although the script might not cover every possible edge case.