### PR TITLE
Record version info

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -87,11 +87,15 @@ def gen_gitrev(env, target, source):
 	revid = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True);
 	fulltag = subprocess.check_output(["git", "tag", "--sort=v:refname"], text=True).split('\n')[-1]
 	tagrev = subprocess.check_output(["git", "rev-parse", fulltag], text=True) if fulltag else ""
+	status = "clean"
+	if subprocess.call(["git", "diff-index", "--quiet", "HEAD", "--"]) != 0:
+		status = "modified"
 	with open(target[0].path, 'w') as gitrev_hpp:
 		print(file=gitrev_hpp)
 		print('#define GIT_REVISION "' + revid[0:7] + '"', file=gitrev_hpp)
 		print('#define GIT_TAG "' + fulltag + '"', file=gitrev_hpp)
 		print('#define GIT_TAG_REVISION "' + tagrev[0:7] + '"', file=gitrev_hpp)
+		print('#define GIT_STATUS "' + status + '"', file=gitrev_hpp)
 		print(file=gitrev_hpp)
 if path.exists(".git"):
 	git_refs = ['.git/HEAD']

--- a/SConstruct
+++ b/SConstruct
@@ -114,7 +114,7 @@ else:
 	# Zipped source downloads from github do not include the repo (probably a good thing)
 	# TODO: This does not work on Windows
 	env.Command('src/tools/gitrev.hpp', '', r"""
-		echo -e "\n#define GIT_REVISION \"\"\n#define GIT_TAG \"\"\n#define GIT_TAG_REVISION \"\"\n" > #TARGET
+		echo -e "\n#define GIT_REVISION \"\"\n#define GIT_TAG \"\"\n#define GIT_TAG_REVISION \"\"\n#define GIT_STATUS \"\"\n#define GIT_REPO \"\"\n" > #TARGET
 	""")
 
 if platform == "darwin":

--- a/SConstruct
+++ b/SConstruct
@@ -84,8 +84,9 @@ if env['debug']:
 # This command generates the header with git revision information
 # NOTE: Changes made here must also be made in pkg/gitrev.sh!
 def gen_gitrev(env, target, source):
-	revid = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True);
-	fulltag = subprocess.check_output(["git", "tag", "--sort=v:refname"], text=True).split('\n')[-1]
+	revid = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True)
+	tag_array = subprocess.check_output(["git", "tag", "--sort=v:refname"], text=True).split('\n')
+	fulltag = list(filter(None, tag_array))[-1]
 	tagrev = subprocess.check_output(["git", "rev-parse", fulltag], text=True) if fulltag else ""
 	status = "clean"
 	if subprocess.call(["git", "diff-index", "--quiet", "HEAD", "--"]) != 0:

--- a/SConstruct
+++ b/SConstruct
@@ -91,12 +91,14 @@ def gen_gitrev(env, target, source):
 	status = "clean"
 	if subprocess.call(["git", "diff-index", "--quiet", "HEAD", "--"]) != 0:
 		status = "modified"
+	repo = subprocess.check_output(["git", "remote", "get-url", "origin"], text=True).strip()
 	with open(target[0].path, 'w') as gitrev_hpp:
 		print(file=gitrev_hpp)
 		print('#define GIT_REVISION "' + revid[0:7] + '"', file=gitrev_hpp)
 		print('#define GIT_TAG "' + fulltag + '"', file=gitrev_hpp)
 		print('#define GIT_TAG_REVISION "' + tagrev[0:7] + '"', file=gitrev_hpp)
 		print('#define GIT_STATUS "' + status + '"', file=gitrev_hpp)
+		print('#define GIT_REPO "' + repo + '"', file=gitrev_hpp)
 		print(file=gitrev_hpp)
 if path.exists(".git"):
 	git_refs = ['.git/HEAD']

--- a/SConstruct
+++ b/SConstruct
@@ -82,6 +82,7 @@ if env['debug']:
 		env.Append(CCFLAGS=['/Zi', '/Od'])
 
 # This command generates the header with git revision information
+# NOTE: Changes made here must also be made in pkg/gitrev.sh!
 def gen_gitrev(env, target, source):
 	revid = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True);
 	fulltag = subprocess.check_output(["git", "tag", "--sort=v:refname"], text=True).split('\n')[-1]

--- a/SConstruct
+++ b/SConstruct
@@ -86,7 +86,10 @@ if env['debug']:
 def gen_gitrev(env, target, source):
 	revid = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True)
 	tag_array = subprocess.check_output(["git", "tag", "--sort=v:refname"], text=True).split('\n')
-	fulltag = list(filter(None, tag_array))[-1]
+	tag_array = list(filter(None, tag_array))
+	fulltag = ""
+	if len(tag_array) > 0:
+		fulltag = tag_array[-1]
 	tagrev = subprocess.check_output(["git", "rev-parse", fulltag], text=True) if fulltag else ""
 	status = "clean"
 	if subprocess.call(["git", "diff-index", "--quiet", "HEAD", "--"]) != 0:

--- a/pkg/gitrev.sh
+++ b/pkg/gitrev.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Usage: gitrev.sh path-to-src
 
+# This script generates the header with git revision information
+# NOTE: Changes made here must also be made in SConstruct!
 REVID=`git rev-parse HEAD`;
 export FULLTAG=`git tag --sort=v:refname | tail -n1`;
 TAGREV=`git rev-parse $FULLTAG`;

--- a/pkg/gitrev.sh
+++ b/pkg/gitrev.sh
@@ -6,5 +6,6 @@
 REVID=`git rev-parse HEAD`;
 export FULLTAG=`git tag --sort=v:refname | tail -n1`;
 TAGREV=`git rev-parse $FULLTAG`;
+STATUS=`git diff-index --quiet HEAD -- && echo "clean" || echo "modified"`;
 
-echo -e "\n#define GIT_REVISION \"${REVID:0:7}\"\n#define GIT_TAG \"$FULLTAG\"\n#define GIT_TAG_REVISION \"${TAGREV:0:7}\"\n" > "$1/tools/gitrev.hpp"
+echo -e "\n#define GIT_REVISION \"${REVID:0:7}\"\n#define GIT_TAG \"$FULLTAG\"\n#define GIT_TAG_REVISION \"${TAGREV:0:7}\"\n#define GIT_STATUS \"${STATUS}\"\n" > "$1/tools/gitrev.hpp"

--- a/pkg/gitrev.sh
+++ b/pkg/gitrev.sh
@@ -7,5 +7,6 @@ REVID=`git rev-parse HEAD`;
 export FULLTAG=`git tag --sort=v:refname | tail -n1`;
 TAGREV=`git rev-parse $FULLTAG`;
 STATUS=`git diff-index --quiet HEAD -- && echo "clean" || echo "modified"`;
+REPO=`git remote get-url origin`;
 
-echo -e "\n#define GIT_REVISION \"${REVID:0:7}\"\n#define GIT_TAG \"$FULLTAG\"\n#define GIT_TAG_REVISION \"${TAGREV:0:7}\"\n#define GIT_STATUS \"${STATUS}\"\n" > "$1/tools/gitrev.hpp"
+echo -e "\n#define GIT_REVISION \"${REVID:0:7}\"\n#define GIT_TAG \"$FULLTAG\"\n#define GIT_TAG_REVISION \"${TAGREV:0:7}\"\n#define GIT_STATUS \"${STATUS}\"\n#define GIT_REPO \"${REPO}\"\n" > "$1/tools/gitrev.hpp"

--- a/proj/vs2013/Common/Common.vcxproj
+++ b/proj/vs2013/Common/Common.vcxproj
@@ -406,7 +406,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;TIXML_USE_TICPP;%(PreprocessorDefinitions);_DEBUG</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MSBUILD_GITREV;WIN32;_WINDOWS;TIXML_USE_TICPP;%(PreprocessorDefinitions);_DEBUG</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\deps\cppcodec;$(SolutionDir)..\..\src\fileio\gzstream;$(SolutionDir)..\..\src\fileio\xml-parser;$(SolutionDir)..\..\src\fileio\resmgr;$(SolutionDir)..\..\src\dialogxml\widgets;$(SolutionDir)..\..\src\dialogxml\dialogs;$(SolutionDir)..\..\src\universe;$(SolutionDir)..\..\src\tools;$(SolutionDir)..\..\src\scenario;$(SolutionDir)..\..\src\universe;$(SolutionDir)..\..\src\fileio;$(SolutionDir)..\..\src\dialogxml;$(SolutionDir)..\..\src\gfx;$(SolutionDir)..\..\src</AdditionalIncludeDirectories>
       <DisableLanguageExtensions>false</DisableLanguageExtensions>
       <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
@@ -435,7 +435,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;TIXML_USE_TICPP;%(PreprocessorDefinitions);NDEBUG</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MSBUILD_GITREV;WIN32;_WINDOWS;TIXML_USE_TICPP;%(PreprocessorDefinitions);NDEBUG</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\deps\cppcodec;$(SolutionDir)..\..\src\fileio\gzstream;$(SolutionDir)..\..\src\fileio\xml-parser;$(SolutionDir)..\..\src\fileio\resmgr;$(SolutionDir)..\..\src\dialogxml\widgets;$(SolutionDir)..\..\src\dialogxml\dialogs;$(SolutionDir)..\..\src\universe;$(SolutionDir)..\..\src\tools;$(SolutionDir)..\..\src\scenario;$(SolutionDir)..\..\src\universe;$(SolutionDir)..\..\src\fileio;$(SolutionDir)..\..\src\dialogxml;$(SolutionDir)..\..\src\gfx;$(SolutionDir)..\..\src</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile />
       <PrecompiledHeaderOutputFile />

--- a/proj/vs2017/Common/Common.vcxproj
+++ b/proj/vs2017/Common/Common.vcxproj
@@ -85,7 +85,7 @@
       <ForcedIncludeFiles>$(SolutionDir)..\..\src\global.hpp</ForcedIncludeFiles>
       <DisableSpecificWarnings>
       </DisableSpecificWarnings>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE;TIXML_USE_TICPP;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MSBUILD_GITREV;WIN32;_WINDOWS;BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE;TIXML_USE_TICPP;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
       <AdditionalUsingDirectories>
       </AdditionalUsingDirectories>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\deps\cppcodec;$(SolutionDir)..\..\src\fileio\gzstream;$(SolutionDir)..\..\src\fileio\xml-parser;$(SolutionDir)..\..\src\fileio\resmgr;$(SolutionDir)..\..\src\dialogxml\widgets;$(SolutionDir)..\..\src\dialogxml\dialogs;$(SolutionDir)..\..\src\universe;$(SolutionDir)..\..\src\tools;$(SolutionDir)..\..\src\scenario;$(SolutionDir)..\..\src\universe;$(SolutionDir)..\..\src\fileio;$(SolutionDir)..\..\src\dialogxml;$(SolutionDir)..\..\src\gfx;$(SolutionDir)..\..\src</AdditionalIncludeDirectories>
@@ -102,7 +102,7 @@
       <Optimization>Disabled</Optimization>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE;TIXML_USE_TICPP;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MSBUILD_GITREV;WIN32;_WINDOWS;BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE;TIXML_USE_TICPP;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\deps\cppcodec;$(SolutionDir)..\..\src\fileio\gzstream;$(SolutionDir)..\..\src\fileio\xml-parser;$(SolutionDir)..\..\src\fileio\resmgr;$(SolutionDir)..\..\src\dialogxml\widgets;$(SolutionDir)..\..\src\dialogxml\dialogs;$(SolutionDir)..\..\src\universe;$(SolutionDir)..\..\src\tools;$(SolutionDir)..\..\src\scenario;$(SolutionDir)..\..\src\universe;$(SolutionDir)..\..\src\fileio;$(SolutionDir)..\..\src\dialogxml;$(SolutionDir)..\..\src\gfx;$(SolutionDir)..\..\src</AdditionalIncludeDirectories>
       <ForcedIncludeFiles>$(SolutionDir)..\..\src\global.hpp</ForcedIncludeFiles>
     </ClCompile>
@@ -123,7 +123,7 @@
       <ForcedIncludeFiles>$(SolutionDir)..\..\src\global.hpp</ForcedIncludeFiles>
       <DisableSpecificWarnings>
       </DisableSpecificWarnings>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE;TIXML_USE_TICPP;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MSBUILD_GITREV;WIN32;_WINDOWS;BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE;TIXML_USE_TICPP;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
       <AdditionalUsingDirectories>
       </AdditionalUsingDirectories>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\deps\cppcodec;$(SolutionDir)..\..\src\fileio\gzstream;$(SolutionDir)..\..\src\fileio\xml-parser;$(SolutionDir)..\..\src\fileio\resmgr;$(SolutionDir)..\..\src\dialogxml\widgets;$(SolutionDir)..\..\src\dialogxml\dialogs;$(SolutionDir)..\..\src\universe;$(SolutionDir)..\..\src\tools;$(SolutionDir)..\..\src\scenario;$(SolutionDir)..\..\src\universe;$(SolutionDir)..\..\src\fileio;$(SolutionDir)..\..\src\dialogxml;$(SolutionDir)..\..\src\gfx;$(SolutionDir)..\..\src</AdditionalIncludeDirectories>
@@ -145,7 +145,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE;TIXML_USE_TICPP;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MSBUILD_GITREV;WIN32;_WINDOWS;BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE;TIXML_USE_TICPP;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\deps\cppcodec;$(SolutionDir)..\..\src\fileio\gzstream;$(SolutionDir)..\..\src\fileio\xml-parser;$(SolutionDir)..\..\src\fileio\resmgr;$(SolutionDir)..\..\src\dialogxml\widgets;$(SolutionDir)..\..\src\dialogxml\dialogs;$(SolutionDir)..\..\src\universe;$(SolutionDir)..\..\src\tools;$(SolutionDir)..\..\src\scenario;$(SolutionDir)..\..\src\universe;$(SolutionDir)..\..\src\fileio;$(SolutionDir)..\..\src\dialogxml;$(SolutionDir)..\..\src\gfx;$(SolutionDir)..\..\src</AdditionalIncludeDirectories>
       <ForcedIncludeFiles>$(SolutionDir)..\..\src\global.hpp</ForcedIncludeFiles>
     </ClCompile>

--- a/src/tools/replay.cpp
+++ b/src/tools/replay.cpp
@@ -15,6 +15,7 @@
 #include <codecvt>
 #include <string>
 #include <boost/lexical_cast.hpp>
+#include "tools/gitrev.hpp"
 #include "gfx/render_shapes.hpp"
 
 using base64 = cppcodec::base64_rfc4648;
@@ -49,6 +50,9 @@ bool init_action_log(std::string command, std::string file) {
 		log_file = file;
 		try {
 			Element root_element("actions");
+			root_element.SetAttribute("SHA", GIT_REVISION);
+			root_element.SetAttribute("Tag", GIT_TAG);
+			root_element.SetAttribute("Status", GIT_STATUS);
 			log_document.InsertEndChild(root_element);
 			log_document.SaveFile(log_file);
 			recording = true;

--- a/src/tools/replay.cpp
+++ b/src/tools/replay.cpp
@@ -15,8 +15,10 @@
 #include <codecvt>
 #include <string>
 #include <boost/lexical_cast.hpp>
-#include "tools/gitrev.hpp"
 #include "gfx/render_shapes.hpp"
+#ifndef MSBUILD_GITREV
+#include "tools/gitrev.hpp"
+#endif
 
 using base64 = cppcodec::base64_rfc4648;
 
@@ -50,10 +52,14 @@ bool init_action_log(std::string command, std::string file) {
 		log_file = file;
 		try {
 			Element root_element("actions");
+			#if defined(GIT_REVISION) && defined(GIT_TAG)
 			root_element.SetAttribute("SHA", GIT_REVISION);
 			root_element.SetAttribute("Tag", GIT_TAG);
+			#endif
+			#if defined(GIT_STATUS) && defined(GIT_REPO)
 			root_element.SetAttribute("Status", GIT_STATUS);
 			root_element.SetAttribute("Repo", GIT_REPO);
+			#endif
 			log_document.InsertEndChild(root_element);
 			log_document.SaveFile(log_file);
 			recording = true;

--- a/src/tools/replay.cpp
+++ b/src/tools/replay.cpp
@@ -53,6 +53,7 @@ bool init_action_log(std::string command, std::string file) {
 			root_element.SetAttribute("SHA", GIT_REVISION);
 			root_element.SetAttribute("Tag", GIT_TAG);
 			root_element.SetAttribute("Status", GIT_STATUS);
+			root_element.SetAttribute("Repo", GIT_REPO);
 			log_document.InsertEndChild(root_element);
 			log_document.SaveFile(log_file);
 			recording = true;

--- a/src/tools/replay.cpp
+++ b/src/tools/replay.cpp
@@ -52,11 +52,9 @@ bool init_action_log(std::string command, std::string file) {
 		log_file = file;
 		try {
 			Element root_element("actions");
-			#if defined(GIT_REVISION) && defined(GIT_TAG)
+			#ifndef MSBUILD_GITREV
 			root_element.SetAttribute("SHA", GIT_REVISION);
 			root_element.SetAttribute("Tag", GIT_TAG);
-			#endif
-			#if defined(GIT_STATUS) && defined(GIT_REPO)
 			root_element.SetAttribute("Status", GIT_STATUS);
 			root_element.SetAttribute("Repo", GIT_REPO);
 			#endif


### PR DESCRIPTION
Close #440 

I found a bug where scons builds defined GIT_TAG as empty because of a trailing blank line in the subprocess output.

Fixed that, and am now recording a root element like this:

```
<actions SHA="f411a46" Tag="v0.0.4" Status="modified" Repo="git@github.com:NQNStudios/cboe.git">
```

The CI will show whether my changes to `gitrev.sh` work for the Xcode build.