### PR TITLE
Fix my dialog construction test case's file loading

### DIFF
--- a/test/SConscript
+++ b/test/SConscript
@@ -25,5 +25,10 @@ def run_tests(env,target,source):
 env.Install("#build/test/", test)
 env.AlwaysBuild(env.Install("#build/test/", Dir("#test/files")))
 env.AlwaysBuild(env.Install("#build/rsrc/", Dir("#rsrc/strings")))
+# The dialog construction test case requires these:
+env.AlwaysBuild(env.Install("#build/rsrc/", Dir("#rsrc/dialogs")))
+env.AlwaysBuild(env.Install("#build/rsrc/", Dir("#rsrc/fonts")))
+env.AlwaysBuild(env.Install("#build/rsrc/", Dir("#rsrc/graphics")))
+
 env.Command("#build/test/junk/", '', 'mkdir "' + Dir("#build/test/junk").path + '"')
 env.Command("#build/test/passed", test, run_tests, chdir=True)


### PR DESCRIPTION
This fixes a test case I wrote years ago which has been silently failing for scons builds.

An upcoming PR will remedy the fact that those failures have been silent--but I haven't yet fixed *other* things which fail besides this.