### PR TITLE
Fix scons tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,6 @@
 					name: build and unit test,
 					run: '.\.github\workflows\scripts\win\scons-build.bat'
 				},
-
 			]
 		},
 		# win-mingw: {
@@ -198,10 +197,10 @@
 					run: 'sudo ./.github/workflows/scripts/linux/install-tgui.sh'
 				},
 				{
-					name: build and unit test,
-					run: CCFLAGS=-fdiagnostics-color=always scons
+					name: build and unit test headless,
+					run: 'xvfb-run ./.github/workflows/scripts/linux/scons-build.sh'
 				}
-			],
+			]
 		}
 	}
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@
 			steps: [
 				{
 					name: checkout,
-					uses: actions/checkout@v2,
+					uses: actions/checkout@v4,
 					with: { submodules: true }
 				},
 				{
@@ -49,7 +49,7 @@
 			steps:  [
 				{
 					name: checkout,
-					uses: actions/checkout@v2,
+					uses: actions/checkout@v4,
 					with: { submodules: true }
 				},
 				{
@@ -77,7 +77,7 @@
 				},
 				{
 					name: checkout,
-					uses: actions/checkout@v2,
+					uses: actions/checkout@v4,
 					with: { submodules: true }
 				},
 				{
@@ -106,7 +106,7 @@
 				},
 				{
 					name: checkout,
-					uses: actions/checkout@v2,
+					uses: actions/checkout@v4,
 					with: { submodules: true }
 				},
 				{
@@ -139,7 +139,7 @@
 				},
 				{
 					name: checkout,
-					uses: actions/checkout@v2,
+					uses: actions/checkout@v4,
 					with: { submodules: true }
 				},
 				{
@@ -163,7 +163,7 @@
 		# 	steps: [
 		# 		{
 		# 			name: checkout,
-		# 			uses: actions/checkout@v2,
+		# 			uses: actions/checkout@v4,
 		#			with: { submodules: true }
 		# 		},
 		# 		{
@@ -186,7 +186,7 @@
 			steps: [
 				{
 					name: checkout,
-					uses: actions/checkout@v2,
+					uses: actions/checkout@v4,
 					with: { submodules: true }
 				},
 				{

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,12 @@
 					name: build and unit test,
 					run: '.\.github\workflows\scripts\win\scons-build.bat'
 				},
+				{
+					name: warn about failure to launch tests,
+					run: 'echo "::warning title=UNIT-TESTS::unit tests failed for win-scons"',
+					shell: bash,
+					if: '${{ hashFiles("build/test/passed") == "" }}'
+				}
 			]
 		},
 		# win-mingw: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@
 					name: warn about failure to launch tests,
 					run: 'echo "::warning title=UNIT-TESTS::unit tests failed for win-scons"',
 					shell: bash,
-					if: '${{ hashFiles("build/test/passed") == "" }}'
+					if: "${{ hashFiles('build/test/passed') == '' }}"
 				}
 			]
 		},

--- a/.github/workflows/scripts/linux/scons-build.sh
+++ b/.github/workflows/scripts/linux/scons-build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -ve
+
+CCFLAGS=-fdiagnostics-color=always scons

--- a/.github/workflows/scripts/linux/scons-build.sh
+++ b/.github/workflows/scripts/linux/scons-build.sh
@@ -1,3 +1,4 @@
 #!/bin/sh -ve
 
-CCFLAGS=-fdiagnostics-color=always scons
+export CCFLAGS=-fdiagnostics-color=always
+scons

--- a/test/SConscript
+++ b/test/SConscript
@@ -23,10 +23,13 @@ else:
 	test = env.Program("#build/bin/boe_test", test_sources + party_classes + common_sources)
 
 def run_tests(env,target,source):
-   import subprocess
-   app = str(source[0].abspath)
-   if not subprocess.call(app):
-      open(target[0].abspath,'w').write("PASSED\n")
+	app = str(source[0].abspath)
+	exit_code = subprocess.call(app)
+	if exit_code == 0:
+		open(target[0].abspath,'w').write("PASSED\n")
+	else:
+		print(f'Unit test failure! Exit code: {exit_code}')
+		exit(exit_code)
 
 env.Install("#build/test/", test)
 if debug_symbols is not None:

--- a/test/SConscript
+++ b/test/SConscript
@@ -29,7 +29,9 @@ def run_tests(env,target,source):
 		open(target[0].abspath,'w').write("PASSED\n")
 	else:
 		print(f'Unit test failure! Exit code: {exit_code}')
-		exit(exit_code)
+		# TODO: When issue #449 is fixed, Windows should also exit on test failure:
+		if str(platform) != "win32":
+			exit(exit_code)
 
 env.Install("#build/test/", test)
 if debug_symbols is not None:


### PR DESCRIPTION
I've been trying to pave the way for #441 by making the scons ci builds fail when the tests fail.

This proved troublesome because the Linux and Win-Scons builds have been failing the tests silently for quite a while.

For some reason, Linux needs an X server to run the tests -- this was a pretty trivial fix because a utility is included on Ubuntu github actions runners called `xvfb` which I had never heard of but seems really awesome. It runs a headless X server for CI workflows. Using this fixed that problem.

(Note for the future: there's a github action that lets you use `xvfb` on Windows and Mac. Maybe we could someday even be running our full replay test suite on CI for all three platforms this way. I don't know how sophisticated it is.)

Now, for win-scons the tests are failing with an error code which I think indicates missing DLLs. I've tried so many different things to fix it, but I can't repro this failure on my own machine. On my PC, the tests run and succeed through Scons. I'm at my wits' end and I'm starting to think it's a poor use of time to keep making this a blocking issue. So I would suggest that we should make the win-scons workflow succeed if it compiles correctly, but issue a warning that the tests didn't run. @CelticMinstrel would this be okay with you, alongside opening a github issue for the real problem?

I'm also trying to trim down the other Github actions warnings, so that the win-scons warning (which I haven't implemented yet) will stand out.