### PR TITLE
fix boost auto-link breaking some win scons builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -208,6 +208,9 @@ if platform == "darwin":
 					bundle_libraries_for(target, [File(check_path)], env)
 					break
 elif platform == "win32":
+	# Boost has a very obnoxious auto-link feature that breaks some local windows builds
+	env.Append(CPPDEFINES=['BOOST_ALL_NO_LIB'])
+
 	if 'msvc' in env['TOOLS']:
 		vcpkg_prefix = path.join((os.environ['HOME'] if 'HOME' in os.environ else 'C:\\'), 'vcpkg')
 		vcpkg_installed = path.join(vcpkg_prefix, 'installed', f'x{arch_short}-windows')


### PR DESCRIPTION
At this point I'm using my own from-source builds to supply pretty much all of the dependencies in my local builds. This is another fix for that case, which hopefully won't affect the CI case.

Setting up another Windows dev environment I was getting a frustrating bug--Boost has some kind of "auto-link" feature which causes it to try to link against a DLL which doesn't exist in my from-source builds and isn't passed as a link flag. The only way to stop this is to define `BOOST_ALL_NO_LIB`.