### PR TITLE
Fix word highlight

### DIFF
--- a/src/game/boe.newgraph.cpp
+++ b/src/game/boe.newgraph.cpp
@@ -835,6 +835,7 @@ void click_talk_rect(word_rect_t word) {
 	mainPtr.setActive();
 	rect_draw_some_item(talk_gworld.getTexture(),talkRect,mainPtr,talk_area_rect);
 	wordRect.offset(talk_area_rect.topLeft());
+	wordRect.width() += 10; // Arbitrary extra space fixes #481 and shouldn't cause any problems
 	TextStyle style;
 	style.font = FONT_DUNGEON;
 	style.pointSize = 18;


### PR DESCRIPTION
Making a small arbitrary width adjustment to word rectangles fixes #481. I can't think of any negative side effects to this and I can't think of a reason to search for a more sophisticated solution.