### PR TITLE
clear_map() call draw_map() after

### DIFF
--- a/src/game/boe.town.cpp
+++ b/src/game/boe.town.cpp
@@ -1284,6 +1284,7 @@ void clear_map() {
 	
 	fill_rect(map_gworld, map_world_rect, sf::Color::Black);
 	
+	draw_map(true);
 }
 
 void draw_map(bool need_refresh) {


### PR DESCRIPTION
I was looking to fix #487 and #428. While I was doing that, I looked through the call sites of `clear_map()` and found that nearly every call was used in a context where we wanted to *redraw* the map, not clear it. We only really want the "clear" behavior of clear_map() once, when the texture is initialized pure white and we want it black instead.

It turns out that modifying `clear_map()` so it calls `draw_map(true) fixes #487, and fixes #428 in one fell swoop. For whatever reason, clear_map() seems to be a misnomer.

I think draw_map() short-circuits safely if nothing can be drawn (i.e. the initialization "fill the new texture with black" case), and if that's correct, this is a simple fix.

I have a hunch that #267 was a manifestation of this bug too--because I've never reproduced the minimap data actually being wiped, but I *can* reproduce loading a file while the map is already open, and having the minimap wiped black in the new game until you move once.