### PR TITLE
Rearrange startup buttons, add tutorial button with stub event

### DIFF
--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -163,9 +163,9 @@ void init_screen_locs() {
 		startup_button[btn].offset(301 * (btn / 3), 48 * (btn % 3));
 	}
 	startup_top.top = 7;
-	startup_top.bottom = startup_button[STARTBTN_LOAD].top;
+	startup_top.bottom = startup_button[STARTBTN_TUTORIAL].top;
 	startup_top.left = startup_base.left;
-	startup_top.right = startup_button[STARTBTN_JOIN].right;
+	startup_top.right = startup_button[STARTBTN_NEW].right;
 	
 	// icon, name, use, give, drip, info, sell/id   each one 13 down
 	item_buttons[0][ITEMBTN_ICON].top = 15;
@@ -3160,6 +3160,12 @@ void start_new_game(bool force) {
 	fs::path file = nav_put_or_temp_party();
 	if(!file.empty()) save_party(file, univ);
 	univ.file = file;
+}
+
+void start_tutorial() {
+	// Start by using the default party
+	start_new_game(true);
+	// TODO start the tutorial scenario, which we need to design.
 }
 
 location get_cur_direction(location the_point) {

--- a/src/game/boe.actions.hpp
+++ b/src/game/boe.actions.hpp
@@ -30,6 +30,7 @@ void handle_new_pc();
 void new_party();
 void handle_death();
 void start_new_game(bool force = false);
+void start_tutorial();
 location get_cur_direction(location the_point);
 bool outd_move_party(location destination,bool forced);
 bool town_move_party(location destination,short forced);

--- a/src/game/boe.consts.hpp
+++ b/src/game/boe.consts.hpp
@@ -84,13 +84,16 @@ enum eTrapType {
 
 // Startup buttons
 enum eStartButton {
-	STARTBTN_LOAD = 0,
-	STARTBTN_NEW = 1,
-	STARTBTN_ORDER = 2,
-	STARTBTN_JOIN = 3,
-	STARTBTN_CUSTOM = 4,
+	// Left Column
+	STARTBTN_TUTORIAL = 0,
+	STARTBTN_LOAD = 1,
+	STARTBTN_PREFS = 2,
+	// Right Column
+	STARTBTN_NEW = 3,
+	STARTBTN_JOIN = 4,
 	STARTBTN_SCROLL = 5,
-	MAX_eStartButton // keep last
+	// Keep last:
+	MAX_eStartButton = 6
 };
 
 // Shop rects

--- a/src/game/boe.graphics.cpp
+++ b/src/game/boe.graphics.cpp
@@ -414,9 +414,14 @@ void draw_startup_stats() {
 
 void draw_start_button(eStartButton which_position,short which_button) {
 	rectangle from_rect,to_rect;
-	// TODO: Change third button (Windows calls it "Support and Downloads")
-	const char *button_labels[] = {"Load Game","Make New Party","Preferences",
-		"Start Scenario","Custom Scenario","Quit"};
+	const char *button_labels[MAX_eStartButton];
+	button_labels[STARTBTN_TUTORIAL] = "Tutorial";
+	button_labels[STARTBTN_LOAD] = "Load Game";
+	button_labels[STARTBTN_PREFS] = "Preferences";
+	button_labels[STARTBTN_NEW] = "Make New Party";
+	button_labels[STARTBTN_JOIN] = "Start Scenario";
+	button_labels[STARTBTN_SCROLL] = "";
+
 	// The 0..65535 version of the blue component was 14472; the commented version was 43144431
 	sf::Color base_color = {0,0,57};
 	

--- a/src/game/boe.startup.cpp
+++ b/src/game/boe.startup.cpp
@@ -66,12 +66,14 @@ void handle_startup_button_click(eStartButton btn, eKeyMod mods) {
 			draw_startup(0);
 			break;
 			
-		case STARTBTN_ORDER:
+		case STARTBTN_PREFS:
 			// pass false so another action is not recorded (the start button action is enough)
 			pick_preferences(false);
 			break;
 		
-		case STARTBTN_CUSTOM: break; // Currently unused
+		case STARTBTN_TUTORIAL:
+			start_tutorial();
+			break;
 			
 		case STARTBTN_SCROLL: case MAX_eStartButton:
 			// These aren't buttons


### PR DESCRIPTION
This creates the arrangement decided on in #173 and takes the first steps to implementing the tutorial.