### PR TITLE
make scons build debug by default

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -8,7 +8,7 @@ opts = Variables(None, ARGUMENTS)
 
 opts.Add(EnumVariable('OS', "Target platform", str(Platform()), ('darwin', 'win32', 'posix')))
 opts.Add('toolset', "Toolset to pass to the SCons builder", 'default')
-opts.Add(BoolVariable('debug', "Build with debug symbols and no optimization", False))
+opts.Add(BoolVariable('debug', "Build with debug symbols and no optimization", True))
 opts.Add(EnumVariable('bits', "Build for 32-bit or 64-bit architectures", '64', ('32', '64')))
 
 # Partial build flags -- by default, all targets will be built,

--- a/src/game/SConscript
+++ b/src/game/SConscript
@@ -44,7 +44,7 @@ elif str(platform) == "posix":
 
 boe = env.Program("#build/bin/Blades of Exile", game_sources + party_classes + common_sources)
 debug_symbols = None
-if str(platform) == "win32" and 'msvc' in env["TOOLS"] and env['debug']:
+if str(platform) == "win32" and 'msvc' in env["TOOLS"] and not env['release']:
 	debug_symbols = boe[0].abspath.replace('.exe', '.pdb')
 
 if str(platform) == "darwin":

--- a/src/pcedit/SConscript
+++ b/src/pcedit/SConscript
@@ -28,7 +28,7 @@ elif str(platform) == "posix":
 
 pced = env.Program("#build/bin/BoE Character Editor", pced_sources + party_classes + common_sources)
 debug_symbols = None
-if str(platform) == "win32" and 'msvc' in env["TOOLS"] and env['debug']:
+if str(platform) == "win32" and 'msvc' in env["TOOLS"] and not env['release']:
 	debug_symbols = pced[0].abspath.replace('.exe', '.pdb')
 
 if str(platform) == "darwin":

--- a/src/scenedit/SConscript
+++ b/src/scenedit/SConscript
@@ -32,7 +32,7 @@ elif str(platform) == "posix":
 
 scened = env.Program("#build/bin/BoE Scenario Editor", scened_sources + common_sources)
 debug_symbols = None
-if str(platform) == "win32" and 'msvc' in env["TOOLS"] and env['debug']:
+if str(platform) == "win32" and 'msvc' in env["TOOLS"] and not env['release']:
 	debug_symbols = scened[0].abspath.replace('.exe', '.pdb')
 
 if str(platform) == "darwin":

--- a/test/SConscript
+++ b/test/SConscript
@@ -14,10 +14,10 @@ test_sources = Glob("""*.cpp""") + Split("""
 debug_symbols = None
 if str(platform) == "win32" and 'msvc' in env["TOOLS"]:
 	link_flags = f'/nologo /SUBSYSTEM:CONSOLE /MACHINE:X{arch_short}'
-	if env['debug']:
+	if not env['release']:
 		link_flags += ' /DEBUG'
 	test = env.Program("#build/bin/boe_test", party_classes + common_sources + test_sources, LINKFLAGS=link_flags)
-	if env['debug']:
+	if not env['release']:
 		debug_symbols = test[0].abspath.replace(".exe", ".pdb")
 else:
 	test = env.Program("#build/bin/boe_test", test_sources + party_classes + common_sources)


### PR DESCRIPTION
I think any developer is going to want their default build to be debug. I'm often frustrated that I can't see a crash's callstack while testing because I accidentally built release.

I replaced the `debug` flag with a `release` flag, default false. When the `debug` flag is passed, it is ignored and a warning is printed explaining the change. Supporting both a `debug` and a `release` flag required to be opposite values was a nightmare, I tried.

Bonus: All unknown options will print a warning. I'm constantly doing `scened=true` instead of `scenedit=true` etc and this should help.