### PR TITLE
Update copyright notices and contact/pricing info.

### DIFF
--- a/pkg/credits/about-boe-template.xml
+++ b/pkg/credits/about-boe-template.xml
@@ -10,7 +10,7 @@
 	<pict type='dlog' num='16' top='6' left='6'/>
 	<text top='6' left='50' width='420' height='33'>
 		Blades of Exile v2.0 alpha <br/>
-		  Copyright 1997-2015, Spiderweb Software, Inc., All rights reserved.
+		  Created 1997, Free Open Source
 	</text>
 	<pane top='42' left='50' width='400' height='100'>
 		<text size='large' top='42' left='150' width='300' height='17'>------      CREDITS      ------</text>

--- a/rsrc/dialogs/about-boe.xml
+++ b/rsrc/dialogs/about-boe.xml
@@ -11,7 +11,7 @@
 	<pict type='dlog' num='16' top='6' left='6'/>
 	<text top='6' left='50' width='420' height='33'>
 		Blades of Exile v2.0 alpha <br/>
-		  Copyright 1997-2015, Spiderweb Software, Inc., All rights reserved.
+		  Created 1997, Free Open Source
 	</text>
 	<pane top='42' left='50' width='400' height='100'>
 		<text size='large' top='42' left='150' width='300' height='17'>------      CREDITS      ------</text>

--- a/rsrc/dialogs/about-pced.xml
+++ b/rsrc/dialogs/about-pced.xml
@@ -1,39 +1,30 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
-	<!--
-	 TODO: This dialog contains out-of-date information
-	 -->
-	<button name='okay' type='regular' top='260' left='431'>OK</button>
 	<pict top='6' left='6' type='dlog' num='16'/>
 	<text top='6' left='50' width='338' height='34'>
 		Blades of Exile Character Editor v2.0 alpha<br/>
-		  Copyright 1997 Jeff Vogel, All rights reserved.
+		  Created 1997, Free Open Source
 	</text>
-	<text top='154' left='50' width='439' height='45'>
-		Blades of Exile (with the editor, hint book, and fully usable scenario editor) is $30.
-		For information on how to order, select 'How To Order' from the File menu.
-	</text>
-	<text top='200' left='50' width='368' height='32'>
-		Comments and questions?
-		The creators of Exile want to hear them.
-		Send them to:
-	</text>
-	<text top='233' left='60' width='354' height='53'>
-		Internet: SpidWeb@spidweb.com <br/>
-		America Online: SpidWeb <br/>
-		Compuserve: 76463,1521 <br/>
-		WWW: http://www.spidweb.com
-	</text>
-	<text top='102' left='50' width='439' height='51'>
-		The Blades of Exile Editor is brought to you by Spiderweb Software - <br/>
-		   "Where our aberrations become your reality." <br/>
-		"Blades of Exile" and Spiderweb Software are trademarks of Spiderweb Software.
-	</text>
-	<text top='42' left='50' width='438' height='59'>
+	<text relative='abs pos' rel-anchor='prev' top='10' left='50' width='438' height='59'>
 		CREDITS: <br/>
 		   Concept, Design, Programming: Jeff Vogel <br/>
-		   Graphics: Andrew Hunter (Wormius@aol.com) <br/>
+		   Graphics: Andrew Hunter <br/>
 		   Other Programming: Mariann Krizsan
 	</text>
+	<text relative='abs pos' rel-anchor='prev' top='10' left='50' width='439' height='51'>
+		The Blades of Exile Editor is created by Spiderweb Software - <br/>
+		   "Where our aberrations become your reality." <br/>
+		"Blades of Exile" and Spiderweb Software are trademarks of Spiderweb Software. <br/>
+		Open Blades of Exile is maintained by volunteer open source developers.
+	</text>
+	<text relative='abs pos' rel-anchor='prev' top='10' left='50' width='368' height='32'>
+		Comments and questions?
+		The maintainers of Open Blades of Exile want to hear them.
+		Open a ticket here:
+	</text>
+	<text relative='abs pos' rel-anchor='prev' top='10' left='60' width='353' colour='link' height='17'>
+		https://github.com/calref/cboe/issues
+	</text>
+	<button name='okay' type='regular' relative='abs pos' rel-anchor='prev' top='10' left='431'>OK</button>
 </dialog>

--- a/rsrc/dialogs/about-scened.xml
+++ b/rsrc/dialogs/about-scened.xml
@@ -1,39 +1,30 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
-	<!--
-	 TODO: This dialog contains out-of-date information
-	 -->
-	<button name='okay' type='regular' top='270' left='430'>OK</button>
 	<pict type='dlog' num='16' top='6' left='6'/>
 	<text top='6' left='50' width='420' height='33'>
 		Blades of Exile Scenario Editor v2.0 alpha<br/>
-		  Copyright 1997, Spiderweb Software, Inc., All rights reserved.
+		  Created 1997, Free Open Source
 	</text>
-	<text top='147' left='50' width='425' height='47'>
-		Blades of Exile is $30 shareware.
-		For information on how to register, run Blades of Exile and select 'How To Order' from the game opening screen.
-	</text>
-	<text top='191' left='50' width='354' height='32'>
-		Comments and questions?
-		The creators of Exile want to hear them.
-		Send them to:
-	</text>
-	<text top='224' left='60' width='353' height='66'>
-		Internet: SpidWeb@spidweb.com <br/>
-		America Online: SpidWeb <br/>
-		Compuserve: 76463,1521 <br/>
-		WWW: http://www.spidweb.com
-	</text>
-	<text top='94' left='50' width='410' height='51'>
-		Blades of Exile is brought to you by Spiderweb Software - <br/>
-		   "Where our aberrations become your reality." <br/>
-		"Blades of Exile" and Spiderweb Software are trademarks of Spiderweb Software.
-	</text>
-	<text top='42' left='50' width='415' height='51'>
+	<text relative='abs pos' rel-anchor='prev' top='10' left='50' width='415'>
 		CREDITS: <br/>
 		   Concept, Design, Programming: Jeff Vogel <br/>
-		   Graphics: Andrew Hunter (Wormius@aol.com) <br/>
-		   Title Screen: James Ernest (ernest@speakeasy.org)
+		   Graphics: Andrew Hunter <br/>
+		   Title Screen: James Ernest
 	</text>
+	<text relative='abs pos' rel-anchor='prev' top='10' left='50' width='410' height='85'>
+		Blades of Exile is created Spiderweb Software - <br/>
+		   "Where our aberrations become your reality." <br/><br/>
+		"Blades of Exile" and Spiderweb Software are trademarks of Spiderweb Software. <br/>
+		Open Blades of Exile is maintained by volunteer open source developers.
+	</text>
+	<text relative='abs pos' rel-anchor='prev' top='10' left='50' width='354' height='32'>
+		Comments and questions?
+		The maintainers of Open Blades of Exile want to hear them.
+		Open a ticket here:
+	</text>
+	<text relative='abs pos' rel-anchor='prev' top='10' left='60' width='353' colour='link' height='17'>
+		https://github.com/calref/cboe/issues
+	</text>
+	<button name='okay' type='regular' relative='abs pos' rel-anchor='prev' top='10' left='430'>OK</button>
 </dialog>

--- a/src/game/boe.graphics.cpp
+++ b/src/game/boe.graphics.cpp
@@ -392,7 +392,7 @@ void draw_startup_stats() {
 	}
 	
 	std::ostringstream sout;
-	sout << "Copyright 1997, All Rights Reserved, v" << oboeVersionString();
+	sout << "Created 1997, Free Open Source, v" << oboeVersionString();
 #if defined(GIT_REVISION) && defined(GIT_TAG_REVISION)
 	if(strcmp(GIT_REVISION, GIT_TAG_REVISION) != 0) {
 		sout << " [" << GIT_REVISION << "]";

--- a/src/scenedit/scen.actions.cpp
+++ b/src/scenedit/scen.actions.cpp
@@ -2257,7 +2257,7 @@ void set_up_start_screen() {
 	set_lb(NLS - 5,LB_TEXT,LB_NO_ACTION,"of Exile License. Using this");
 	set_lb(NLS - 4,LB_TEXT,LB_NO_ACTION,"program implies that you agree ");
 	set_lb(NLS - 3,LB_TEXT,LB_NO_ACTION,"with the terms of the license.");
-	set_lb(NLS - 2,LB_TEXT,LB_NO_ACTION,"Copyright 1997, All rights reserved.");
+	set_lb(NLS - 2,LB_TEXT,LB_NO_ACTION,"Created 1997, Free Open Source");
 	set_lb(NLS - 1,LB_TEXT,LB_NO_ACTION,version());
 	change_made = false;
 	update_mouse_spot(translate_mouse_coordinates(sf::Mouse::getPosition(mainPtr)));
@@ -2292,7 +2292,7 @@ void set_up_main_screen() {
 	set_lb(-1,LB_TEXT,LB_LOAD_TOWN,"Load Another Town");
 	set_lb(-1,LB_TEXT,LB_EDIT_TOWN,"Edit Town Terrain");
 	set_lb(-1,LB_TEXT,LB_EDIT_TALK,"Edit Town Dialogue");
-	set_lb(NLS - 2,LB_TEXT,LB_NO_ACTION,"Copyright 1997, All rights reserved.");
+	set_lb(NLS - 2,LB_TEXT,LB_NO_ACTION,"Created 1997, Free Open Source");
 	set_lb(NLS - 1,LB_TEXT,LB_NO_ACTION,version());
 	overall_mode = MODE_MAIN_SCREEN;
 	right_sbar->show();


### PR DESCRIPTION
With permission, I've changed the Copyright notices to say "Created 1997, Free Open Source" which I think will make things seem more welcoming as opposed to "All Rights Reserved".

Removed pricing/how to order messages.

Replaced old contact info with links to the repo's issue tracker.

Made about-pced.xml and about-scened.xml use relative positioning

Close #499