### PR TITLE
Update Readme to reduce confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CI status](https://github.com/calref/cboe/actions/workflows/ci.yml/badge.svg)](https://github.com/calref/cboe/actions/workflows/ci.yml)
 
-Classic Blades of Exile
-=======================
+Open Blades of Exile
+====================
 
 This project hosts the source code to the classic RPG creator Blades of
 Exile after it was released


### PR DESCRIPTION
It is a little confusing that the Readme says "Classic Blades of Exile". When I was looking for builds many years ago that was something that tripped me up. Is it significant? If not, maybe we should change it. Everywhere else, we already say Blades of Exile or Open Blades of Exile.