### PR TITLE
Fix lighting

### DIFF
--- a/src/game/boe.newgraph.cpp
+++ b/src/game/boe.newgraph.cpp
@@ -153,7 +153,10 @@ void apply_unseen_mask() {
 void apply_light_mask(bool onWindow) {
 	static Region dark_mask_region;
 	rectangle temp = {0,0,108,84},paint_rect,base_rect = {0,0,36,28};
-	rectangle big_to = {13,13,337,265};
+	// I correct the values to make the display ok
+	// but I am not sure what are the correct values
+	rectangle big_to = {13+2,13+14,337+3,265+15};
+	//rectangle big_to = {13,13,337,265};
 	bool same_mask = true;
 	if(!get_bool_pref("DrawTerrainFrills", true) || fog_lifted)
 		return;
@@ -211,7 +214,9 @@ void apply_light_mask(bool onWindow) {
 	for(short i = 1; i < 12; i++)
 		for(short j = 1; j < 12; j++) {
 			if(light_area[i][j] == 2) {
-				int xOffset = 13 + 28 * (i - 3), yOffset = 13 + 36 * (j - 3);
+				// UNSURE WHY 28+...,18+... seems to gives better result that 13+...,13+...
+				int xOffset = 28 + 28 * (i - 3), yOffset = 18 + 36 * (j - 3);
+				//int xOffset = 13 + 28 * (i - 3), yOffset = 13 + 36 * (j - 3);
 				Region oval_region;
 				oval_region.addEllipse(temp);
 				oval_region.offset(xOffset, yOffset);

--- a/src/game/boe.newgraph.cpp
+++ b/src/game/boe.newgraph.cpp
@@ -214,9 +214,7 @@ void apply_light_mask(bool onWindow) {
 	for(short i = 1; i < 12; i++)
 		for(short j = 1; j < 12; j++) {
 			if(light_area[i][j] == 2) {
-				// UNSURE WHY 28+...,18+... seems to gives better result that 13+...,13+...
 				int xOffset = 28 + 28 * (i - 3), yOffset = 18 + 36 * (j - 3);
-				//int xOffset = 13 + 28 * (i - 3), yOffset = 13 + 36 * (j - 3);
 				Region oval_region;
 				oval_region.addEllipse(temp);
 				oval_region.offset(xOffset, yOffset);
@@ -224,7 +222,8 @@ void apply_light_mask(bool onWindow) {
 			}
 			if(light_area[i][j] == 3) {
 				paint_rect = base_rect;
-				paint_rect.offset(13 + 28 * (i - 2),13 + 36 * (j - 2));
+				int xOffset = 13 + 28 * (i - 2), yOffset = 13 + 36 * (j - 2);
+				paint_rect.offset(xOffset, yOffset);
 				paint_rect.right += 28;
 				paint_rect.bottom += 36;
 				Region temp_rect_rgn;

--- a/src/game/boe.newgraph.cpp
+++ b/src/game/boe.newgraph.cpp
@@ -152,7 +152,7 @@ void apply_unseen_mask() {
 
 void apply_light_mask(bool onWindow) {
 	static Region dark_mask_region;
-	rectangle temp = {0,0,108,84},paint_rect,base_rect = {0,0,36,28};
+	rectangle base_ellipse = {0,0,106,84},paint_rect,base_rect = {0,0,36,28};
 	// I correct the values to make the display ok
 	// but I am not sure what are the correct values
 	rectangle big_to = {13+2,13+14,337+3,265+15};
@@ -214,9 +214,9 @@ void apply_light_mask(bool onWindow) {
 	for(short i = 1; i < 12; i++)
 		for(short j = 1; j < 12; j++) {
 			if(light_area[i][j] == 2) {
-				int xOffset = 28 + 28 * (i - 3), yOffset = 18 + 36 * (j - 3);
+				int xOffset = 28 + 28 * (i - 3), yOffset = 16 + 36 * (j - 3);
 				Region oval_region;
-				oval_region.addEllipse(temp);
+				oval_region.addEllipse(base_ellipse);
 				oval_region.offset(xOffset, yOffset);
 				dark_mask_region -= oval_region;
 			}


### PR DESCRIPTION
Fix #493 

Fosnola had fixed part of the light mask visual errors having to do with the offsets for the overall rectangle and the ellipses.

<details> 
  <summary>Before</summary>
   
![image](https://github.com/user-attachments/assets/6b5164d6-a702-4b41-8fd4-bdad7dd9d0e9)

![image](https://github.com/user-attachments/assets/0c141b43-d6c1-4156-908f-86cb96f43505)
</details>

After:

<img width="424" alt="Screenshot 2024-11-30 at 2 00 01 PM" src="https://github.com/user-attachments/assets/aae9c8a7-0109-4879-b653-fb035a475eff">

In my opinion there are still some oddities in the light mask system (see #509), but this is an absolute improvement and the other problems are much more complicated, so this should just go in.

