### PR TITLE
Cancel look & talk targeting modes. Escape key to cancel anything.

### DIFF
--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -376,8 +376,13 @@ void handle_begin_talk(bool& need_reprint) {
 	if(recording){
 		record_action("handle_begin_talk", "");
 	}
-	overall_mode = MODE_TALK_TOWN;
-	add_string_to_buf("Talk: Select someone.");
+	if(overall_mode == MODE_TALK_TOWN){
+		overall_mode = MODE_TOWN;
+		add_string_to_buf("  Cancelled.");
+	}else if(overall_mode == MODE_TOWN){
+		overall_mode = MODE_TALK_TOWN;
+		add_string_to_buf("Talk: Select someone.");
+	}
 	need_reprint = true;
 }
 
@@ -1395,7 +1400,7 @@ bool handle_action(const sf::Event& event, cFramerateLimiter& fps_limiter) {
 				break;
 				
 			case TOOLBAR_TALK:
-				if(overall_mode == MODE_TOWN)
+				if(overall_mode == MODE_TOWN || overall_mode == MODE_TALK_TOWN)
 					handle_begin_talk(need_reprint);
 				break;
 				
@@ -2541,7 +2546,7 @@ bool handle_keystroke(const sf::Event& event, cFramerateLimiter& fps_limiter){
 			break;
 			
 		case 't': // Talk
-			if(overall_mode == MODE_TOWN) {
+			if(overall_mode == MODE_TOWN || overall_mode == MODE_TALK_TOWN) {
 				handle_begin_talk(need_reprint);
 				advance_time(did_something, need_redraw, need_reprint);
 			}

--- a/src/game/boe.actions.hpp
+++ b/src/game/boe.actions.hpp
@@ -60,7 +60,7 @@ void handle_parry(bool& did_something, bool& need_redraw, bool& need_reprint);
 void show_dialog_action(std::string xml_file);
 void handle_new_pc_graphic();
 void handle_rename_pc();
-void handle_begin_look(bool right_button, bool& need_redraw);
+void handle_begin_look(bool right_button, bool& need_redraw, bool& need_reprint);
 void handle_look(location destination, bool right_button, eKeyMod mods, bool& need_redraw, bool& need_reprint);
 void screen_shift(int dx, int dy, bool& need_redraw);
 void handle_rest(bool& need_redraw, bool& need_reprint);

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -434,7 +434,7 @@ static void replay_next_action() {
 		return;
 	}else if(t == "handle_begin_look"){
 		bool right_button = str_to_bool(next_action.GetText());
-		handle_begin_look(right_button, need_redraw);
+		handle_begin_look(right_button, need_redraw, need_reprint);
 		if (right_button){
 			return;
 		}

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -938,8 +938,6 @@ void queue_fake_event(const sf::Event& event) {
 	fake_event_queue.push_back(event);
 }
 
-
-
 void handle_one_minimap_event(const sf::Event& event) {
 	if(event.type == sf::Event::Closed) {
 		close_map(true);

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -944,11 +944,21 @@ void handle_one_minimap_event(const sf::Event& event) {
 	} else if(event.type == sf::Event::GainedFocus) {
 		makeFrontWindow(mainPtr);
 	} else if(event.type == sf::Event::KeyPressed) {
-		switch(event.key.code) {
+		switch(event.key.code){
 			case sf::Keyboard::Escape:
 				close_map(true);
+				return;
 				break;
 			default: break;
+		}
+		char chr = keyToChar(event.key.code, event.key.shift);
+		switch(chr){
+			case 'a':
+				close_map(true);
+				return;
+				break;
+			default:
+				break;
 		}
 	}
 }

--- a/src/game/boe.town.cpp
+++ b/src/game/boe.town.cpp
@@ -1537,6 +1537,7 @@ bool is_door(location destination) {
 	return false;
 }
 
+extern void close_map(bool record);
 
 void display_map() {
 	if(recording){
@@ -1549,8 +1550,12 @@ void display_map() {
 		return;
 	}
 
-	// Show the automap if it's not already visible
-	if(map_visible) return;
+	// Hide the automap if it's already visible
+	if(map_visible){
+		close_map(false);
+		return;
+	}
+
 	give_help(62,0);
 	
 	rectangle the_rect;


### PR DESCRIPTION
Look and talk targeting can be canceled now.

Escape will cancel any mode targeting in progress.

And since re-typing a letter cancels everything else, I made the map act the same ('a' to toggle)