### PR TITLE
LOG function and LOG_VALUE macro will save time and wrist exertion

### DIFF
--- a/src/game/boe.graphics.cpp
+++ b/src/game/boe.graphics.cpp
@@ -3,7 +3,6 @@
 #include <cstdio>
 #include <list>
 #include <unordered_map>
-#include <string>
 #include <memory>
 
 #include "boe.global.hpp"

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -10,6 +10,7 @@
 #define BOE_PCH
 
 #include <string>
+#include <iostream>
 
 typedef unsigned short mon_num_t;
 typedef signed short miss_num_t;
@@ -40,5 +41,11 @@ inline bool str_to_bool(std::string str) {
 inline std::string bool_to_str(bool b) {
 	return b ? "true" : "false";
 }
+
+inline void LOG(std::string line) {
+	std::cout << line << std::endl;
+}
+
+#define LOG_VALUE(x) std::cout << #x << ": " << x << std::endl;
 
 #endif


### PR DESCRIPTION
I'm constantly typing the same debug boilerplate:

`std::cout << "var: " << var << std::endl;`

It gets ridiculous and I really want to reduce keystrokes because my wrists hurt.

I found that you can simplify this with a preprocessor macro. It works with variables, and also arbitrary expressions, which is cool. I called that macro LOG_VALUE and put it in global.hpp.

For a similar purpose, I made a global function that logs a line of text (std::string) and I named it LOG (uppercase to match the macro--I think it just makes sense to have temporary log statements jump out at you when reading/diffing code.)