### PR TITLE
Replay system improvement/refactor

### DIFF
--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -303,23 +303,22 @@ static void process_args(int argc, char* argv[]) {
 	}
 }
 
-static void replay_next_action() {
+void replay_action(Element& action) {
 	bool did_something = false, need_redraw = false, need_reprint = false;
 
 	std::string _last_action_type = last_action_type;
-	Element& next_action = pop_next_action();
-	std::string t = next_action.Value();
+	std::string t = action.Value();
 	int enum_v;
 	
 	// NOTE: Action replay blocks need to return early unless the action advances time
 	if(overall_mode == MODE_STARTUP && t == "startup_button_click"){
-		auto info = info_from_action(next_action);
+		auto info = info_from_action(action);
 		eStartButton btn = static_cast<eStartButton>(std::stoi(info["btn"]));
 		eKeyMod mods = static_cast<eKeyMod>(std::stoi(info["mods"]));
 		handle_startup_button_click(btn, mods);
 		return;
 	}else if(t == "load_party"){
-		decode_file(next_action.GetText(), tempDir / "temp.exg");
+		decode_file(action.GetText(), tempDir / "temp.exg");
 		load_party(tempDir / "temp.exg", univ);
 
 		finish_load_party();
@@ -330,25 +329,25 @@ static void replay_next_action() {
 		menu_activate();
 		return;
 	}else if(t == "move"){
-		location l = location_from_action(next_action);
+		location l = location_from_action(action);
 		handle_move(l, did_something, need_redraw, need_reprint);
 	}else if(t == "handle_switch_pc"){
-		short which_pc = short_from_action(next_action);
+		short which_pc = short_from_action(action);
 		handle_switch_pc(which_pc, need_redraw, need_reprint);
 	}else if(t == "handle_switch_pc_items"){
-		short which_pc = short_from_action(next_action);
+		short which_pc = short_from_action(action);
 		handle_switch_pc_items(which_pc, need_redraw);
 		update_item_stats_area(need_reprint);
 	}else if(t == "handle_equip_item"){
-		short item_hit = short_from_action(next_action);
+		short item_hit = short_from_action(action);
 		handle_equip_item(item_hit, need_redraw);
 		update_item_stats_area(need_reprint);
 	}else if(t == "handle_use_item"){
-		short item_hit = short_from_action(next_action);
+		short item_hit = short_from_action(action);
 		handle_use_item(item_hit, did_something, need_redraw);
 		update_item_stats_area(need_reprint);
 	}else if(t == "handle_item_shop_action"){
-		short item_hit = short_from_action(next_action);
+		short item_hit = short_from_action(action);
 		handle_item_shop_action(item_hit);
 		update_item_stats_area(need_reprint);
 	}else if(t == "handle_alchemy"){
@@ -364,25 +363,25 @@ static void replay_next_action() {
 	}else if(t == "handle_get_items"){
 		handle_get_items(did_something, need_redraw, need_reprint);
 	}else if(t == "handle_drop_item_id"){
-		short item_hit = short_from_action(next_action);
+		short item_hit = short_from_action(action);
 		handle_drop_item(item_hit, need_redraw);
 		update_item_stats_area(need_reprint);
 	}else if(t == "handle_drop_item_location"){
-		location destination = location_from_action(next_action);
+		location destination = location_from_action(action);
 		handle_drop_item(destination, need_redraw);
 	}else if(t == "handle_give_item"){
-		short item_hit = short_from_action(next_action);
+		short item_hit = short_from_action(action);
 		handle_give_item(item_hit, did_something, need_redraw);
 		update_item_stats_area(need_reprint);
 	}else if(t == "close_window"){
 		handle_quit_event();
 		return;
 	}else if(t == "arrow_button_click"){
-		rectangle button_rect = boost::lexical_cast<rectangle>(next_action.GetText());
+		rectangle button_rect = boost::lexical_cast<rectangle>(action.GetText());
 		arrow_button_click(button_rect);
 		return;
 	}else if(t == "show_dialog_action"){
-		show_dialog_action(next_action.GetText());
+		show_dialog_action(action.GetText());
 		return;
 	}else if(t == "handle_drop_pc"){
 		handle_drop_pc();
@@ -421,14 +420,14 @@ static void replay_next_action() {
 		display_alchemy();
 		return;
 	}else if(t == "display_spells"){
-		auto info = info_from_action(next_action);
+		auto info = info_from_action(action);
 		eSkill mode = boost::lexical_cast<eSkill>(info["mode"]);
 		short force_spell = boost::lexical_cast<short>(info["force_spell"]);
 
 		display_spells(mode, force_spell, nullptr);
 		return;
 	}else if(t == "display_skills"){
-		eSkill force_skill = boost::lexical_cast<eSkill>(next_action.GetText());
+		eSkill force_skill = boost::lexical_cast<eSkill>(action.GetText());
 
 		display_skills(force_skill, nullptr);
 		return;
@@ -445,24 +444,24 @@ static void replay_next_action() {
 		handle_help_toc();
 		return;
 	}else if(t == "menu_give_help"){
-		short help1 = short_from_action(next_action);
+		short help1 = short_from_action(action);
 		menu_give_help(help1);
 		return;
 	}else if(t == "handle_begin_look"){
-		bool right_button = str_to_bool(next_action.GetText());
+		bool right_button = str_to_bool(action.GetText());
 		handle_begin_look(right_button, need_redraw, need_reprint);
 		if (right_button){
 			return;
 		}
 	}else if(t == "handle_look"){
-		auto info = info_from_action(next_action);
+		auto info = info_from_action(action);
 		location destination = boost::lexical_cast<location>(info["destination"]);
 		bool right_button = str_to_bool(info["right_button"]);
 		eKeyMod mods = static_cast<eKeyMod>(std::stoi(info["mods"]));
 
 		handle_look(destination, right_button, mods, need_redraw, need_reprint);
 	}else if(t == "screen_shift"){
-		auto info = info_from_action(next_action);
+		auto info = info_from_action(action);
 		int dx = std::stoi(info["dx"]);
 		int dy = std::stoi(info["dy"]);
 
@@ -470,17 +469,17 @@ static void replay_next_action() {
 	}else if(t == "handle_rest"){
 		handle_rest(need_redraw, need_reprint);
 	}else if(t == "handle_menu_spell"){
-		eSpell spell_picked = static_cast<eSpell>(std::stoi(next_action.GetText()));
+		eSpell spell_picked = static_cast<eSpell>(std::stoi(action.GetText()));
 		handle_menu_spell(spell_picked);
 		return;
 	}else if(t == "handle_spellcast"){
-		auto info = info_from_action(next_action);
+		auto info = info_from_action(action);
 		eSkill which_type = boost::lexical_cast<eSkill>(info["which_type"]);
 		spell_forced = str_to_bool(info["spell_forced"]);
 
 		handle_spellcast(which_type, did_something, need_redraw, need_reprint);
 	}else if(t == "handle_target_space"){
-		auto info = info_from_action(next_action);
+		auto info = info_from_action(action);
 		location destination = boost::lexical_cast<location>(info["destination"]);
 		num_targets_left = boost::lexical_cast<short>(info["num_targets_left"]);
 
@@ -497,21 +496,21 @@ static void replay_next_action() {
 		handle_bash_pick_select(need_reprint, false);
 		return;
 	}else if(t == "handle_bash"){
-		location destination = location_from_action(next_action);
+		location destination = location_from_action(action);
 		handle_bash_pick(destination, did_something, need_redraw, true);
 	}else if(t == "handle_pick"){
-		location destination = location_from_action(next_action);
+		location destination = location_from_action(action);
 		handle_bash_pick(destination, did_something, need_redraw, false);
 	}else if(t == "handle_use_space_select"){
 		handle_use_space_select(need_reprint);
 	}else if(t == "handle_use_space"){
-		location destination = location_from_action(next_action);
+		location destination = location_from_action(action);
 		handle_use_space(destination, did_something, need_redraw);
 	}else if(t == "show_inventory"){
 		show_inventory();
 		return;
 	}else if(t == "give_help"){
-		auto info = info_from_action(next_action);
+		auto info = info_from_action(action);
 		short help1 = boost::lexical_cast<short>(info["help1"]);
 		short help2 = boost::lexical_cast<short>(info["help2"]);
 		give_help(help1, help2);
@@ -576,32 +575,32 @@ static void replay_next_action() {
 		debug_heal_plus_extra();
 		return;
 	}else if(t == "handle_print_pc_hp"){
-		handle_print_pc_hp(boost::lexical_cast<int>(next_action.GetText()), need_reprint);
+		handle_print_pc_hp(boost::lexical_cast<int>(action.GetText()), need_reprint);
 	}else if(t == "handle_print_pc_sp"){
-		handle_print_pc_sp(boost::lexical_cast<int>(next_action.GetText()), need_reprint);
+		handle_print_pc_sp(boost::lexical_cast<int>(action.GetText()), need_reprint);
 	}else if(t == "give_pc_info"){
-		give_pc_info(boost::lexical_cast<short>(next_action.GetText()));
+		give_pc_info(boost::lexical_cast<short>(action.GetText()));
 		return;
 	}else if(t == "handle_trade_places"){
-		handle_trade_places(boost::lexical_cast<short>(next_action.GetText()), need_reprint);
+		handle_trade_places(boost::lexical_cast<short>(action.GetText()), need_reprint);
 	}else if(t == "handle_begin_talk"){
 		handle_begin_talk(need_reprint);
 	}else if(t == "handle_talk"){
-		handle_talk(location_from_action(next_action), did_something, need_redraw, need_reprint);
+		handle_talk(location_from_action(action), did_something, need_redraw, need_reprint);
 	}else if(t == "click_talk_rect"){
-		word_rect_t word_rect = word_rect_from_action(next_action);
+		word_rect_t word_rect = word_rect_from_action(action);
 		click_talk_rect(word_rect);
 		handle_talk_node(word_rect.node);
 		return;
 	}else if(t == "click_shop_rect"){
-		rectangle rect = boost::lexical_cast<rectangle>(next_action.GetText());
+		rectangle rect = boost::lexical_cast<rectangle>(action.GetText());
 		click_shop_rect(rect);
 		return;
 	}else if(t == "end_shop_mode"){
 		end_shop_mode();
 		return;
 	}else if(t == "scrollbar_setPosition"){
-		auto info = info_from_action(next_action);
+		auto info = info_from_action(action);
 		std::string name = info["name"];
 		long newPos = boost::lexical_cast<long>(info["newPos"]);
 
@@ -609,19 +608,19 @@ static void replay_next_action() {
 		sbar->setPosition(newPos);
 		return;
 	}else if(t == "use_spec_item"){
-		use_spec_item(boost::lexical_cast<short>(next_action.GetText()), need_redraw);
+		use_spec_item(boost::lexical_cast<short>(action.GetText()), need_redraw);
 		update_item_stats_area(need_reprint);
 	}else if(t == "show_item_info"){
-		show_item_info(boost::lexical_cast<short>(next_action.GetText()));
+		show_item_info(boost::lexical_cast<short>(action.GetText()));
 		update_item_stats_area(need_reprint);
 		return;
 	}else if(t == "set_stat_window"){
-		set_stat_window(static_cast<eItemWinMode>(boost::lexical_cast<int>(next_action.GetText())));
+		set_stat_window(static_cast<eItemWinMode>(boost::lexical_cast<int>(action.GetText())));
 		update_item_stats_area(need_reprint);
 	}else if(t == "handle_sale"){
-		handle_sale(boost::lexical_cast<int>(next_action.GetText()));
+		handle_sale(boost::lexical_cast<int>(action.GetText()));
 	}else if(t == "handle_info_request"){
-		handle_info_request(boost::lexical_cast<int>(next_action.GetText()));
+		handle_info_request(boost::lexical_cast<int>(action.GetText()));
 	}else if(t == "close_map"){
 		close_map(true);
 		return;
@@ -630,7 +629,7 @@ static void replay_next_action() {
 	}else if(t == "handle_parry"){
 		handle_parry(did_something, need_redraw, need_reprint);
 	}else if(t == "handle_monster_info_menu"){
-		handle_monster_info_menu(boost::lexical_cast<int>(next_action.GetText()));
+		handle_monster_info_menu(boost::lexical_cast<int>(action.GetText()));
 		return;
 	}else if(t == "cancel_item_target"){
 		cancel_item_target(did_something, need_redraw, need_reprint);
@@ -639,12 +638,16 @@ static void replay_next_action() {
 		throw std::string { "Replay system internal error! advance_time() was supposed to be called by the last action, but wasn't: " } + _last_action_type;
 	}else{
 		std::ostringstream sstr;
-		sstr << "Couldn't replay action: " << next_action;
+		sstr << "Couldn't replay action: " << action;
 		throw sstr.str();
 	}
 
 	// NOTE: commands that do not advance time must return early
 	advance_time(did_something, need_redraw, need_reprint);
+}
+
+static void replay_next_action() {
+	replay_action(pop_next_action());
 }
 
 void init_boe(int argc, char* argv[]) {

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -122,6 +122,8 @@ extern long anim_ticks;
 static void init_boe(int, char*[]);
 static void showWelcome();
 
+static void replay_next_action();
+
 void handle_quit_event();
 void handle_help_toc();
 void menu_give_help(short help1);
@@ -277,15 +279,20 @@ static void process_args(int argc, char* argv[]) {
 			extern boost::optional<cFramerateLimiter> replay_fps_limit;
 			replay_fps_limit.emplace(*replay_speed);
 		}
+		// Handle replays that loaded a savegame from the command line
+		if(has_next_action("load_party")){
+			replay_next_action();
+		}
 		return;
 	}
-	if(record_to){
+	else if(record_to){
 		if(!init_action_log(record_unique || record_to->empty() ? "record-unique" : "record", *record_to)){
 			std::cerr << "Failed to start recording: " << *record_to << std::endl;
 			exit(1);
 		}
-		return;
+		// Don't return, because we want to support recording a run that starts with a party from the CLI.
 	}
+
 	if(saved_game) {
 		if(!load_party(*saved_game, univ)) {
 			std::cout << "Failed to load save file: " << *saved_game << std::endl;

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -262,11 +262,27 @@ static void process_args(int argc, char* argv[]) {
 		cli.writeToStream(std::cout);
 		exit(0);
 	}
-	if(record_to && init_action_log(record_unique || record_to->empty() ? "record-unique" : "record", *record_to)) return;
-	if(replay && init_action_log("replay", *replay)) {
+	if(replay){
+		if(record_to){
+			std::cout << "Warning: flag --record conflicts with --replay and will be ignored." << std::endl;
+		}
+		if(saved_game){
+			std::cout << "Warning: save file argument conflicts with --replay and will be ignored." << std::endl;
+		}
+		if(!init_action_log("replay", *replay)) {
+			std::cerr << "Failed to load replay: " << *replay << std::endl;
+			exit(1);
+		}
 		if(replay_speed) {
 			extern boost::optional<cFramerateLimiter> replay_fps_limit;
 			replay_fps_limit.emplace(*replay_speed);
+		}
+		return;
+	}
+	if(record_to){
+		if(!init_action_log(record_unique || record_to->empty() ? "record-unique" : "record", *record_to)){
+			std::cerr << "Failed to start recording: " << *record_to << std::endl;
+			exit(1);
 		}
 		return;
 	}

--- a/src/tools/replay.cpp
+++ b/src/tools/replay.cpp
@@ -110,6 +110,7 @@ bool init_action_log(std::string command, std::string file) {
 			replaying = true;
 		} catch(...) {
 			std::cout << "Failed to load file " << file << std::endl;
+			return false;
 		}
 		return true;
 	}


### PR DESCRIPTION
* Makes the replay system `exit(1)` with an error message if it can't initialize the action log.
* Refactor the `replay_next_action()` function so we could theoretically pass arbitrary generated actions, or store actions from `pop_next_action()` to process out of order.
* Allow recording a session that starts with loading a party from CLI