### PR TITLE
D flag for shops is now ignored

### DIFF
--- a/src/game/boe.dlgutil.cpp
+++ b/src/game/boe.dlgutil.cpp
@@ -884,10 +884,6 @@ void handle_talk_node(int which_talk_entry) {
 			return;
 			
 		case eTalkNode::SHOP:
-			if(d < 0 || d > 11) {
-				showError("Invalid shop type!");
-				return;
-			}
 			start_shop_mode(b,a,save_talk_str1);
 			can_save_talk = false;
 			return;


### PR DESCRIPTION
Creating a new scenario in the current editor and giving it a shop, the editor defaults the extra D flag to something that would have been invalid back when shops weren't unified under one node type.

This should be fine, but the check for a valid D value was left in. So any shop created in the current editor would throw an error despite being valid. I removed the check.