### PR TITLE
Cancel item target

### DIFF
--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -1006,7 +1006,11 @@ void handle_item_shop_action(short item_hit) {
 				target.ident = true;
 				shopper.combine_things();
 				if(overall_mode == MODE_ITEM_TARGET) {
-					// TODO: End if there are no unidentified items left
+					if(all_items_identified()){
+						overall_mode = MODE_TOWN;
+						stat_screen_mode = MODE_INVEN;
+						ASB("Identify: All of your items are identified.");
+					}
 				}
 			}
 			break;

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -1006,7 +1006,7 @@ void handle_item_shop_action(short item_hit) {
 				target.ident = true;
 				shopper.combine_things();
 				if(overall_mode == MODE_ITEM_TARGET) {
-					if(all_items_identified()){
+					if(univ.party.all_items_identified()){
 						overall_mode = MODE_TOWN;
 						stat_screen_mode = MODE_INVEN;
 						ASB("Identify: All of your items are identified.");

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2277,6 +2277,11 @@ bool handle_keystroke(const sf::Event& event, cFramerateLimiter& fps_limiter){
 			case MODE_THROWING:
 				handle_missile(need_redraw, need_reprint);
 				break;
+			// Cancel item target
+			case MODE_ITEM_TARGET:
+				cancel_item_target(did_something, need_redraw, need_reprint);
+				advance_time(did_something, need_redraw, need_reprint);
+				break;
 
 			// Defer to closing the map:
 			default:

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -605,11 +605,9 @@ void do_mage_spell(short pc_num,eSpell spell_num,bool freebie) {
 				if(all_identified){
 					sstr << "already ";
 				}else{
-					for(cPlayer& pc : univ.party){
+					for(cPlayer& pc : univ.party)
 						for(cItem& item : pc.items)
 							item.ident = true;
-						pc.combine_things();
-					}
 				}
 				sstr << "identified.";
 				ASB(sstr.str());

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -585,6 +585,7 @@ void do_mage_spell(short pc_num,eSpell spell_num,bool freebie) {
 			break;
 			
 		case eSpell::IDENTIFY:
+			// TODO: Cancel without spending points if there are no unidentified items
 			if(!freebie)
 				univ.party[pc_num].cur_sp -= (*spell_num).cost;
 			if(!univ.scenario.is_legacy && is_town()) {

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -609,9 +609,11 @@ void do_mage_spell(short pc_num,eSpell spell_num,bool freebie) {
 				if(all_identified){
 					sstr << "already ";
 				}else{
-					for(cPlayer& pc : univ.party)
+					for(cPlayer& pc : univ.party){
 						for(cItem& item : pc.items)
 							item.ident = true;
+						pc.combine_things();
+					}
 				}
 				sstr << "identified.";
 				ASB(sstr.str());

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -585,11 +585,7 @@ void do_mage_spell(short pc_num,eSpell spell_num,bool freebie) {
 			break;
 			
 		case eSpell::IDENTIFY:{
-			bool all_identified = true;
-			for(cPlayer& pc : univ.party)
-				for(cItem& item : pc.items)
-					if (item.variety != eItemType::NO_ITEM)
-						all_identified = all_identified && item.ident;
+			bool all_identified = all_items_identified();
 
 			// Cancel without spending points if there are no unidentified items
 			if(!(freebie || all_identified))
@@ -2623,4 +2619,13 @@ short party_size(bool only_living) {
 	
 	return num_pcs;
 	
+}
+
+bool all_items_identified() {
+	bool all_identified = true;
+	for(cPlayer& pc : univ.party)
+		for(cItem& item : pc.items)
+			if (item.variety != eItemType::NO_ITEM)
+				all_identified &= item.ident;
+	return all_identified;
 }

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -585,18 +585,31 @@ void do_mage_spell(short pc_num,eSpell spell_num,bool freebie) {
 			break;
 			
 		case eSpell::IDENTIFY:
-			// TODO: Cancel without spending points if there are no unidentified items
-			if(!freebie)
+			bool all_identified = true;
+			for(cPlayer& pc : univ.party)
+				for(cItem& item : pc.items)
+					all_identified &= item.ident;
+
+			// Cancel without spending points if there are no unidentified items
+			if(!(freebie || all_identified))
 				univ.party[pc_num].cur_sp -= (*spell_num).cost;
-			if(!univ.scenario.is_legacy && is_town()) {
-				ASB("Select items to identify. Press Space when done.");
+
+			if(!univ.scenario.is_legacy && is_town() && !all_identified) {
+				ASB("Select items to identify. Press Space");
+				ASB("   when done.");
 				overall_mode = MODE_ITEM_TARGET;
 				stat_screen_mode = MODE_IDENTIFY;
 				shop_identify_cost = 0;
 				put_item_screen(stat_window);
 				break;
 			}
-			ASB("All of your items are identified.");
+			std::ostringstream sstr;
+			sstr << "All of your items are ";
+			if(all_identified){
+				sstr << "already ";
+			}
+			sstr << "identified.";
+			ASB(sstr.str(););
 			for(cPlayer& pc : univ.party)
 				for(cItem& item : pc.items)
 					item.ident = true;

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -585,7 +585,7 @@ void do_mage_spell(short pc_num,eSpell spell_num,bool freebie) {
 			break;
 			
 		case eSpell::IDENTIFY:{
-			bool all_identified = all_items_identified();
+			bool all_identified = univ.party.all_items_identified();
 
 			// Cancel without spending points if there are no unidentified items
 			if(!(freebie || all_identified))
@@ -2619,13 +2619,4 @@ short party_size(bool only_living) {
 	
 	return num_pcs;
 	
-}
-
-bool all_items_identified() {
-	bool all_identified = true;
-	for(cPlayer& pc : univ.party)
-		for(cItem& item : pc.items)
-			if (item.variety != eItemType::NO_ITEM)
-				all_identified &= item.ident;
-	return all_identified;
 }

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -621,7 +621,8 @@ void do_mage_spell(short pc_num,eSpell spell_num,bool freebie) {
 			if(!freebie)
 				univ.party[pc_num].cur_sp -= (*spell_num).cost;
 			if(is_town()) {
-				ASB("Select items to recharge. Press Space when done.");
+				ASB("Select items to recharge. Press Space");
+				ASB("   when done.");
 				overall_mode = MODE_ITEM_TARGET;
 				stat_screen_mode = MODE_RECHARGE;
 				shop_identify_cost = 0;

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -584,11 +584,12 @@ void do_mage_spell(short pc_num,eSpell spell_num,bool freebie) {
 			increase_light(50);
 			break;
 			
-		case eSpell::IDENTIFY:
+		case eSpell::IDENTIFY:{
 			bool all_identified = true;
 			for(cPlayer& pc : univ.party)
 				for(cItem& item : pc.items)
-					all_identified &= item.ident;
+					if (item.variety != eItemType::NO_ITEM)
+						all_identified = all_identified && item.ident;
 
 			// Cancel without spending points if there are no unidentified items
 			if(!(freebie || all_identified))
@@ -602,18 +603,21 @@ void do_mage_spell(short pc_num,eSpell spell_num,bool freebie) {
 				shop_identify_cost = 0;
 				put_item_screen(stat_window);
 				break;
+			}else{
+				std::ostringstream sstr;
+				sstr << "All of your items are ";
+				if(all_identified){
+					sstr << "already ";
+				}else{
+					for(cPlayer& pc : univ.party)
+						for(cItem& item : pc.items)
+							item.ident = true;
+				}
+				sstr << "identified.";
+				ASB(sstr.str());
 			}
-			std::ostringstream sstr;
-			sstr << "All of your items are ";
-			if(all_identified){
-				sstr << "already ";
-			}
-			sstr << "identified.";
-			ASB(sstr.str(););
-			for(cPlayer& pc : univ.party)
-				for(cItem& item : pc.items)
-					item.ident = true;
 			break;
+		}
 
 		case eSpell::RECHARGE:
 			if(!freebie)

--- a/src/game/boe.party.hpp
+++ b/src/game/boe.party.hpp
@@ -48,6 +48,7 @@ short wilderness_lore_present(ter_num_t ter);
 void print_spell_cast(eSpell spell,eSkill which);
 void put_party_in_scen(std::string scen_name);
 short party_size(bool only_living);
+bool all_items_identified();
 
 // This is defined in pc.editors.cpp since it is also used by the character editor
 bool spend_xp(short pc_num, short mode, cDialog* parent);

--- a/src/pcedit/pc.action.cpp
+++ b/src/pcedit/pc.action.cpp
@@ -77,6 +77,7 @@ bool handle_action(const sf::Event & event) {
 		   univ.party[current_active_pc].items[i].variety != eItemType::NO_ITEM) {
 			flash_rect(item_string_rects[i][2]);
 			univ.party[current_active_pc].items[i].ident = true;
+			univ.party[current_active_pc].combine_things();
 		}
 	}
 	

--- a/src/pcedit/pc.action.cpp
+++ b/src/pcedit/pc.action.cpp
@@ -77,7 +77,6 @@ bool handle_action(const sf::Event & event) {
 		   univ.party[current_active_pc].items[i].variety != eItemType::NO_ITEM) {
 			flash_rect(item_string_rects[i][2]);
 			univ.party[current_active_pc].items[i].ident = true;
-			univ.party[current_active_pc].combine_things();
 		}
 	}
 	

--- a/src/universe/party.cpp
+++ b/src/universe/party.cpp
@@ -617,6 +617,15 @@ bool cParty::forced_give(cItem item,eItemAbil abil,short dat) {
 	return false;
 }
 
+bool cParty::all_items_identified() {
+	bool all_identified = true;
+	for(cPlayer& pc : *this)
+		for(cItem& item : pc.items)
+			if (item.variety != eItemType::NO_ITEM)
+				all_identified &= item.ident;
+	return all_identified;
+}
+
 bool cParty::has_abil(eItemAbil abil, short dat) const {
 	for(int i = 0; i < 6; i++)
 		if(adven[i]->main_status == eMainStatus::ALIVE)

--- a/src/universe/party.hpp
+++ b/src/universe/party.hpp
@@ -201,6 +201,7 @@ public:
 	
 	bool give_item(cItem item,int flags);
 	bool forced_give(cItem item,eItemAbil abil,short dat = -1);
+	bool all_items_identified();
 	bool has_abil(eItemAbil abil, short dat = -1) const;
 	bool take_abil(eItemAbil abil, short dat = -1);
 	bool has_class(unsigned int item_class, bool require_charges = false);


### PR DESCRIPTION
I forgot to have Escape cancel item target mode.

While I'm at it, I want to make identification cancel in advance if there are no unidentified items, and it should end after identifying the last item (as was TODO noted).