### PR TITLE
remove the cancel button in case where it would be ignored

### DIFF
--- a/src/dialogxml/dialogs/pictchoice.cpp
+++ b/src/dialogxml/dialogs/pictchoice.cpp
@@ -157,3 +157,7 @@ ePicType cPictChoice::getPicChosenType() const {
 size_t cPictChoice::getSelected() const {
 	return cur;
 }
+
+void cPictChoice::disableCancel() {
+	dlg["cancel"].hide();
+}

--- a/src/dialogxml/dialogs/pictchoice.hpp
+++ b/src/dialogxml/dialogs/pictchoice.hpp
@@ -75,6 +75,8 @@ public:
 	/// Get the index of the selected icon in the original list.
 	/// @return The index
 	size_t getSelected() const;
+	/// Disallow the player from cancelling without making a choice
+	void disableCancel();
 };
 
 #endif

--- a/src/game/boe.dlgutil.cpp
+++ b/src/game/boe.dlgutil.cpp
@@ -1589,6 +1589,7 @@ class cChooseScenario {
 public:
 	cChooseScenario() {
 		// TODO: Add a button to jump to the scenarios folder
+		// Note: if the player jumps to the scenarios folder and adds scenarios, build_scen_headers() must be called again
 		scen_headers = build_scen_headers(); // TODO: Either make this local to this class, or make it take scen_headers by reference
 	}
 	scen_header_type run() {

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -216,12 +216,6 @@ bool create_pc(short spot,cDialog* parent) {
 	if(!still_ok)
 		return false;
 	
-	// TODO this can return false if the player cancels the choice.
-	// Currently doing so does not stop the PC from being created.
-	// Which it probably shouldn't, because the player will have
-	// already invested some time assigning race/abilities/skill points.
-	// Probably better to just remove the Cancel button from the PC
-	// graphic dialog in this case.
 	pick_pc_graphic(spot,0,parent);
 
 	pick_pc_name(spot,parent);
@@ -2174,7 +2168,7 @@ eAlchemy alch_choice(short pc_num) {
 	return chooseAlchemy.getResult<eAlchemy>();
 }
 
-// mode ... 0 - create  1 - created
+// mode ... 0 - create new pc  1 - change existing pc graphic
 bool pick_pc_graphic(short pc_num,short mode,cDialog* parent) {
 	store_graphic_pc_num = pc_num;
 	store_graphic_mode = mode;
@@ -2182,6 +2176,12 @@ bool pick_pc_graphic(short pc_num,short mode,cDialog* parent) {
 	set_cursor(sword_curs);
 	
 	cPictChoice pcPic(0,36,PIC_PC,parent);
+	// When creating a new PC, the player has already put time into stat selection, so they won't want to
+	// cancel and lose that work
+	if(mode == 0){
+		pcPic.disableCancel();
+	}
+
 	// Customize it for this special case of choosing a PC graphic
 	dynamic_cast<cPict&>(pcPic->getControl("mainpic")).setPict(7);
 	pcPic->getControl("prompt").setText("Select a graphic for your PC:");


### PR DESCRIPTION
Saw a TODO comment that was trivial to resolve.

Previously: You could click "Cancel" when choosing the graphic for a new PC, but it would create the PC anyway.

Now: You can't click "Cancel" in that situation (which is good because it prevents loss of prior stat choices).