### PR TITLE
Quality of life: Spellcasting

### DIFF
--- a/rsrc/dialogs/cast-spell.xml
+++ b/rsrc/dialogs/cast-spell.xml
@@ -28,12 +28,12 @@
 	<button name='target5' type='small' def-key='shift 5' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'><key/></button>
 	<button name='target6' type='small' def-key='shift 6' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'><key/></button>
 	<!-- To the right of target buttons, green arrows to highlight choice -->
-	<text name='arrow1' relative='neg pos-in' anchor='hp1' top='0' left='20' width='32' height='16' colour='light_green'>-&gt;</text>
-	<text name='arrow2' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_green'>-&gt;</text>
-	<text name='arrow3' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_green'>-&gt;</text>
-	<text name='arrow4' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_green'>-&gt;</text>
-	<text name='arrow5' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_green'>-&gt;</text>
-	<text name='arrow6' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_green'>-&gt;</text>
+	<text name='arrow1' relative='neg pos-in' anchor='hp1' top='0' left='20' width='32' height='16' colour='light-green'>-&gt;</text>
+	<text name='arrow2' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light-green'>-&gt;</text>
+	<text name='arrow3' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light-green'>-&gt;</text>
+	<text name='arrow4' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light-green'>-&gt;</text>
+	<text name='arrow5' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light-green'>-&gt;</text>
+	<text name='arrow6' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light-green'>-&gt;</text>
 	<!-- To the right of target buttons, PC HP -->
 	<text name='hp-head' size='large' relative='pos-in pos-in' anchor='target-head' top='0' left='55' width='223' height='16'>HP:</text>
 	<text name='hp1' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='red'/>
@@ -44,12 +44,12 @@
 	<text name='hp6' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='red'/>
 	<!-- To the right of PC HP, PC SP -->
 	<text name='sp-head' size='large' relative='pos-in pos-in' anchor='hp-head' top='0' left='24' width='223' height='16'>SP:</text>
-	<text name='sp1' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
-	<text name='sp2' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
-	<text name='sp3' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
-	<text name='sp4' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
-	<text name='sp5' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
-	<text name='sp6' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
+	<text name='sp1' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light-blue'/>
+	<text name='sp2' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light-blue'/>
+	<text name='sp3' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light-blue'/>
+	<text name='sp4' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light-blue'/>
+	<text name='sp5' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light-blue'/>
+	<text name='sp6' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light-blue'/>
 	<!-- To the right of PC SP, Status icons -->
 	<!-- Whee... time for the status effects! 15 statuses x 6 PCs! -->
 	<text name='status-head' size='large' relative='pos-in pos-in' anchor='sp-head' top='0' left='24' width='223' height='16'>Status:</text>

--- a/rsrc/dialogs/cast-spell.xml
+++ b/rsrc/dialogs/cast-spell.xml
@@ -23,18 +23,18 @@
 	<text name='pc4' top='156' left='88' width='122' height='16'/>
 	<text name='pc5' top='180' left='88' width='122' height='16'/>
 	<text name='pc6' top='204' left='88' width='122' height='16'/>
-	<text name='hp1' top='85' left='265' width='32' height='16'/>
-	<text name='hp2' top='109' left='265' width='32' height='16'/>
-	<text name='hp3' top='133' left='265' width='32' height='16'/>
-	<text name='hp4' top='156' left='265' width='32' height='16'/>
-	<text name='hp5' top='181' left='265' width='32' height='16'/>
-	<text name='hp6' top='205' left='265' width='32' height='16'/>
-	<text name='sp1' top='85' left='304' width='32' height='16'/>
-	<text name='sp2' top='109' left='304' width='32' height='16'/>
-	<text name='sp3' top='133' left='304' width='32' height='16'/>
-	<text name='sp4' top='156' left='304' width='32' height='16'/>
-	<text name='sp5' top='181' left='304' width='32' height='16'/>
-	<text name='sp6' top='205' left='304' width='32' height='16'/>
+	<text name='hp1' top='85' left='265' width='32' height='16' colour='red'/>
+	<text name='hp2' top='109' left='265' width='32' height='16' colour='red'/>
+	<text name='hp3' top='133' left='265' width='32' height='16' colour='red'/>
+	<text name='hp4' top='156' left='265' width='32' height='16' colour='red'/>
+	<text name='hp5' top='181' left='265' width='32' height='16' colour='red'/>
+	<text name='hp6' top='205' left='265' width='32' height='16' colour='red'/>
+	<text name='sp1' top='85' left='304' width='32' height='16' colour='light_blue'/>
+	<text name='sp2' top='109' left='304' width='32' height='16' colour='light_blue'/>
+	<text name='sp3' top='133' left='304' width='32' height='16' colour='light_blue'/>
+	<text name='sp4' top='156' left='304' width='32' height='16' colour='light_blue'/>
+	<text name='sp5' top='181' left='304' width='32' height='16' colour='light_blue'/>
+	<text name='sp6' top='205' left='304' width='32' height='16' colour='light_blue'/>
 	<text name='feedback' framed='true' top='400' left='30' width='186' height='16'>Pick spell to cast.</text>
 	<led name='spell1' state='off' top='247' left='14'/>
 	<led name='spell2' state='off' top='261' left='14'/>

--- a/rsrc/dialogs/cast-spell.xml
+++ b/rsrc/dialogs/cast-spell.xml
@@ -53,47 +53,111 @@
 	<!-- To the right of PC SP, Status icons -->
 	<text name='status-head' size='large' relative='pos-in pos-in' anchor='sp-head' top='0' left='24' width='223' height='16'>Status:</text>
 
+	<!-- Whee... time for the status effects! Fifteen per PC! -->
+	<pict name='pc1-stat1' type='status' num='0' top='84' left='334'/> <pict name='pc1-stat2' type='status' num='0' top='84' left='347'/>
+	<pict name='pc1-stat3' type='status' num='0' top='84' left='360'/> <pict name='pc1-stat4' type='status' num='0' top='84' left='373'/>
+	<pict name='pc1-stat5' type='status' num='0' top='84' left='386'/> <pict name='pc1-stat6' type='status' num='0' top='84' left='399'/>
+	<pict name='pc1-stat7' type='status' num='0' top='84' left='412'/> <pict name='pc1-stat8' type='status' num='0' top='84' left='425'/>
+	<pict name='pc1-stat9' type='status' num='0' top='84' left='438'/> <pict name='pc1-stat10' type='status' num='0' top='84' left='451'/>
+	<pict name='pc1-stat11' type='status' num='0' top='84' left='464'/><pict name='pc1-stat12' type='status' num='0' top='84' left='477'/>
+	<pict name='pc1-stat13' type='status' num='0' top='84' left='490'/><pict name='pc1-stat14' type='status' num='0' top='84' left='503'/>
+	<pict name='pc1-stat15' type='status' num='0' top='84' left='516'/>
 
-	<text name='feedback' framed='true' top='400' left='30' width='186' height='16'>Pick spell to cast.</text>
-	<led name='spell1' state='off' top='247' left='14'/>
-	<led name='spell2' state='off' top='261' left='14'/>
-	<led name='spell3' state='off' top='275' left='14'/>
-	<led name='spell4' state='off' top='289' left='14'/>
-	<led name='spell5' state='off' top='303' left='14'/>
-	<led name='spell6' state='off' top='317' left='14'/>
-	<led name='spell7' state='off' top='331' left='14'/>
-	<led name='spell8' state='off' top='345' left='14'/>
-	<led name='spell9' state='off' top='359' left='14'/>
-	<led name='spell10' state='off' top='373' left='14'/>
-	<led name='spell11' state='off' top='247' left='177'/>
-	<led name='spell12' state='off' top='261' left='177'/>
-	<led name='spell13' state='off' top='275' left='177'/>
-	<led name='spell14' state='off' top='289' left='177'/>
-	<led name='spell15' state='off' top='303' left='177'/>
-	<led name='spell16' state='off' top='317' left='177'/>
-	<led name='spell17' state='off' top='331' left='177'/>
-	<led name='spell18' state='off' top='345' left='177'/>
-	<led name='spell19' state='off' top='359' left='177'/>
-	<led name='spell20' state='off' top='373' left='177'/>
-	<led name='spell21' state='off' top='247' left='339'/>
-	<led name='spell22' state='off' top='261' left='339'/>
-	<led name='spell23' state='off' top='275' left='339'/>
-	<led name='spell24' state='off' top='289' left='339'/>
-	<led name='spell25' state='off' top='303' left='339'/>
-	<led name='spell26' state='off' top='317' left='339'/>
-	<led name='spell27' state='off' top='331' left='339'/>
-	<led name='spell28' state='off' top='345' left='339'/>
-	<led name='spell29' state='off' top='359' left='339'/>
-	<led name='spell30' state='off' top='373' left='339'/>
-	<led name='spell31' state='off' top='247' left='488'/>
-	<led name='spell32' state='off' top='261' left='488'/>
-	<led name='spell33' state='off' top='275' left='488'/>
-	<led name='spell34' state='off' top='289' left='488'/>
-	<led name='spell35' state='off' top='303' left='488'/>
-	<led name='spell36' state='off' top='317' left='488'/>
-	<led name='spell37' state='off' top='331' left='488'/>
-	<led name='spell38' state='off' top='345' left='488'/>
+	<pict name='pc2-stat1' type='status' num='0' top='109' left='334'/> <pict name='pc2-stat2' type='status' num='0' top='109' left='347'/>
+	<pict name='pc2-stat3' type='status' num='0' top='109' left='360'/> <pict name='pc2-stat4' type='status' num='0' top='109' left='373'/>
+	<pict name='pc2-stat5' type='status' num='0' top='109' left='386'/> <pict name='pc2-stat6' type='status' num='0' top='109' left='399'/>
+	<pict name='pc2-stat7' type='status' num='0' top='109' left='412'/> <pict name='pc2-stat8' type='status' num='0' top='109' left='425'/>
+	<pict name='pc2-stat9' type='status' num='0' top='109' left='438'/> <pict name='pc2-stat10' type='status' num='0' top='109' left='451'/>
+	<pict name='pc2-stat11' type='status' num='0' top='109' left='464'/><pict name='pc2-stat12' type='status' num='0' top='109' left='477'/>
+	<pict name='pc2-stat13' type='status' num='0' top='109' left='490'/><pict name='pc2-stat14' type='status' num='0' top='109' left='503'/>
+	<pict name='pc2-stat15' type='status' num='0' top='109' left='516'/>
+
+	<pict name='pc3-stat1' type='status' num='0' top='134' left='334'/> <pict name='pc3-stat2' type='status' num='0' top='134' left='347'/>
+	<pict name='pc3-stat3' type='status' num='0' top='134' left='360'/> <pict name='pc3-stat4' type='status' num='0' top='134' left='373'/>
+	<pict name='pc3-stat5' type='status' num='0' top='134' left='386'/> <pict name='pc3-stat6' type='status' num='0' top='134' left='399'/>
+	<pict name='pc3-stat7' type='status' num='0' top='134' left='412'/> <pict name='pc3-stat8' type='status' num='0' top='134' left='425'/>
+	<pict name='pc3-stat9' type='status' num='0' top='134' left='438'/> <pict name='pc3-stat10' type='status' num='0' top='134' left='451'/>
+	<pict name='pc3-stat11' type='status' num='0' top='134' left='464'/><pict name='pc3-stat12' type='status' num='0' top='134' left='477'/>
+	<pict name='pc3-stat13' type='status' num='0' top='134' left='490'/><pict name='pc3-stat14' type='status' num='0' top='134' left='503'/>
+	<pict name='pc3-stat15' type='status' num='0' top='134' left='516'/>
+
+	<pict name='pc4-stat1' type='status' num='0' top='159' left='334'/> <pict name='pc4-stat2' type='status' num='0' top='159' left='347'/>
+	<pict name='pc4-stat3' type='status' num='0' top='159' left='360'/> <pict name='pc4-stat4' type='status' num='0' top='159' left='373'/>
+	<pict name='pc4-stat5' type='status' num='0' top='159' left='386'/> <pict name='pc4-stat6' type='status' num='0' top='159' left='399'/>
+	<pict name='pc4-stat7' type='status' num='0' top='159' left='412'/> <pict name='pc4-stat8' type='status' num='0' top='159' left='425'/>
+	<pict name='pc4-stat9' type='status' num='0' top='159' left='438'/> <pict name='pc4-stat10' type='status' num='0' top='159' left='451'/>
+	<pict name='pc4-stat11' type='status' num='0' top='159' left='464'/><pict name='pc4-stat12' type='status' num='0' top='159' left='477'/>
+	<pict name='pc4-stat13' type='status' num='0' top='159' left='490'/><pict name='pc4-stat14' type='status' num='0' top='159' left='503'/>
+	<pict name='pc4-stat15' type='status' num='0' top='159' left='516'/>
+
+	<pict name='pc5-stat1' type='status' num='0' top='184' left='334'/> <pict name='pc5-stat2' type='status' num='0' top='184' left='347'/>
+	<pict name='pc5-stat3' type='status' num='0' top='184' left='360'/> <pict name='pc5-stat4' type='status' num='0' top='184' left='373'/>
+	<pict name='pc5-stat5' type='status' num='0' top='184' left='386'/> <pict name='pc5-stat6' type='status' num='0' top='184' left='399'/>
+	<pict name='pc5-stat7' type='status' num='0' top='184' left='412'/> <pict name='pc5-stat8' type='status' num='0' top='184' left='425'/>
+	<pict name='pc5-stat9' type='status' num='0' top='184' left='438'/> <pict name='pc5-stat10' type='status' num='0' top='184' left='451'/>
+	<pict name='pc5-stat11' type='status' num='0' top='184' left='464'/><pict name='pc5-stat12' type='status' num='0' top='184' left='477'/>
+	<pict name='pc5-stat13' type='status' num='0' top='184' left='490'/><pict name='pc5-stat14' type='status' num='0' top='184' left='503'/>
+	<pict name='pc5-stat15' type='status' num='0' top='184' left='516'/>
+
+	<pict name='pc6-stat1' type='status' num='0' top='209' left='334'/> <pict name='pc6-stat2' type='status' num='0' top='209' left='347'/>
+	<pict name='pc6-stat3' type='status' num='0' top='209' left='360'/> <pict name='pc6-stat4' type='status' num='0' top='209' left='373'/>
+	<pict name='pc6-stat5' type='status' num='0' top='209' left='386'/> <pict name='pc6-stat6' type='status' num='0' top='209' left='399'/>
+	<pict name='pc6-stat7' type='status' num='0' top='209' left='412'/> <pict name='pc6-stat8' type='status' num='0' top='209' left='425'/>
+	<pict name='pc6-stat9' type='status' num='0' top='209' left='438'/> <pict name='pc6-stat10' type='status' num='0' top='209' left='451'/>
+	<pict name='pc6-stat11' type='status' num='0' top='209' left='464'/><pict name='pc6-stat12' type='status' num='0' top='209' left='477'/>
+	<pict name='pc6-stat13' type='status' num='0' top='209' left='490'/><pict name='pc6-stat14' type='status' num='0' top='209' left='503'/>
+	<pict name='pc6-stat15' type='status' num='0' top='209' left='516'/>
+
+	<!-- Spell columns -->
+	<text name='col1' top='227' left='10' width='100' height='16'/>
+	<led name='spell1' state='off' relative='pos-in pos-in' rel-anchor='prev' top='20' left='6'/>
+	<led name='spell2' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell3' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell4' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell5' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell6' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell7' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell8' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell9' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell10' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+
+	<text name='col2' relative='pos-in pos-in' anchor='col1' top='0' left='152' width='100' height='16'/>
+	<led name='spell11' state='off' relative='pos-in pos-in' rel-anchor='prev' top='20' left='4'/>
+	<led name='spell12' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell13' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell14' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell15' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell16' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell17' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell18' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell19' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell20' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+
+	<text name='col3' relative='pos-in pos-in' anchor='col2' top='0' left='164' width='100' height='16'/>
+	<led name='spell21' state='off' relative='pos-in pos-in' rel-anchor='prev' top='20' left='4'/>
+	<led name='spell22' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell23' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell24' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell25' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell26' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell27' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell28' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell29' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell30' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+
+	<text name='col4' relative='pos-in pos-in' anchor='col3' top='0' left='160' width='100' height='16'/>
+	<led name='spell31' state='off' relative='pos-in pos-in' rel-anchor='prev' top='20' left='4'/>
+	<led name='spell32' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell33' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell34' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell35' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell36' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell37' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+	<led name='spell38' state='off' relative='pos-in pos-in' rel-anchor='prev' top='14' left='0'/>
+
 	<button name='other' type='large' def-key='space' top='394' left='371'>Other Spells</button>
+
+	<!-- Help messages -->
 	<text top='0' left='202' width='290' height='57'>
 		Keyboard:
 		<key ref='caster1'/><key ref='caster2'/><key ref='caster3'/>
@@ -106,67 +170,10 @@
 		key by spell to cast spell.<br/>
 		Alt-click spell name for description.
 	</text>
+	<text name='feedback' framed='true' top='400' left='30' width='186' height='16'>Pick spell to cast.</text>
 	<button name='help' type='help' def-key='help' top='6' left='596'/>
-	<text name='col1' top='227' left='10' width='100' height='16'/>
-	<text name='col2' top='227' left='162' width='100' height='16'/>
-	<text name='col3' top='227' left='326' width='100' height='16'/>
-	<text name='col4' top='227' left='486' width='100' height='16'/>
-	<!-- Whee... time for the status effects! Fifteen per PC! -->
-<pict name='pc1-stat1' type='status' num='0' top='84' left='334'/> <pict name='pc1-stat2' type='status' num='0' top='84' left='347'/>
-<pict name='pc1-stat3' type='status' num='0' top='84' left='360'/> <pict name='pc1-stat4' type='status' num='0' top='84' left='373'/>
-<pict name='pc1-stat5' type='status' num='0' top='84' left='386'/> <pict name='pc1-stat6' type='status' num='0' top='84' left='399'/>
-<pict name='pc1-stat7' type='status' num='0' top='84' left='412'/> <pict name='pc1-stat8' type='status' num='0' top='84' left='425'/>
-<pict name='pc1-stat9' type='status' num='0' top='84' left='438'/> <pict name='pc1-stat10' type='status' num='0' top='84' left='451'/>
-<pict name='pc1-stat11' type='status' num='0' top='84' left='464'/><pict name='pc1-stat12' type='status' num='0' top='84' left='477'/>
-<pict name='pc1-stat13' type='status' num='0' top='84' left='490'/><pict name='pc1-stat14' type='status' num='0' top='84' left='503'/>
-<pict name='pc1-stat15' type='status' num='0' top='84' left='516'/>
 
-<pict name='pc2-stat1' type='status' num='0' top='109' left='334'/> <pict name='pc2-stat2' type='status' num='0' top='109' left='347'/>
-<pict name='pc2-stat3' type='status' num='0' top='109' left='360'/> <pict name='pc2-stat4' type='status' num='0' top='109' left='373'/>
-<pict name='pc2-stat5' type='status' num='0' top='109' left='386'/> <pict name='pc2-stat6' type='status' num='0' top='109' left='399'/>
-<pict name='pc2-stat7' type='status' num='0' top='109' left='412'/> <pict name='pc2-stat8' type='status' num='0' top='109' left='425'/>
-<pict name='pc2-stat9' type='status' num='0' top='109' left='438'/> <pict name='pc2-stat10' type='status' num='0' top='109' left='451'/>
-<pict name='pc2-stat11' type='status' num='0' top='109' left='464'/><pict name='pc2-stat12' type='status' num='0' top='109' left='477'/>
-<pict name='pc2-stat13' type='status' num='0' top='109' left='490'/><pict name='pc2-stat14' type='status' num='0' top='109' left='503'/>
-<pict name='pc2-stat15' type='status' num='0' top='109' left='516'/>
-
-<pict name='pc3-stat1' type='status' num='0' top='134' left='334'/> <pict name='pc3-stat2' type='status' num='0' top='134' left='347'/>
-<pict name='pc3-stat3' type='status' num='0' top='134' left='360'/> <pict name='pc3-stat4' type='status' num='0' top='134' left='373'/>
-<pict name='pc3-stat5' type='status' num='0' top='134' left='386'/> <pict name='pc3-stat6' type='status' num='0' top='134' left='399'/>
-<pict name='pc3-stat7' type='status' num='0' top='134' left='412'/> <pict name='pc3-stat8' type='status' num='0' top='134' left='425'/>
-<pict name='pc3-stat9' type='status' num='0' top='134' left='438'/> <pict name='pc3-stat10' type='status' num='0' top='134' left='451'/>
-<pict name='pc3-stat11' type='status' num='0' top='134' left='464'/><pict name='pc3-stat12' type='status' num='0' top='134' left='477'/>
-<pict name='pc3-stat13' type='status' num='0' top='134' left='490'/><pict name='pc3-stat14' type='status' num='0' top='134' left='503'/>
-<pict name='pc3-stat15' type='status' num='0' top='134' left='516'/>
-
-<pict name='pc4-stat1' type='status' num='0' top='159' left='334'/> <pict name='pc4-stat2' type='status' num='0' top='159' left='347'/>
-<pict name='pc4-stat3' type='status' num='0' top='159' left='360'/> <pict name='pc4-stat4' type='status' num='0' top='159' left='373'/>
-<pict name='pc4-stat5' type='status' num='0' top='159' left='386'/> <pict name='pc4-stat6' type='status' num='0' top='159' left='399'/>
-<pict name='pc4-stat7' type='status' num='0' top='159' left='412'/> <pict name='pc4-stat8' type='status' num='0' top='159' left='425'/>
-<pict name='pc4-stat9' type='status' num='0' top='159' left='438'/> <pict name='pc4-stat10' type='status' num='0' top='159' left='451'/>
-<pict name='pc4-stat11' type='status' num='0' top='159' left='464'/><pict name='pc4-stat12' type='status' num='0' top='159' left='477'/>
-<pict name='pc4-stat13' type='status' num='0' top='159' left='490'/><pict name='pc4-stat14' type='status' num='0' top='159' left='503'/>
-<pict name='pc4-stat15' type='status' num='0' top='159' left='516'/>
-
-<pict name='pc5-stat1' type='status' num='0' top='184' left='334'/> <pict name='pc5-stat2' type='status' num='0' top='184' left='347'/>
-<pict name='pc5-stat3' type='status' num='0' top='184' left='360'/> <pict name='pc5-stat4' type='status' num='0' top='184' left='373'/>
-<pict name='pc5-stat5' type='status' num='0' top='184' left='386'/> <pict name='pc5-stat6' type='status' num='0' top='184' left='399'/>
-<pict name='pc5-stat7' type='status' num='0' top='184' left='412'/> <pict name='pc5-stat8' type='status' num='0' top='184' left='425'/>
-<pict name='pc5-stat9' type='status' num='0' top='184' left='438'/> <pict name='pc5-stat10' type='status' num='0' top='184' left='451'/>
-<pict name='pc5-stat11' type='status' num='0' top='184' left='464'/><pict name='pc5-stat12' type='status' num='0' top='184' left='477'/>
-<pict name='pc5-stat13' type='status' num='0' top='184' left='490'/><pict name='pc5-stat14' type='status' num='0' top='184' left='503'/>
-<pict name='pc5-stat15' type='status' num='0' top='184' left='516'/>
-
-<pict name='pc6-stat1' type='status' num='0' top='209' left='334'/> <pict name='pc6-stat2' type='status' num='0' top='209' left='347'/>
-<pict name='pc6-stat3' type='status' num='0' top='209' left='360'/> <pict name='pc6-stat4' type='status' num='0' top='209' left='373'/>
-<pict name='pc6-stat5' type='status' num='0' top='209' left='386'/> <pict name='pc6-stat6' type='status' num='0' top='209' left='399'/>
-<pict name='pc6-stat7' type='status' num='0' top='209' left='412'/> <pict name='pc6-stat8' type='status' num='0' top='209' left='425'/>
-<pict name='pc6-stat9' type='status' num='0' top='209' left='438'/> <pict name='pc6-stat10' type='status' num='0' top='209' left='451'/>
-<pict name='pc6-stat11' type='status' num='0' top='209' left='464'/><pict name='pc6-stat12' type='status' num='0' top='209' left='477'/>
-<pict name='pc6-stat13' type='status' num='0' top='209' left='490'/><pict name='pc6-stat14' type='status' num='0' top='209' left='503'/>
-<pict name='pc6-stat15' type='status' num='0' top='209' left='516'/>
-
-
-<button name='cancel' type='regular' def-key='esc' top='394' left='479'>Cancel</button>
-<button name='cast' type='regular' top='394' left='549'>Cast</button>
+	<!-- Main buttons -->
+	<button name='cancel' type='regular' def-key='esc' top='394' left='479'>Cancel</button>
+	<button name='cast' type='regular' top='394' left='549'>Cast</button>
 </dialog>

--- a/rsrc/dialogs/cast-spell.xml
+++ b/rsrc/dialogs/cast-spell.xml
@@ -51,62 +51,113 @@
 	<text name='sp5' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
 	<text name='sp6' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
 	<!-- To the right of PC SP, Status icons -->
+	<!-- Whee... time for the status effects! 15 statuses x 6 PCs! -->
 	<text name='status-head' size='large' relative='pos-in pos-in' anchor='sp-head' top='0' left='24' width='223' height='16'>Status:</text>
 
-	<!-- Whee... time for the status effects! Fifteen per PC! -->
-	<pict name='pc1-stat1' type='status' num='0' top='84' left='334'/> <pict name='pc1-stat2' type='status' num='0' top='84' left='347'/>
-	<pict name='pc1-stat3' type='status' num='0' top='84' left='360'/> <pict name='pc1-stat4' type='status' num='0' top='84' left='373'/>
-	<pict name='pc1-stat5' type='status' num='0' top='84' left='386'/> <pict name='pc1-stat6' type='status' num='0' top='84' left='399'/>
-	<pict name='pc1-stat7' type='status' num='0' top='84' left='412'/> <pict name='pc1-stat8' type='status' num='0' top='84' left='425'/>
-	<pict name='pc1-stat9' type='status' num='0' top='84' left='438'/> <pict name='pc1-stat10' type='status' num='0' top='84' left='451'/>
-	<pict name='pc1-stat11' type='status' num='0' top='84' left='464'/><pict name='pc1-stat12' type='status' num='0' top='84' left='477'/>
-	<pict name='pc1-stat13' type='status' num='0' top='84' left='490'/><pict name='pc1-stat14' type='status' num='0' top='84' left='503'/>
-	<pict name='pc1-stat15' type='status' num='0' top='84' left='516'/>
+	<pict name='pc1-stat1' type='status' num='0' relative='pos-in pos-in' anchor='status-head' top='24' left='0'/>
+	<pict name='pc2-stat1' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat1' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat1' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat1' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat1' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
 
-	<pict name='pc2-stat1' type='status' num='0' top='109' left='334'/> <pict name='pc2-stat2' type='status' num='0' top='109' left='347'/>
-	<pict name='pc2-stat3' type='status' num='0' top='109' left='360'/> <pict name='pc2-stat4' type='status' num='0' top='109' left='373'/>
-	<pict name='pc2-stat5' type='status' num='0' top='109' left='386'/> <pict name='pc2-stat6' type='status' num='0' top='109' left='399'/>
-	<pict name='pc2-stat7' type='status' num='0' top='109' left='412'/> <pict name='pc2-stat8' type='status' num='0' top='109' left='425'/>
-	<pict name='pc2-stat9' type='status' num='0' top='109' left='438'/> <pict name='pc2-stat10' type='status' num='0' top='109' left='451'/>
-	<pict name='pc2-stat11' type='status' num='0' top='109' left='464'/><pict name='pc2-stat12' type='status' num='0' top='109' left='477'/>
-	<pict name='pc2-stat13' type='status' num='0' top='109' left='490'/><pict name='pc2-stat14' type='status' num='0' top='109' left='503'/>
-	<pict name='pc2-stat15' type='status' num='0' top='109' left='516'/>
+	<pict name='pc1-stat2' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat1' top='0' left='13'/>
+	<pict name='pc2-stat2' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat2' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat2' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat2' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat2' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
 
-	<pict name='pc3-stat1' type='status' num='0' top='134' left='334'/> <pict name='pc3-stat2' type='status' num='0' top='134' left='347'/>
-	<pict name='pc3-stat3' type='status' num='0' top='134' left='360'/> <pict name='pc3-stat4' type='status' num='0' top='134' left='373'/>
-	<pict name='pc3-stat5' type='status' num='0' top='134' left='386'/> <pict name='pc3-stat6' type='status' num='0' top='134' left='399'/>
-	<pict name='pc3-stat7' type='status' num='0' top='134' left='412'/> <pict name='pc3-stat8' type='status' num='0' top='134' left='425'/>
-	<pict name='pc3-stat9' type='status' num='0' top='134' left='438'/> <pict name='pc3-stat10' type='status' num='0' top='134' left='451'/>
-	<pict name='pc3-stat11' type='status' num='0' top='134' left='464'/><pict name='pc3-stat12' type='status' num='0' top='134' left='477'/>
-	<pict name='pc3-stat13' type='status' num='0' top='134' left='490'/><pict name='pc3-stat14' type='status' num='0' top='134' left='503'/>
-	<pict name='pc3-stat15' type='status' num='0' top='134' left='516'/>
+	<pict name='pc1-stat3' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat2' top='0' left='13'/>
+	<pict name='pc2-stat3' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat3' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat3' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat3' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat3' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
 
-	<pict name='pc4-stat1' type='status' num='0' top='159' left='334'/> <pict name='pc4-stat2' type='status' num='0' top='159' left='347'/>
-	<pict name='pc4-stat3' type='status' num='0' top='159' left='360'/> <pict name='pc4-stat4' type='status' num='0' top='159' left='373'/>
-	<pict name='pc4-stat5' type='status' num='0' top='159' left='386'/> <pict name='pc4-stat6' type='status' num='0' top='159' left='399'/>
-	<pict name='pc4-stat7' type='status' num='0' top='159' left='412'/> <pict name='pc4-stat8' type='status' num='0' top='159' left='425'/>
-	<pict name='pc4-stat9' type='status' num='0' top='159' left='438'/> <pict name='pc4-stat10' type='status' num='0' top='159' left='451'/>
-	<pict name='pc4-stat11' type='status' num='0' top='159' left='464'/><pict name='pc4-stat12' type='status' num='0' top='159' left='477'/>
-	<pict name='pc4-stat13' type='status' num='0' top='159' left='490'/><pict name='pc4-stat14' type='status' num='0' top='159' left='503'/>
-	<pict name='pc4-stat15' type='status' num='0' top='159' left='516'/>
+	<pict name='pc1-stat4' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat3' top='0' left='13'/>
+	<pict name='pc2-stat4' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat4' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat4' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat4' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat4' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
 
-	<pict name='pc5-stat1' type='status' num='0' top='184' left='334'/> <pict name='pc5-stat2' type='status' num='0' top='184' left='347'/>
-	<pict name='pc5-stat3' type='status' num='0' top='184' left='360'/> <pict name='pc5-stat4' type='status' num='0' top='184' left='373'/>
-	<pict name='pc5-stat5' type='status' num='0' top='184' left='386'/> <pict name='pc5-stat6' type='status' num='0' top='184' left='399'/>
-	<pict name='pc5-stat7' type='status' num='0' top='184' left='412'/> <pict name='pc5-stat8' type='status' num='0' top='184' left='425'/>
-	<pict name='pc5-stat9' type='status' num='0' top='184' left='438'/> <pict name='pc5-stat10' type='status' num='0' top='184' left='451'/>
-	<pict name='pc5-stat11' type='status' num='0' top='184' left='464'/><pict name='pc5-stat12' type='status' num='0' top='184' left='477'/>
-	<pict name='pc5-stat13' type='status' num='0' top='184' left='490'/><pict name='pc5-stat14' type='status' num='0' top='184' left='503'/>
-	<pict name='pc5-stat15' type='status' num='0' top='184' left='516'/>
+	<pict name='pc1-stat5' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat4' top='0' left='13'/>
+	<pict name='pc2-stat5' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat5' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat5' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat5' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat5' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
 
-	<pict name='pc6-stat1' type='status' num='0' top='209' left='334'/> <pict name='pc6-stat2' type='status' num='0' top='209' left='347'/>
-	<pict name='pc6-stat3' type='status' num='0' top='209' left='360'/> <pict name='pc6-stat4' type='status' num='0' top='209' left='373'/>
-	<pict name='pc6-stat5' type='status' num='0' top='209' left='386'/> <pict name='pc6-stat6' type='status' num='0' top='209' left='399'/>
-	<pict name='pc6-stat7' type='status' num='0' top='209' left='412'/> <pict name='pc6-stat8' type='status' num='0' top='209' left='425'/>
-	<pict name='pc6-stat9' type='status' num='0' top='209' left='438'/> <pict name='pc6-stat10' type='status' num='0' top='209' left='451'/>
-	<pict name='pc6-stat11' type='status' num='0' top='209' left='464'/><pict name='pc6-stat12' type='status' num='0' top='209' left='477'/>
-	<pict name='pc6-stat13' type='status' num='0' top='209' left='490'/><pict name='pc6-stat14' type='status' num='0' top='209' left='503'/>
-	<pict name='pc6-stat15' type='status' num='0' top='209' left='516'/>
+	<pict name='pc1-stat6' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat5' top='0' left='13'/>
+	<pict name='pc2-stat6' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat6' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat6' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat6' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat6' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+
+	<pict name='pc1-stat7' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat6' top='0' left='13'/>
+	<pict name='pc2-stat7' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat7' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat7' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat7' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat7' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+
+	<pict name='pc1-stat8' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat7' top='0' left='13'/>
+	<pict name='pc2-stat8' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat8' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat8' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat8' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat8' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+
+	<pict name='pc1-stat9' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat8' top='0' left='13'/>
+	<pict name='pc2-stat9' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat9' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat9' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat9' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat9' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+
+	<pict name='pc1-stat10' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat9' top='0' left='13'/>
+	<pict name='pc2-stat10' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat10' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat10' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat10' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat10' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+
+	<pict name='pc1-stat11' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat10' top='0' left='13'/>
+	<pict name='pc2-stat11' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat11' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat11' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat11' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat11' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+
+	<pict name='pc1-stat12' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat11' top='0' left='13'/>
+	<pict name='pc2-stat12' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat12' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat12' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat12' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat12' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+
+	<pict name='pc1-stat13' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat12' top='0' left='13'/>
+	<pict name='pc2-stat13' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat13' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat13' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat13' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat13' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+
+	<pict name='pc1-stat14' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat13' top='0' left='13'/>
+	<pict name='pc2-stat14' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat14' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat14' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat14' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat14' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+
+	<pict name='pc1-stat15' type='status' num='0' relative='pos-in pos-in' anchor='pc1-stat14' top='0' left='13'/>
+	<pict name='pc2-stat15' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc3-stat15' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc4-stat15' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc5-stat15' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
+	<pict name='pc6-stat15' type='status' num='0' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'/>
 
 	<!-- Spell columns -->
 	<text name='col1' top='227' left='10' width='100' height='16'/>

--- a/rsrc/dialogs/cast-spell.xml
+++ b/rsrc/dialogs/cast-spell.xml
@@ -3,38 +3,57 @@
 <dialog defbtn='cast'>
 	<pict name='pic' type='dlog' num='12' top='9' left='9'/>
 	<text size='large' top='6' left='54' width='139' height='18'>Select a Spell:</text>
-	<button name='caster1' type='regular' def-key='1' top='81' left='10'><key/></button>
-	<button name='caster2' type='regular' def-key='2' top='105' left='10'><key/></button>
-	<button name='caster3' type='regular' def-key='3' top='129' left='10'><key/></button>
-	<button name='caster4' type='regular' def-key='4' top='153' left='10'><key/></button>
-	<button name='caster5' type='regular' def-key='5' top='177' left='10'><key/></button>
-	<button name='caster6' type='regular' def-key='6' top='201' left='10'><key/></button>
-	<button name='target1' type='small' def-key='shift 1' top='82' left='235'><key/></button>
-	<button name='target2' type='small' def-key='shift 2' top='106' left='235'><key/></button>
-	<button name='target3' type='small' def-key='shift 3' top='130' left='235'><key/></button>
-	<button name='target4' type='small' def-key='shift 4' top='154' left='235'><key/></button>
-	<button name='target5' type='small' def-key='shift 5' top='178' left='235'><key/></button>
-	<button name='target6' type='small' def-key='shift 6' top='202' left='235'><key/></button>
-	<button name='cancel' type='regular' def-key='esc' top='394' left='479'>Cancel</button>
-	<button name='cast' type='regular' top='394' left='549'>Cast</button>
-	<text name='pc1' top='84' left='88' width='122' height='16'/>
-	<text name='pc2' top='108' left='88' width='122' height='16'/>
-	<text name='pc3' top='132' left='88' width='122' height='16'/>
-	<text name='pc4' top='156' left='88' width='122' height='16'/>
-	<text name='pc5' top='180' left='88' width='122' height='16'/>
-	<text name='pc6' top='204' left='88' width='122' height='16'/>
-	<text name='hp1' top='85' left='265' width='32' height='16' colour='red'/>
-	<text name='hp2' top='109' left='265' width='32' height='16' colour='red'/>
-	<text name='hp3' top='133' left='265' width='32' height='16' colour='red'/>
-	<text name='hp4' top='156' left='265' width='32' height='16' colour='red'/>
-	<text name='hp5' top='181' left='265' width='32' height='16' colour='red'/>
-	<text name='hp6' top='205' left='265' width='32' height='16' colour='red'/>
-	<text name='sp1' top='85' left='304' width='32' height='16' colour='light_blue'/>
-	<text name='sp2' top='109' left='304' width='32' height='16' colour='light_blue'/>
-	<text name='sp3' top='133' left='304' width='32' height='16' colour='light_blue'/>
-	<text name='sp4' top='156' left='304' width='32' height='16' colour='light_blue'/>
-	<text name='sp5' top='181' left='304' width='32' height='16' colour='light_blue'/>
-	<text name='sp6' top='205' left='304' width='32' height='16' colour='light_blue'/>
+	<!-- To the left of PC names, buttons to select caster -->
+	<text name='caster-head' size='large' top='60' left='22' width='75' height='16'>Caster:</text>
+	<button name='caster1' type='regular' def-key='1' relative='neg pos-in' rel-anchor='prev' top='19' left='12'><key/></button>
+	<button name='caster2' type='regular' def-key='2' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'><key/></button>
+	<button name='caster3' type='regular' def-key='3' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'><key/></button>
+	<button name='caster4' type='regular' def-key='4' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'><key/></button>
+	<button name='caster5' type='regular' def-key='5' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'><key/></button>
+	<button name='caster6' type='regular' def-key='6' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'><key/></button>
+	<!-- PC names -->
+	<text name='pc-head' size='large' relative='pos-in pos-in' anchor='caster-head' top='0' left='66' width='75' height='16'></text><!-- Just for positioning-->
+	<text name='pc1' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='122' height='16'/>
+	<text name='pc2' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='122' height='16'/>
+	<text name='pc3' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='122' height='16'/>
+	<text name='pc4' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='122' height='16'/>
+	<text name='pc5' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='122' height='16'/>
+	<text name='pc6' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='122' height='16'/>
+	<!-- To the right of PC name, buttons to select target -->
+	<text name='target-head' size='large' relative='pos-in pos-in' anchor='pc-head' top='0' left='112' width='223' height='16'>Target:</text>
+	<button name='target1' type='small' def-key='shift 1' relative='pos-in pos-in' rel-anchor='prev' top='19' left='6'><key/></button>
+	<button name='target2' type='small' def-key='shift 2' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'><key/></button>
+	<button name='target3' type='small' def-key='shift 3' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'><key/></button>
+	<button name='target4' type='small' def-key='shift 4' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'><key/></button>
+	<button name='target5' type='small' def-key='shift 5' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'><key/></button>
+	<button name='target6' type='small' def-key='shift 6' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0'><key/></button>
+	<!-- To the right of target buttons, green arrows to highlight choice -->
+	<text name='arrow1' relative='neg pos-in' anchor='hp1' top='0' left='20' width='32' height='16' colour='light_green'>-&gt;</text>
+	<text name='arrow2' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_green'>-&gt;</text>
+	<text name='arrow3' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_green'>-&gt;</text>
+	<text name='arrow4' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_green'>-&gt;</text>
+	<text name='arrow5' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_green'>-&gt;</text>
+	<text name='arrow6' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_green'>-&gt;</text>
+	<!-- To the right of target buttons, PC HP -->
+	<text name='hp-head' size='large' relative='pos-in pos-in' anchor='target-head' top='0' left='55' width='223' height='16'>HP:</text>
+	<text name='hp1' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='red'/>
+	<text name='hp2' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='red'/>
+	<text name='hp3' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='red'/>
+	<text name='hp4' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='red'/>
+	<text name='hp5' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='red'/>
+	<text name='hp6' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='red'/>
+	<!-- To the right of PC HP, PC SP -->
+	<text name='sp-head' size='large' relative='pos-in pos-in' anchor='hp-head' top='0' left='24' width='223' height='16'>SP:</text>
+	<text name='sp1' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
+	<text name='sp2' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
+	<text name='sp3' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
+	<text name='sp4' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
+	<text name='sp5' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
+	<text name='sp6' relative='pos-in pos-in' rel-anchor='prev' top='24' left='0' width='32' height='16' colour='light_blue'/>
+	<!-- To the right of PC SP, Status icons -->
+	<text name='status-head' size='large' relative='pos-in pos-in' anchor='sp-head' top='0' left='24' width='223' height='16'>Status:</text>
+
+
 	<text name='feedback' framed='true' top='400' left='30' width='186' height='16'>Pick spell to cast.</text>
 	<led name='spell1' state='off' top='247' left='14'/>
 	<led name='spell2' state='off' top='261' left='14'/>
@@ -75,8 +94,6 @@
 	<led name='spell37' state='off' top='331' left='488'/>
 	<led name='spell38' state='off' top='345' left='488'/>
 	<button name='other' type='large' def-key='space' top='394' left='371'>Other Spells</button>
-	<text size='large' top='60' left='9' width='75' height='16'>Caster:</text>
-	<text size='large' top='60' left='209' width='223' height='16'>Target:  HP:   SP:    Status:</text>
 	<text top='0' left='202' width='290' height='57'>
 		Keyboard:
 		<key ref='caster1'/><key ref='caster2'/><key ref='caster3'/>
@@ -148,4 +165,8 @@
 <pict name='pc6-stat11' type='status' num='0' top='209' left='464'/><pict name='pc6-stat12' type='status' num='0' top='209' left='477'/>
 <pict name='pc6-stat13' type='status' num='0' top='209' left='490'/><pict name='pc6-stat14' type='status' num='0' top='209' left='503'/>
 <pict name='pc6-stat15' type='status' num='0' top='209' left='516'/>
+
+
+<button name='cancel' type='regular' def-key='esc' top='394' left='479'>Cancel</button>
+<button name='cast' type='regular' top='394' left='549'>Cast</button>
 </dialog>

--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <sstream>
 #include <string>
+#include <map>
 #include "dialog.hpp"
 #include "gfx/tiling.hpp" // for bg
 #include "fileio/resmgr/res_dialog.hpp"
@@ -44,6 +45,8 @@ short cDialog::defaultBackground = cDialog::BG_DARK;
 cDialog* cDialog::topWindow = nullptr;
 void (*cDialog::redraw_everything)() = nullptr;
 std::mt19937 cDialog::ui_rand;
+
+extern std::map<std::string,sf::Color> colour_map;
 
 extern bool check_for_interrupt(std::string);
 
@@ -86,39 +89,9 @@ sf::Color cControl::parseColor(string what){
 			}
 		}
 		clr.r = r, clr.g = g, clr.b = b;
-	}else if(what == "black")
-		clr.r = 0x00, clr.g = 0x00, clr.b = 0x00;
-	else if(what == "red")
-		clr.r = 0xFF, clr.g = 0x00, clr.b = 0x00;
-	else if(what == "lime")
-		clr.r = 0x00, clr.g = 0xFF, clr.b = 0x00;
-	else if(what == "blue")
-		clr.r = 0x00, clr.g = 0x00, clr.b = 0xFF;
-	else if(what == "yellow")
-		clr.r = 0xFF, clr.g = 0xFF, clr.b = 0x00;
-	else if(what == "aqua")
-		clr.r = 0x00, clr.g = 0xFF, clr.b = 0xFF;
-	else if(what == "fuchsia")
-		clr.r = 0xFF, clr.g = 0x00, clr.b = 0xFF;
-	else if(what == "white")
-		clr.r = 0xFF, clr.g = 0xFF, clr.b = 0xFF;
-	else if(what == "gray" || what == "grey")
-		clr.r = 0x80, clr.g = 0x80, clr.b = 0x80;
-	else if(what == "maroon")
-		clr.r = 0x80, clr.g = 0x00, clr.b = 0x00;
-	else if(what == "green")
-		clr.r = 0x00, clr.g = 0x80, clr.b = 0x00;
-	else if(what == "navy")
-		clr.r = 0x00, clr.g = 0x00, clr.b = 0x80;
-	else if(what == "olive")
-		clr.r = 0x80, clr.g = 0x80, clr.b = 0x00;
-	else if(what == "teal")
-		clr.r = 0x00, clr.g = 0x80, clr.b = 0x80;
-	else if(what == "purple")
-		clr.r = 0x80, clr.g = 0x00, clr.b = 0x80;
-	else if(what == "silver")
-		clr.r = 0xC0, clr.g = 0xC0, clr.b = 0xC0;
-	else throw -1;
+	}else if(colour_map.find(what) != colour_map.end()){
+		return colour_map[what];
+	}else throw -1;
 	return clr;
 }
 

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -266,6 +266,14 @@ void handle_spellcast(eSkill which_type, bool& did_something, bool& need_redraw,
 	short store_sp[6];
 	extern short spec_target_fail;
 	extern eSpecCtxType spec_target_type;
+	// Dual-caster recast hint toggle:
+	// Change the recast hint to mage if last spell wasn't mage
+	if(spell_forced && is_combat() && univ.current_pc().last_cast_type != which_type){
+		spell_forced = false;
+		univ.current_pc().last_cast_type = which_type;
+		need_redraw = true;
+		return;
+	}
 	if(!someone_awake()) {
 		ASB("Everyone's asleep/paralyzed.");
 		need_reprint = true;

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2457,6 +2457,7 @@ bool handle_keystroke(const sf::Event& event, cFramerateLimiter& fps_limiter){
 				// cast multi-target spell, set # targets to 0 so that space clicked doesn't matter
 				num_targets_left = 0;
 				handle_target_space(center, did_something, need_redraw, need_reprint);
+				advance_time(did_something, need_redraw, need_reprint);
 			} else if(overall_mode == MODE_SPELL_TARGET)
 				// Rotate a force wall
 				spell_cast_hit_return();

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -1850,6 +1850,7 @@ void handle_menu_spell(eSpell spell_picked) {
 	spell_forced = true;
 	pc_casting = univ.cur_pc;
 	univ.current_pc().last_cast[spell_type] = spell_picked;
+	univ.current_pc().last_cast_type = spell_type;
 	if(spell_type == eSkill::MAGE_SPELLS)
 		store_mage = spell_picked;
 	else store_priest = spell_picked;

--- a/src/game/boe.graphics.cpp
+++ b/src/game/boe.graphics.cpp
@@ -667,11 +667,11 @@ void put_text_bar(std::string str, std::string right_str) {
 	to_rect.left += 5;
 	to_rect.right -= 5;
 	win_draw_string(text_bar_gworld, to_rect, str, eTextMode::LEFT_TOP, style);
-	// Style has to be wrap to get right-alignment
-	win_draw_string(text_bar_gworld, to_rect, right_str, eTextMode::WRAP, style, true);
-	to_rect.right -= string_length(right_str, style);
-	
-	if(!monsters_going) {
+	// the recast hint will replace status icons:
+	if(!right_str.empty()){
+		// Style has to be wrap to get right-alignment
+		win_draw_string(text_bar_gworld, to_rect, right_str, eTextMode::WRAP, style, true);
+	}else if(!monsters_going) {
 		sf::Texture& status_gworld = *ResMgr::graphics.get("staticons");
 		to_rect.top -= 2;
 		to_rect.left = to_rect.right - 15;

--- a/src/game/boe.graphics.cpp
+++ b/src/game/boe.graphics.cpp
@@ -634,11 +634,15 @@ void draw_text_bar() {
 		}
 		if(!hint_prefix.empty()){
 			hint_out << hint_prefix << ": ";
-			const cSpell& spell = (*current_pc.last_cast[type]);
-			if(pc_can_cast_spell(current_pc,type) && spell.cost <= current_pc.get_magic()) {
-				hint_out << "Recast " << spell.name();
+			if(current_pc.last_cast[type] != eSpell::NONE){
+				const cSpell& spell = (*current_pc.last_cast[type]);
+				if(pc_can_cast_spell(current_pc,type) && spell.cost <= current_pc.get_magic()) {
+					hint_out << "Recast " << spell.name();
+				}else{
+					hint_out << "Cannot recast";
+				}
 			}else{
-				hint_out << "Cannot recast";
+				hint_out << "No spell to recast";
 			}
 		}
 

--- a/src/game/boe.graphics.hpp
+++ b/src/game/boe.graphics.hpp
@@ -31,7 +31,7 @@ void redraw_screen(int refresh);
 void put_background();
 void draw_text_bar();
 void refresh_text_bar();
-void put_text_bar(std::string str);
+void put_text_bar(std::string str, std::string right_str = "");
 void draw_terrain(short	mode = 0);
 void place_trim(short q,short r,location where,ter_num_t ter_type);
 void draw_trim(short q,short r,short which_trim,short which_mode);

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -147,7 +147,7 @@ eStatMode stat_screen_mode;
 short anim_step = -1;
 
 // Spell casting globals
-eSpell store_mage = eSpell::LIGHT, store_priest = eSpell::BLESS_MINOR;
+eSpell store_mage = eSpell::NONE, store_priest = eSpell::NONE;
 short store_mage_lev = 0, store_priest_lev = 0;
 short store_spell_target = 6,pc_casting;
 short num_targets_left = 0;

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -2070,9 +2070,7 @@ eSpell pick_spell(short pc_num,eSkill type) { // 70 - no spell OW spell num
 		cLed& led = dynamic_cast<cLed&>(castSpell[id]);
 		led.attachKey(key);
 		castSpell.addLabelFor(id, {static_cast<char>(i > 25 ? toupper(key.c) : key.c)}, LABEL_LEFT, 8, true);
-		if(spell_index[i] == 90){
-			continue;
-		}
+		// All LEDs should get the click handler and set state, because page 2 will hide them if necessary
 		led.setState((pc_can_cast_spell(univ.party[pc_casting],cSpell::fromNum(type,on_which_spell_page == 0 ? i : spell_index[i])))
 					 ? led_red : led_green);
 		led.attachClickHandler(std::bind(pick_spell_select_led, _1, _2, _3, type, std::ref(dark), std::ref(former_spell)));

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -1655,8 +1655,8 @@ static void draw_spell_info(cDialog& me, const eSkill store_situation, const sho
 					}
 					break;
 				case SELECT_ANY:
-					// TODO: Split off party members should probably be excluded too?
-					if(univ.party[i].main_status != eMainStatus::ABSENT) {
+					// Absent party members and split-off party members are excluded
+					if(univ.party[i].main_status != eMainStatus::ABSENT && univ.party[i].main_status < eMainStatus::SPLIT) {
 						me[id].show();
 					}
 					else {

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -1880,9 +1880,7 @@ static bool pick_spell_select_led(cDialog& me, std::string id, eKeyMod mods, con
 		me["feedback"].setText(bad_spell);
 	}
 	else {
-		if(store_situation == eSkill::MAGE_SPELLS)
-			store_spell = (on_which_spell_page == 0) ? item_hit : spell_index[item_hit];
-		else store_spell = (on_which_spell_page == 0) ? item_hit : spell_index[item_hit];
+		store_spell = (on_which_spell_page == 0) ? item_hit : spell_index[item_hit];
 		draw_spell_info(me, store_situation, store_spell);
 		put_spell_led_buttons(me, store_situation, store_spell);
 		

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -99,6 +99,9 @@ short spell_index[38] = {38,39,40,41,42,43,44,45,90,90,46,47,48,49,50,51,52,53,9
 // Says which buttons hit which spells on second spell page, 90 means no button
 bool can_choose_caster;
 
+const sf::Color SELECTED_COLOUR = Colours::LIGHT_GREEN;
+const sf::Color DISABLED_COLOUR = Colours::GREY;
+
 // Dialog vars
 short store_graphic_pc_num ;
 short store_graphic_mode ;
@@ -1718,7 +1721,7 @@ static void put_pc_caster_buttons(cDialog& me) {
 		std::string n = boost::lexical_cast<std::string>(i + 1);
 		if(me["caster" + n].isVisible()) {
 			if(i == pc_casting)
-				me["pc" + n].setColour(Colours::RED);
+				me["pc" + n].setColour(SELECTED_COLOUR);
 			else me["pc" + n].setColour(me.getDefTextClr());
 		}
 	}
@@ -1728,8 +1731,8 @@ static void put_pc_target_buttons(cDialog& me, short& store_last_target_darkened
 	
 	if(store_spell_target < 6) {
 		std::string n = boost::lexical_cast<std::string>(store_spell_target + 1);
-		me["hp" + n].setColour(Colours::RED);
-		me["sp" + n].setColour(Colours::RED);
+		me["hp" + n].setColour(SELECTED_COLOUR);
+		me["sp" + n].setColour(SELECTED_COLOUR);
 	}
 	if((store_last_target_darkened < 6) && (store_last_target_darkened != store_spell_target)) {
 		std::string n = boost::lexical_cast<std::string>(store_last_target_darkened + 1);
@@ -1752,12 +1755,16 @@ static void put_spell_led_buttons(cDialog& me, const eSkill store_situation,cons
 			eSpell spell = cSpell::fromNum(store_situation, spell_for_this_button);
 			if(store_spell == spell_for_this_button) {
 				led.setState(led_green);
+				// Text color:
+				led.setColour(SELECTED_COLOUR);
 			}
 			else if(pc_can_cast_spell(univ.party[pc_casting],spell)) {
 				led.setState(led_red);
+				led.setColour(me.getDefTextClr());
 			}
 			else {
 				led.setState(led_off);
+				led.setColour(DISABLED_COLOUR);
 			}
 		}
 	}

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -1706,6 +1706,7 @@ static void draw_spell_pc_info(cDialog& me) {
 		if(univ.party[i].main_status != eMainStatus::ABSENT) {
 			me["pc" + n].setText(univ.party[i].name);
 			
+			me["arrow" + n].hide();
 			if(univ.party[i].main_status == eMainStatus::ALIVE) {
 				me["hp" + n].setTextToNum(univ.party[i].cur_health);
 				me["sp" + n].setTextToNum(univ.party[i].cur_sp);
@@ -1731,13 +1732,11 @@ static void put_pc_target_buttons(cDialog& me, short& store_last_target_darkened
 	
 	if(store_spell_target < 6) {
 		std::string n = boost::lexical_cast<std::string>(store_spell_target + 1);
-		me["hp" + n].setColour(SELECTED_COLOUR);
-		me["sp" + n].setColour(SELECTED_COLOUR);
+		me["arrow" + n].show();
 	}
 	if((store_last_target_darkened < 6) && (store_last_target_darkened != store_spell_target)) {
 		std::string n = boost::lexical_cast<std::string>(store_last_target_darkened + 1);
-		me["hp" + n].setColour(me.getDefTextClr());
-		me["sp" + n].setColour(me.getDefTextClr());
+		me["arrow" + n].hide();
 	}
 	store_last_target_darkened = store_spell_target;
 }

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -1926,6 +1926,7 @@ static bool finish_pick_spell(cDialog& me, bool spell_toast, const short store_s
 	if(store_situation == eSkill::MAGE_SPELLS && (*picked_spell).need_select == SELECT_NO) {
 		store_last_cast_mage = pc_casting;
 		univ.party[pc_casting].last_cast[store_situation] = picked_spell;
+		univ.party[pc_casting].last_cast_type = store_situation;
 		me.toast(false);
 		me.setResult<short>(store_spell);
 		return true;
@@ -1933,6 +1934,7 @@ static bool finish_pick_spell(cDialog& me, bool spell_toast, const short store_s
 	if(store_situation == eSkill::PRIEST_SPELLS && (*picked_spell).need_select == SELECT_NO) {
 		store_last_cast_priest = pc_casting;
 		univ.party[pc_casting].last_cast[store_situation] = picked_spell;
+		univ.party[pc_casting].last_cast_type = store_situation;
 		me.toast(false);
 		me.setResult<short>(store_spell);
 		return true;
@@ -1950,6 +1952,7 @@ static bool finish_pick_spell(cDialog& me, bool spell_toast, const short store_s
 		store_last_cast_mage = pc_casting;
 	else store_last_cast_priest = pc_casting;
 	univ.party[pc_casting].last_cast[store_situation] = picked_spell;
+	univ.party[pc_casting].last_cast_type = store_situation;
 	me.toast(true);
 	return true;
 }

--- a/src/gfx/render_shapes.cpp
+++ b/src/gfx/render_shapes.cpp
@@ -29,6 +29,7 @@ std::map<std::string,sf::Color> colour_map = {
 	{"pink", Colours::PINK},
 	{"yellow", Colours::YELLOW},
 	{"orange", Colours::ORANGE},
+	{"light_blue", Colours::LIGHT_BLUE},
 	{"shadow", Colours::SHADOW},
 	{"title_blue", Colours::TITLE_BLUE},
 	{"navy", Colours::NAVY},

--- a/src/gfx/render_shapes.cpp
+++ b/src/gfx/render_shapes.cpp
@@ -36,7 +36,15 @@ std::map<std::string,sf::Color> colour_map = {
 	{"dark_blue", Colours::DARK_BLUE},
 	{"dark-green", Colours::DARK_GREEN},
 	{"light-green", Colours::LIGHT_GREEN},
-	{"dark-red", Colours::DARK_RED}
+	{"dark-red", Colours::DARK_RED},
+	// Extra Colors
+	{"lime", Colours::LIME},
+	{"aqua", Colours::AQUA},
+	{"fuchsia", Colours::FUCHSIA},
+	{"maroon", Colours::MAROON},
+	{"olive", Colours::OLIVE},
+	{"purple", Colours::PURPLE},
+	{"silvel", Colours::SILVER}
 };
 
 // TODO: Put these classes in a header?

--- a/src/gfx/render_shapes.cpp
+++ b/src/gfx/render_shapes.cpp
@@ -17,6 +17,27 @@
 using boost::math::constants::pi;
 using pt_idx_t = decltype(((sf::Shape*)nullptr)->getPointCount());
 
+std::map<std::string,sf::Color> colour_map = {
+	{"white", Colours::WHITE},
+	{"black", Colours::BLACK},
+	{"grey", Colours::GREY},
+	{"gray", Colours::GREY},
+	{"red", Colours::RED},
+	{"green", Colours::GREEN},
+	{"blue", Colours::BLUE},
+	{"teal", Colours::TEAL},
+	{"pink", Colours::PINK},
+	{"yellow", Colours::YELLOW},
+	{"orange", Colours::ORANGE},
+	{"shadow", Colours::SHADOW},
+	{"title_blue", Colours::TITLE_BLUE},
+	{"navy", Colours::NAVY},
+	{"dark_blue", Colours::DARK_BLUE},
+	{"dark_green", Colours::DARK_GREEN},
+	{"light_green", Colours::LIGHT_GREEN},
+	{"dark_red", Colours::DARK_RED}
+};
+
 // TODO: Put these classes in a header?
 class EllipseShape : public sf::Shape {
 	float divSz;

--- a/src/gfx/render_shapes.cpp
+++ b/src/gfx/render_shapes.cpp
@@ -44,7 +44,7 @@ std::map<std::string,sf::Color> colour_map = {
 	{"maroon", Colours::MAROON},
 	{"olive", Colours::OLIVE},
 	{"purple", Colours::PURPLE},
-	{"silvel", Colours::SILVER}
+	{"silver", Colours::SILVER}
 };
 
 // TODO: Put these classes in a header?

--- a/src/gfx/render_shapes.cpp
+++ b/src/gfx/render_shapes.cpp
@@ -29,14 +29,14 @@ std::map<std::string,sf::Color> colour_map = {
 	{"pink", Colours::PINK},
 	{"yellow", Colours::YELLOW},
 	{"orange", Colours::ORANGE},
-	{"light_blue", Colours::LIGHT_BLUE},
+	{"light-blue", Colours::LIGHT_BLUE},
 	{"shadow", Colours::SHADOW},
-	{"title_blue", Colours::TITLE_BLUE},
+	{"title-blue", Colours::TITLE_BLUE},
 	{"navy", Colours::NAVY},
 	{"dark_blue", Colours::DARK_BLUE},
-	{"dark_green", Colours::DARK_GREEN},
-	{"light_green", Colours::LIGHT_GREEN},
-	{"dark_red", Colours::DARK_RED}
+	{"dark-green", Colours::DARK_GREEN},
+	{"light-green", Colours::LIGHT_GREEN},
+	{"dark-red", Colours::DARK_RED}
 };
 
 // TODO: Put these classes in a header?

--- a/src/gfx/render_shapes.hpp
+++ b/src/gfx/render_shapes.hpp
@@ -48,6 +48,7 @@ void undo_clip(sf::RenderTarget& where);
 namespace Colours {
 	const sf::Color WHITE = sf::Color::White;
 	const sf::Color BLACK = sf::Color::Black;
+	const sf::Color GREY   { 0x80, 0x80, 0x80};
 	const sf::Color RED    { 0xdd, 0x00, 0x00};
 	const sf::Color GREEN  { 0x00, 0x88, 0x00};
 	const sf::Color BLUE   { 0x00, 0x00, 0xdd};

--- a/src/gfx/render_shapes.hpp
+++ b/src/gfx/render_shapes.hpp
@@ -11,6 +11,7 @@
 
 #include <vector>
 #include <memory>
+#include <map>
 #include <SFML/Graphics/Shape.hpp>
 #include "location.hpp"
 

--- a/src/gfx/render_shapes.hpp
+++ b/src/gfx/render_shapes.hpp
@@ -57,6 +57,7 @@ namespace Colours {
 	const sf::Color PINK   { 0xff, 0x00, 0x99};
 	const sf::Color YELLOW { 0xff, 0xff, 0x31};
 	const sf::Color ORANGE { 0xff, 0x80, 0x00};
+	const sf::Color LIGHT_BLUE { 0xad, 0xd8, 0xe6 }; // Spell points on dark background
 	// Text colours for shopping / talking
 	// TODO: The Windows version appears to use completely different colours?
 	const sf::Color SHADOW      { 0x00, 0x00, 0x68}; // formerly c[3] QD colour = {0,0,26623} (shop/character name shadow, shop subtitle)

--- a/src/gfx/render_shapes.hpp
+++ b/src/gfx/render_shapes.hpp
@@ -67,6 +67,14 @@ namespace Colours {
 	const sf::Color DARK_GREEN  { 0x00, 0x60, 0x00}; // formerly c[5] QD colour = {0,40959,0} (talking buttons)
 	const sf::Color LIGHT_GREEN { 0x00, 0xa0, 0x00}; // formerly c[6] QD colour = {0,24575,0} (talking buttons pressed)
 	const sf::Color DARK_RED    { 0xa0, 0x00, 0x14}; // formerly c[7] (clickable text, new in OBoE)
+	// Extra colors
+	const sf::Color LIME { 0x00, 0xFF, 0x00};
+	const sf::Color AQUA { 0x00, 0xFF, 0xFF};
+	const sf::Color FUCHSIA { 0xFF, 0x00, 0xFF};
+	const sf::Color MAROON { 0x80, 0x00, 0x00};
+	const sf::Color OLIVE { 0x80, 0x80, 0x00};
+	const sf::Color PURPLE { 0x80, 0x00, 0x80};
+	const sf::Color SILVER { 0xC0, 0xC0, 0xC0};
 }
 
 const sf::Color PRESET_WORD_ON = Colours::DARK_GREEN;

--- a/src/gfx/render_text.cpp
+++ b/src/gfx/render_text.cpp
@@ -149,7 +149,7 @@ static void win_draw_string(sf::RenderTarget& dest_window,rectangle dest_rect,st
 	short total_width = str_to_draw.getLocalBounds().width;
 	
 	eTextMode mode = options.mode;
-	if(mode == eTextMode::WRAP && total_width < dest_rect.width())
+	if(mode == eTextMode::WRAP && total_width < dest_rect.width() && !options.right_align)
 		mode = eTextMode::LEFT_TOP;
 	if(mode == eTextMode::LEFT_TOP && str.find('|') != std::string::npos)
 		mode = eTextMode::WRAP;

--- a/src/spell.cpp
+++ b/src/spell.cpp
@@ -212,7 +212,7 @@ cSpell M_FLIGHT = cSpell(eSpell::FLIGHT).asType(eSkill::MAGE_SPELLS).asLevel(6)
 cSpell M_SHOCKWAVE = cSpell(eSpell::SHOCKWAVE).asType(eSkill::MAGE_SPELLS).asLevel(7)
 	.withCost(12).withRefer(REFER_IMMED).when(WHEN_COMBAT).finish();
 cSpell M_BLESS_MAJOR = cSpell(eSpell::BLESS_MAJOR).asType(eSkill::MAGE_SPELLS).asLevel(7)
-	.withCost(8).withRefer(REFER_IMMED).when(WHEN_COMBAT).when(WHEN_TOWN).asPeaceful().finish();
+	.withCost(8).withRefer(REFER_IMMED).when(WHEN_COMBAT).asPeaceful().finish();
 cSpell M_PARALYSIS_MASS = cSpell(eSpell::PARALYSIS_MASS).asType(eSkill::MAGE_SPELLS).asLevel(7)
 	.withRange(8).withCost(20).withRefer(REFER_IMMED).when(WHEN_COMBAT).finish();
 cSpell M_PROTECTION = cSpell(eSpell::PROTECTION).asType(eSkill::MAGE_SPELLS).asLevel(7)

--- a/src/spell.cpp
+++ b/src/spell.cpp
@@ -47,6 +47,7 @@ cSpell& cSpell::needsSelect(eSpellSelect sel) {
 	return *this;
 }
 
+// Mark a spell as castable by pacifist PCs
 cSpell& cSpell::asPeaceful() {
 	peaceful = true;
 	return *this;

--- a/src/spell.cpp
+++ b/src/spell.cpp
@@ -47,7 +47,6 @@ cSpell& cSpell::needsSelect(eSpellSelect sel) {
 	return *this;
 }
 
-// Mark a spell as castable by pacifist PCs
 cSpell& cSpell::asPeaceful() {
 	peaceful = true;
 	return *this;
@@ -92,6 +91,10 @@ eSpell cSpell::fromNum(int num) {
 		return eSpell::NONE;
 	return check;
 }
+
+// NOTE:
+// asPeaceful() marks a spell as castable by pacifist PCs. It doesn't mean "only in peace mode"
+// (which would make a lot of these contradictory/broken)
 
 // Mage Spells
 cSpell M_LIGHT = cSpell(eSpell::LIGHT).asType(eSkill::MAGE_SPELLS).asLevel(1)

--- a/src/universe/pc.hpp
+++ b/src/universe/pc.hpp
@@ -106,6 +106,9 @@ public:
 	long unique_id;
 	// transient stuff
 	std::map<eSkill,eSpell> last_cast = {{ eSkill::MAGE_SPELLS, eSpell::NONE}, { eSkill::PRIEST_SPELLS, eSpell::NONE }};
+	// There is already a global last_spellcast_type, but that variable is for the whole party.
+	// This one is per-PC
+	eSkill last_cast_type = eSkill::INVALID;
 	location combat_pos;
 	short parry = 0;
 	iLiving* last_attacked = nullptr; // Note: Currently this is assigned but never read

--- a/src/universe/pc.hpp
+++ b/src/universe/pc.hpp
@@ -105,7 +105,7 @@ public:
 	eRace race;
 	long unique_id;
 	// transient stuff
-	std::map<eSkill,eSpell> last_cast;
+	std::map<eSkill,eSpell> last_cast = {{ eSkill::MAGE_SPELLS, eSpell::NONE}, { eSkill::PRIEST_SPELLS, eSpell::NONE }};
 	location combat_pos;
 	short parry = 0;
 	iLiving* last_attacked = nullptr; // Note: Currently this is assigned but never read

--- a/test/init.cpp
+++ b/test/init.cpp
@@ -258,7 +258,7 @@ TEST_CASE("Construction sanity test for player character") {
 		CHECK(pc.traits.empty());
 		CHECK(pc.race == eRace::HUMAN);
 		// Skip unique_id since it's non-deterministic
-		CHECK(pc.last_cast.empty());
+		CHECK(pc.last_cast.size() == 2);
 		CHECK(pc.combat_pos == loc(-1,-1));
 		CHECK(pc.parry == 0);
 		CHECK(pc.last_attacked == nullptr);


### PR DESCRIPTION
This makes changes to the spellcasting UI.

* M or P to recast will no longer default to Light or Minor Bless/Minor Heal. You need to cast something before recast becomes available. This fixes #535 and I think it's disorienting when I've just started the game and M casts Light in a town that's fully lit, so the change is generally good I'd say.
* I implemented a recasting hint in the text bar, which was one of the things I mentioned in my quality-of-life checklist https://github.com/NQNStudios/cboe/issues/16. It should move status icons to the left when necessary, to fall between the left text and right text. I think with very long spell names, this could overlap with the text, which would be bad. But I don't know what statuses go in the text bar so I haven't tested/handled that case yet.
<img width="452" alt="Screenshot 2025-01-18 at 5 39 31 PM" src="https://github.com/user-attachments/assets/17bdc363-d67a-4924-a14d-197430693d30" />

* Sometimes when my eyes glaze over, I think I'm casting the spell on the wrong side of the LED. I thought there was a bug when I cast Long Light instead of Dumbfound (even though I know the distance between the two is pretty large -- I wasn't paying much attention). I thought it would be nice to highlight the name of the selected spell. Light green seemed to make more sense than red for that, because the LED turns green. Then I made the caster/target selection texts also use light green instead of red, to match. Uncastable spells are grey.

<img width="915" alt="Screenshot 2025-01-18 at 5 39 15 PM" src="https://github.com/user-attachments/assets/9e52ecc2-c82a-4a8b-9a75-c2433591f85e" />

Honestly still haven't decided if I like how it looks, so feedback is welcome.

