### PR TITLE
Keys can shift the screen

### DIFF
--- a/rsrc/dialogs/preferences.xml
+++ b/rsrc/dialogs/preferences.xml
@@ -43,6 +43,7 @@
 	</group>
 	<text name='misc-head' size='large' relative='pos-in pos' anchor='spd-head' top='30' left='0' width='182' height='17'>Miscellaneous:</text>
 	<led name='nosound' relative='pos-in pos' anchor='misc-head' top='6' left='15'>No Sounds</led>
+	<led name='keyshift' relative='pos-in pos' rel-anchor='prev' top='10' left='0'>Directional keys can shift the screen</led>
 	<led name='repeatdesc' relative='pos-in pos' rel-anchor='prev' top='10' left='0'>Show room descriptions more than once</led>
 	<led name='easier' relative='pos-in pos' rel-anchor='prev' top='10' left='0'>Make game easier (monsters much weaker)</led>
 	<led name='lesswm' relative='pos-in pos' rel-anchor='prev' top='10' left='0'>Fewer wandering monsters</led>

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -1283,6 +1283,9 @@ static void handle_party_death() {
 }
 
 void screen_shift(int dx, int dy, bool& need_redraw) {
+	if(abs(dx) + abs(dy) == 0)
+		return;
+
 	if(recording){
 		std::map<std::string,std::string> info;
 		info["dx"] = boost::lexical_cast<std::string>(dx);
@@ -1292,8 +1295,15 @@ void screen_shift(int dx, int dy, bool& need_redraw) {
 
 	center.x += dx;
 	center.y += dy;
+}
 
-	need_redraw = true;
+// If configured to move the screen with arrow keys, do it and return true
+bool handle_screen_shift(location delta, bool& need_redraw) {
+	if(scrollableModes.count(overall_mode) && get_bool_pref("DirectionalKeyScrolling", true)){
+		screen_shift(delta.x, delta.y, need_redraw);
+		return true;
+	}
+	return false;
 }
 
 void handle_print_pc_hp(int which_pc, bool& need_reprint) {
@@ -2249,6 +2259,13 @@ bool handle_keystroke(const sf::Event& event, cFramerateLimiter& fps_limiter){
 		{120,185},{150,185},{180,185},
 		{120,155},{150,155},{180,135}
 	};
+	// Screen shift deltas ordered to correspond with keypad keys
+	location screen_shift_delta[10] = {
+		{0,0},{-1,1},{0,1},{1,1},
+		{-1,0},{0,0},{1,0},
+		{-1,-1},{0,-1},{1,-1}
+	};
+
 	Key talk_chars[9] = {Key::L,Key::N,Key::J,Key::B,Key::S,Key::R,Key::D,Key::G,Key::A};
 	Key shop_chars[8] = {Key::A,Key::B,Key::C,Key::D,Key::E,Key::F,Key::G,Key::H};
 
@@ -2370,11 +2387,14 @@ bool handle_keystroke(const sf::Event& event, cFramerateLimiter& fps_limiter){
 					chr2 = Key::Z;
 				}
 				else {
-					pass_point = mainPtr.mapCoordsToPixel(terrain_click[i], mainView);
-					pass_event.mouseButton.x = pass_point.x;
-					pass_event.mouseButton.y = pass_point.y;
-					are_done = handle_action(pass_event, fps_limiter);
-					return are_done;
+					if(!handle_screen_shift(screen_shift_delta[i], need_redraw)){
+						// Directional keys simulate directional click
+						pass_point = mainPtr.mapCoordsToPixel(terrain_click[i], mainView);
+						pass_event.mouseButton.x = pass_point.x;
+						pass_event.mouseButton.y = pass_point.y;
+						are_done = handle_action(pass_event, fps_limiter);
+						return are_done;
+					}
 				}
 			}
 	}

--- a/src/game/boe.actions.hpp
+++ b/src/game/boe.actions.hpp
@@ -64,6 +64,7 @@ void handle_rename_pc();
 void handle_begin_look(bool right_button, bool& need_redraw, bool& need_reprint);
 void handle_look(location destination, bool right_button, eKeyMod mods, bool& need_redraw, bool& need_reprint);
 void screen_shift(int dx, int dy, bool& need_redraw);
+bool handle_screen_shift(location delta, bool& need_redraw);
 void handle_rest(bool& need_redraw, bool& need_reprint);
 void handle_spellcast(eSkill which_type, bool& did_something, bool& need_redraw, bool& need_reprint, bool record = true);
 void handle_target_space(location destination, bool& did_something, bool& need_redraw, bool& need_reprint);

--- a/src/game/boe.dlgutil.cpp
+++ b/src/game/boe.dlgutil.cpp
@@ -1185,6 +1185,7 @@ static bool prefs_event_filter (cDialog& me, std::string id, eKeyMod) {
 		else if(cur_display_mode == "br") set_pref("DisplayMode", 4);
 		else if(cur_display_mode == "win") set_pref("DisplayMode", 5);
 		set_pref("PlaySounds", dynamic_cast<cLed&>(me["nosound"]).getState() == led_off);
+		set_pref("DirectionalKeyScrolling", dynamic_cast<cLed&>(me["keyshift"]).getState() != led_off);
 		set_pref("RepeatRoomDescriptions", dynamic_cast<cLed&>(me["repeatdesc"]).getState() != led_off);
 		set_pref("ShowInstantHelp", dynamic_cast<cLed&>(me["nohelp"]).getState() == led_off);
 		
@@ -1278,6 +1279,7 @@ void pick_preferences(bool record) {
 	}
 	
 	dynamic_cast<cLed&>(prefsDlog["nosound"]).setState(get_bool_pref("PlaySounds", true) ? led_off : led_red);
+	dynamic_cast<cLed&>(prefsDlog["keyshift"]).setState(get_bool_pref("DirectionalKeyScrolling", true) ? led_red : led_off);
 	dynamic_cast<cLed&>(prefsDlog["repeatdesc"]).setState(get_bool_pref("RepeatRoomDescriptions") ? led_red : led_off);
 	dynamic_cast<cLed&>(prefsDlog["nohelp"]).setState(get_bool_pref("ShowInstantHelp", true) ? led_off : led_red);
 	if(overall_mode == MODE_STARTUP && !party_in_memory) {

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -927,6 +927,18 @@ location terrain_click[8] = {
 	{120,185}, // west
 	{120,155}, // northwest
 };
+// Screen shift deltas ordered to correspond with eDirection
+// TODO screen_shift_delta is duplicated (with different ordering) in boe.actions.cpp
+location screen_shift_delta[8] = {
+	{0,-1}, // north
+	{1,-1}, // northeast
+	{1,0}, // east
+	{1,1}, // southeast
+	{0,1}, // south
+	{-1,1}, // southwest
+	{-1,0}, // west
+	{-1,-1}, // northwest
+};
 
 static void fire_delayed_key(Key code) {
 	bool isUpPressed = delayed_keys[Key::Up] > 0;
@@ -967,11 +979,18 @@ static void fire_delayed_key(Key code) {
 	}
 
 	if(dir != -1){
-		sf::Event pass_event = {sf::Event::MouseButtonPressed};
-		location pass_point = mainPtr.mapCoordsToPixel(terrain_click[dir], mainView);
-		pass_event.mouseButton.x = pass_point.x;
-		pass_event.mouseButton.y = pass_point.y;
-		queue_fake_event(pass_event);
+		bool need_redraw = false;
+		if(handle_screen_shift(screen_shift_delta[dir], need_redraw)){
+			if(need_redraw){
+				draw_terrain();
+			}
+		}else{
+			sf::Event pass_event = {sf::Event::MouseButtonPressed};
+			location pass_point = mainPtr.mapCoordsToPixel(terrain_click[dir], mainView);
+			pass_event.mouseButton.x = pass_point.x;
+			pass_event.mouseButton.y = pass_point.y;
+			queue_fake_event(pass_event);
+		}
 	}
 }
 


### PR DESCRIPTION
This makes it so arrow keys/numpad can control screen shift when it's available.

When this preference is enabled, #482 will not be an issue (Fix #482). But the player will also miss out on cases where adjacent targeting would be a good thing. I haven't done anything smart to determine whether one mode or the other is better on a case-by-case basis.