### PR TITLE
When the player can't end outdoor combat, list living enemies

### DIFF
--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -4660,7 +4660,10 @@ bool hit_end_c_button() {
 	bool end_ok = true;
 	
 	if(which_combat_type == 0) {
-		end_ok = out_monst_all_dead();
+		auto out_monst_remaining = out_monst_alive();
+		if(!out_monst_remaining.empty()){
+			end_ok = false;
+		}
 	}
 	for(cPlayer& pc : univ.party) {
 		if(pc.status[eStatus::FORCECAGE] > 0) {
@@ -4674,14 +4677,23 @@ bool hit_end_c_button() {
 	return end_ok;
 }
 
-bool out_monst_all_dead() {
-	for(short i = 0; i < univ.town.monst.size(); i++)
-		if(univ.town.monst[i].is_alive() && !univ.town.monst[i].is_friendly()) {
+std::map<std::string,short> out_monst_alive() {
+	std::map<std::string,short> monst_alive;
+	for(short i = 0; i < univ.town.monst.size(); i++){
+		cCreature& m = univ.town.monst[i];
+		if(m.is_alive() && !m.is_friendly()) {
+			if(monst_alive.find(m.m_name) != monst_alive.end()){
+				// Would += work in this context?
+				monst_alive[m.m_name] = monst_alive[m.m_name] + 1;
+			}else{
+				monst_alive[m.m_name] = 1;
+			}
+
 			//print_nums(5555,i,univ.town.monst[i].number);
 			//print_nums(5555,univ.town.monst[i].m_loc.x,univ.town.monst[i].m_loc.y);
-			return false;
 		}
-	return true;
+	}
+	return monst_alive;
 }
 
 void end_combat() {

--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -45,6 +45,7 @@ extern short fast_bang;
 extern short store_current_pc;
 extern short combat_posing_monster , current_working_monster ; // 0-5 PC 100 + x - monster x
 extern short missile_firer,current_monst_tactic;
+extern cOutdoors::cWandering store_wandering_special;
 eSpell spell_being_cast;
 bool spell_freebie;
 short missile_inv_slot, ammo_inv_slot;
@@ -4662,6 +4663,10 @@ bool hit_end_c_button() {
 	if(which_combat_type == 0) {
 		auto out_monst_remaining = out_monst_alive();
 		if(!out_monst_remaining.empty()){
+			// Print remaining monsters.
+			add_string_to_buf("Enemies are still alive!");
+			print_encounter_monsters(store_wandering_special, nullptr, out_monst_remaining);
+
 			end_ok = false;
 		}
 	}

--- a/src/game/boe.combat.hpp
+++ b/src/game/boe.combat.hpp
@@ -2,6 +2,7 @@
 #ifndef BOE_GAME_COMBAT_H
 #define BOE_GAME_COMBAT_H
 
+#include <map>
 #include "location.hpp"
 #include "scenario/monster.hpp"
 #include "scenario/outdoors.hpp"
@@ -49,7 +50,7 @@ void do_poison();
 void handle_disease();
 void handle_acid();
 bool hit_end_c_button();
-bool out_monst_all_dead();
+std::map<std::string,short> out_monst_alive();
 void end_combat();
 bool combat_cast_mage_spell();
 bool combat_cast_priest_spell();

--- a/src/game/boe.text.hpp
+++ b/src/game/boe.text.hpp
@@ -19,6 +19,8 @@ cVehicle* town_boat_there(location where);
 cVehicle* out_boat_there(location where);
 cVehicle* town_horse_there(location where);
 cVehicle* out_horse_there(location where);
+// Specify the alive map when combat is in progress so casualties and summons are reflected
+void print_encounter_monsters(cOutdoors::cWandering encounter, short* nums, std::map<std::string,short> alive = {});
 void notify_out_combat_began(cOutdoors::cWandering encounter,short *nums) ;
 std::string get_m_name(mon_num_t num);
 std::string get_ter_name(ter_num_t num);


### PR DESCRIPTION
This implements a quality of life feature on my checklist https://github.com/NQNStudios/cboe/issues/16

When you try to end outdoor combat and monsters are alive, it prints which ones and how many, preserving the same print order as when the encounter begins, and saving summoned monsters for last.