### PR TITLE
Remove warning for spells that use default 1-sq pattern.

### DIFF
--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -5185,9 +5185,8 @@ void start_spell_targeting(eSpell num, bool freebie, int spell_range, eSpellPat 
 			}
 			break;
 		default:
-			if((*num).refer == REFER_TARGET)
-				std::cout << "  Warning: Spell " << (*num).name() << " didn't assign target shape." << std::endl;
-			else add_string_to_buf("  Error: Entered targeting for non-targeted spell " + (*num).name(), 4);
+			if((*num).refer != REFER_TARGET)
+				add_string_to_buf("  Error: Entered targeting for non-targeted spell " + (*num).name(), 4);
 			break;
 	}
 }


### PR DESCRIPTION
This fixes #489.

I considered an alternate solution of adding a case for every 1-sq-target spell, but there are so many of them. Targeting 1 square is a sensible default, not something that should have to be specified, and this warning would only really be useful when adding new spells to avoid forgetting to specify their shape. I say we don't need it.