### PR TITLE
Scenedit Quality of life: be helpful when scrolling past boundaries

### DIFF
--- a/rsrc/dialogs/shift-outdoor-section.xml
+++ b/rsrc/dialogs/shift-outdoor-section.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
+<dialog defbtn='no'>
+	<button name='no' type='regular' def-key='n' top='39' left='244'>No</button>
+	<button name='yes' type='regular' def-key='y' top='39' left='178'>Yes</button>
+	<pict type='dlog' num='11' top='9' left='9'/>
+	<text top='4' left='51' width='251' height='32'>
+		Shift to this outdoor section?
+	</text>
+    <text name='out-sec' relative='pos-in pos' rel-anchor='prev' top='4' left='0'></text>
+</dialog>

--- a/rsrc/dialogs/shift-town-entrance.xml
+++ b/rsrc/dialogs/shift-town-entrance.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
+<dialog defbtn='no'>
+	<button name='no' type='regular' def-key='n' top='39' left='244'>No</button>
+	<button name='yes' type='regular' def-key='y' top='39' left='178'>Yes</button>
+	<pict type='dlog' num='11' top='9' left='9'/>
+	<text top='4' left='51' width='251' height='32'>
+		Shift to this town's entrance in this outdoor section?
+	</text>
+    <text name='out-sec' relative='pos-in pos' rel-anchor='prev' top='4' left='0'></text>
+</dialog>

--- a/src/dialogxml/dialogs/strchoice.hpp
+++ b/src/dialogxml/dialogs/strchoice.hpp
@@ -52,7 +52,8 @@ public:
 	cDialog* operator->();
 	/// Show the dialog.
 	/// @param selectedIndex The index of the string that should be initially selected when the dialog is shown.
-	/// @return The index of the newly selected string; if the user cancelled, this will be equal to selectedIndex.
+	/// @return The index of the newly selected string; if the user cancelled, this will be equal to the initial
+	/// selectedIndex you provide. (So, pass -1 or something to signify that cancelling means the result is invalid.)
 	/// If initialized from an iterator range, this will be relative to begin.
 	size_t show(size_t selectedIndex);
 };

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -440,33 +440,28 @@ static void handle_scenario_args() {
 		}
 		// Try to put the party in an outdoor section from which you can enter the town --
 		// so when you leave, you'll hopefully be in the right place.
-		bool found_entrance = false;
-		for(int x = 0; x < univ.scenario.outdoors.width(); ++x){
-			for(int y = 0; y < univ.scenario.outdoors.height(); ++y){
-				for(spec_loc_t& entrance : univ.scenario.outdoors[x][y]->city_locs){
-					if(entrance.spec == *scen_arg_town){
-						// Very janky but I don't know how else to make it properly load the right sections and set i_w_c
-						while(univ.party.outdoor_corner.x > x){
-							shift_universe_left();
-						}
-						while(univ.party.outdoor_corner.x < x){
-							shift_universe_right();
-						}
-						while(univ.party.outdoor_corner.y > y){
-							shift_universe_up();
-						}
-						while(univ.party.outdoor_corner.y < y){
-							shift_universe_down();
-						}
-						outd_move_party(local_to_global(entrance), true);
-
-						found_entrance = true;
-						break;
-					}
-				}
-				if(found_entrance) break;
+		auto town_entrances = univ.scenario.find_town_entrances(*scen_arg_town);
+		if(!town_entrances.empty()){
+			// TODO a dialog could be shown to choose between multiple entrances,
+			// but maybe that would be janky, because this happens when you're trying to launch
+			// from INSIDE a town.
+			town_entrance_t first_entrance_found = town_entrances[0];
+			int x = first_entrance_found.out_sec.x;
+			int y = first_entrance_found.out_sec.y;
+			// Very janky but I don't know how else to make it properly load the right sections and set i_w_c
+			while(univ.party.outdoor_corner.x > x){
+				shift_universe_left();
 			}
-			if(found_entrance) break;
+			while(univ.party.outdoor_corner.x < x){
+				shift_universe_right();
+			}
+			while(univ.party.outdoor_corner.y > y){
+				shift_universe_up();
+			}
+			while(univ.party.outdoor_corner.y < y){
+				shift_universe_down();
+			}
+			outd_move_party(local_to_global(first_entrance_found.loc), true);
 		}
 
 		short town_entrance = 0;

--- a/src/scenario/scenario.cpp
+++ b/src/scenario/scenario.cpp
@@ -577,3 +577,17 @@ void cScenario::readFrom(const cTagFile& file){
 		}
 	}
 }
+
+std::vector<town_entrance_t> cScenario::find_town_entrances(int town_num) {
+	std::vector<town_entrance_t> matching_entrances;
+	for(int x = 0; x < outdoors.width(); ++x){
+		for(int y = 0; y < outdoors.height(); ++y){
+			for(spec_loc_t& entrance : outdoors[x][y]->city_locs){
+				if(town_num == -1 || entrance.spec == town_num){
+					matching_entrances.push_back({{x, y}, {entrance.x, entrance.y}, static_cast<int>(entrance.spec)});
+				}
+			}
+		}
+	}
+	return matching_entrances;
+}

--- a/src/scenario/scenario.hpp
+++ b/src/scenario/scenario.hpp
@@ -39,6 +39,13 @@ struct scenario_header_flags {
 
 enum eContentRating {G, PG, R, NC17};
 
+// Used for finding town entrances in the outdoors
+struct town_entrance_t {
+	location out_sec;
+	location loc;
+	int town;
+};
+
 class cScenario {
 public:
 	class cItemStorage {
@@ -117,6 +124,10 @@ public:
 	cItem return_treasure(int loot, bool allow_junk_treasure = false) const;
 	cItem pull_item_of_type(unsigned int loot_max,short min_val,short max_val,const std::vector<eItemType>& types,bool allow_junk_treasure=false) const;
 	
+	// Debugging/Editing helper: find town entrances in the outdoors. When town_num is specified, only return entrances
+	// to the town with that number
+	std::vector<town_entrance_t> find_town_entrances(int town_num = -1);
+
 	void reset_version();
 	explicit cScenario();
 	~cScenario();

--- a/src/scenedit/scen.actions.cpp
+++ b/src/scenedit/scen.actions.cpp
@@ -25,6 +25,7 @@
 #include "tools/cursors.hpp"
 #include "dialogxml/widgets/scrollbar.hpp"
 #include "dialogxml/dialogs/strdlog.hpp"
+#include "dialogxml/dialogs/strchoice.hpp"
 #include "dialogxml/dialogs/choicedlog.hpp"
 #ifndef MSBUILD_GITREV
 #include "tools/gitrev.hpp"
@@ -1860,7 +1861,24 @@ void handle_editor_screen_shift(int dx, int dy) {
 				return;
 			}
 		}else if(town_entrances.size() > 1){
+			std::vector<std::string> entrance_strings;
+			for(town_entrance_t entrance : town_entrances){
+				std::ostringstream sstr;
+				sstr << "Entrance in section " << entrance.out_sec << " at " <<  entrance.loc;
+				entrance_strings.push_back(sstr.str());
 
+			}
+			cStringChoice dlog(entrance_strings, "Shift to one of this town's entrances in the outdoors?");
+			size_t choice = dlog.show(-1);
+			if(choice >= 0 && choice < town_entrances.size()){
+				town_entrance_t entrance = town_entrances[choice];
+				set_current_out(entrance.out_sec);
+				start_out_edit();
+				cen_x = entrance.loc.x;
+				cen_y = entrance.loc.y;
+				redraw_screen();
+				return;
+			}
 		}
 	}
 

--- a/src/scenedit/scen.actions.cpp
+++ b/src/scenedit/scen.actions.cpp
@@ -236,10 +236,7 @@ static bool handle_lb_action(location the_point) {
 						file_to_load = nav_get_scenario();
 						if(!file_to_load.empty() && load_scenario(file_to_load, scenario)) {
 							set_current_town(scenario.last_town_edited);
-							cur_out = scenario.last_out_edited;
-							current_terrain = scenario.outdoors[cur_out.x][cur_out.y];
-							overall_mode = MODE_MAIN_SCREEN;
-							set_up_main_screen();
+							set_current_out(scenario.last_out_edited);
 						} else if(!file_to_load.empty())
 							// If we tried to load but failed, the scenario record is messed up, so boot to start screen.
 							set_up_start_screen();
@@ -277,9 +274,7 @@ static bool handle_lb_action(location the_point) {
 					case LB_LOAD_OUT:
 						spot_hit = pick_out(cur_out, scenario);
 						if(spot_hit != cur_out) {
-							cur_out = spot_hit;
-							current_terrain = scenario.outdoors[cur_out.x][cur_out.y];
-							set_up_main_screen();
+							set_current_out(spot_hit);
 						}
 						break;
 					case LB_EDIT_OUT:

--- a/src/scenedit/scen.actions.cpp
+++ b/src/scenedit/scen.actions.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <string>
 #include <stack>
+#include <vector>
 #include <boost/lexical_cast.hpp>
 #include "scen.global.hpp"
 #include "scenario/scenario.hpp"
@@ -1844,7 +1845,23 @@ void handle_editor_screen_shift(int dx, int dy) {
 
 	if(out_of_bounds){
 		// In town, prompt whether to go back to outdoor entrance location
+		std::vector<town_entrance_t> town_entrances = scenario.find_town_entrances(cur_town);
+		if(town_entrances.size() == 1){
+			town_entrance_t only_entrance = town_entrances[0];
+			cChoiceDlog shift_prompt("shift-town-entrance", {"yes", "no"});
+			shift_prompt->getControl("out-sec").setText(boost::lexical_cast<std::string>(only_entrance.out_sec));
 
+			if(shift_prompt.show() == "yes"){
+				set_current_out(only_entrance.out_sec);
+				start_out_edit();
+				cen_x = only_entrance.loc.x;
+				cen_y = only_entrance.loc.y;
+				redraw_screen();
+				return;
+			}
+		}else if(town_entrances.size() > 1){
+
+		}
 	}
 
 	cen_x = minmax(min, max, cen_x + dx);

--- a/src/scenedit/scen.actions.cpp
+++ b/src/scenedit/scen.actions.cpp
@@ -1795,8 +1795,26 @@ bool handle_outdoor_sec_shift(int dx, int dy){
 	shift_prompt->getControl("out-sec").setText(boost::lexical_cast<std::string>(new_out_sec));
 
 	if(shift_prompt.show() == "yes"){
+		int last_cen_x = cen_x;
+		int last_cen_y = cen_y;
 		set_current_out(new_out_sec);
-		// TODO match the terrain view to where we were
+		// match the terrain view to where we were
+		start_out_edit();
+		if(dx < 0) {
+			cen_x = get_current_area()->max_dim - 4;
+		}else if(dx > 0){
+			cen_x = 3;
+		}else{
+			cen_x = last_cen_x;
+		}
+		if(dy < 0){
+			cen_y = get_current_area()->max_dim - 4;
+		}else if(dy > 0){
+			cen_y = 3;
+		}else{
+			cen_y = last_cen_y;
+		}
+		redraw_screen();
 	}
 	return true;
 }

--- a/src/scenedit/scen.actions.hpp
+++ b/src/scenedit/scen.actions.hpp
@@ -8,6 +8,7 @@ void flash_rect(rectangle to_flash);
 void swap_terrain();
 void set_new_terrain(ter_num_t selected_terrain);
 void handle_keystroke(sf::Event event);
+void handle_editor_screen_shift(int dx, int dy);
 void handle_scroll(const sf::Event& event);
 void get_wandering_monst();
 void get_town_info();

--- a/src/scenedit/scen.appleevents.mm
+++ b/src/scenedit/scen.appleevents.mm
@@ -52,11 +52,9 @@ void set_up_apple_events() {
 	
 	if(load_scenario(fileName, scenario)) {
 		set_current_town(scenario.last_town_edited);
-		cur_out = scenario.last_out_edited;
-		current_terrain = scenario.outdoors[cur_out.x][cur_out.y];
 		change_made = false;
 		ae_loading = true;
-		set_up_main_screen();
+		set_current_out(scenario.last_out_edited);
 	}
 	return TRUE;
 }

--- a/src/scenedit/scen.main.cpp
+++ b/src/scenedit/scen.main.cpp
@@ -304,11 +304,9 @@ static void process_args(int argc, char* argv[]) {
 	if(!file.empty()) {
 		if(load_scenario(file, scenario)) {
 			set_current_town(scenario.last_town_edited);
-			cur_out = scenario.last_out_edited;
-			current_terrain = scenario.outdoors[cur_out.x][cur_out.y];
 			change_made = false;
 			ae_loading = true;
-			set_up_main_screen();
+			set_current_out(scenario.last_out_edited);
 		} else {
 			std::cout << "Failed to load scenario: " << file << std::endl;
 		}
@@ -449,11 +447,8 @@ void handle_menu_choice(eMenu item_hit) {
 			if(!file_to_load.empty() && load_scenario(file_to_load, scenario)) {
 				cur_town = scenario.last_town_edited;
 				town = scenario.towns[cur_town];
-				cur_out = scenario.last_out_edited;
-				current_terrain = scenario.outdoors[cur_out.x][cur_out.y];
-				overall_mode = MODE_MAIN_SCREEN;
 				change_made = false;
-				set_up_main_screen();
+				set_current_out(scenario.last_out_edited);
 			} else if(!file_to_load.empty())
 				set_up_start_screen(); // Failed to load file, dump to start
 			undo_list.clear();

--- a/src/scenedit/scen.townout.cpp
+++ b/src/scenedit/scen.townout.cpp
@@ -1296,6 +1296,13 @@ void set_current_town(int to) {
 	scenario.last_town_edited = cur_town;
 }
 
+void set_current_out(location out_sec) {
+	cur_out = out_sec;
+	scenario.last_out_edited = cur_out;
+	current_terrain = scenario.outdoors[cur_out.x][cur_out.y];
+	set_up_main_screen();
+}
+
 aNewTown::aNewTown(cTown* t)
 	: cAction("add town")
 	, theTown(t)

--- a/src/scenedit/scen.townout.hpp
+++ b/src/scenedit/scen.townout.hpp
@@ -23,3 +23,4 @@ void edit_placed_item(short which_i);
 void delete_last_town();
 void edit_town_wand();
 void set_current_town(int to);
+void set_current_out(location out_sec);


### PR DESCRIPTION
I've implemented 2 features here:
* When scrolling past the boundaries of the current outdoor section, you will get a yes/no prompt which can load the adjacent section for you at the corresponding center position.
* When scrolling past the boundaries (literal, not the changeable rectangle) of the current town, the editor will ask if you want to jump to the town's entrance in the outdoors. If there are more than one, you can choose.

I did this because I need to be able to find town entrances in the built-in scenarios so I can debug things.