### PR TITLE
Shop change and talk mode fix

### DIFF
--- a/rsrc/strings/talk-node-descs.txt
+++ b/rsrc/strings/talk-node-descs.txt
@@ -53,7 +53,7 @@ Which shop
 Unused
 Unused
 Name of shop
-Unused
+Response if nothing for sale ...
 Receive Training
 Unused
 Unused

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -1376,14 +1376,18 @@ bool handle_action(const sf::Event& event, cFramerateLimiter& fps_limiter) {
 	
 	// Now split off the extra stuff, like talking and shopping.
 	if(overall_mode == MODE_TALKING) {
-		handle_talk_event(the_point, fps_limiter);
-		if(overall_mode != MODE_TALKING)
-			return false;
+		if(handle_talk_event(the_point, fps_limiter)){
+			advance_time(did_something, need_redraw, need_reprint);
+			are_done = All_Done;
+			return are_done;
+		}
 	}
 	if(overall_mode == MODE_SHOPPING) {
-		handle_shop_event(the_point, fps_limiter);
-		if(overall_mode != MODE_SHOPPING)
-			return false;
+		if(handle_shop_event(the_point, fps_limiter)){
+			advance_time(did_something, need_redraw, need_reprint);
+			are_done = All_Done;
+			return are_done;
+		}
 	}
 
 	// Otherwise they're in a terrain view mode

--- a/src/game/boe.dlgutil.cpp
+++ b/src/game/boe.dlgutil.cpp
@@ -219,18 +219,17 @@ void end_shop_mode() {
 	}
 }
 
-void handle_shop_event(location p, cFramerateLimiter& fps_limiter) {
+bool handle_shop_event(location p, cFramerateLimiter& fps_limiter) {
 	if(p.in(talk_help_rect)) {
-		if(!help_btn->handleClick(p, fps_limiter))
-			return;
-		give_help_and_record(226,27);
-		return;
+		if(help_btn->handleClick(p, fps_limiter))
+			give_help_and_record(226,27);
+		return true;
 	}
 	
 	if(p.in(shop_done_rect)) {
 		if(done_btn->handleClick(p, fps_limiter))
 			end_shop_mode();
-		return;
+		return true;
 	}
 
 	for(short i = 0; i < 8; i++) {
@@ -252,11 +251,14 @@ void handle_shop_event(location p, cFramerateLimiter& fps_limiter) {
 		if(p.in(active_rect)) {
 			click_shop_rect(active_rect);
 			handle_sale(what_picked);
+			return true;
 		} else if(p.in(item_help_rect)){
 			click_shop_rect(item_help_rect);
 			handle_info_request(what_picked);
+			return true;
 		}
 	}
+	return false;
 }
 
 void handle_sale(int i) {
@@ -1110,18 +1112,18 @@ void handle_talk_node(int which_talk_entry) {
 	place_talk_str(save_talk_str1,save_talk_str2,0,dummy_rect);
 }
 
-void handle_talk_event(location p, cFramerateLimiter& fps_limiter) {
+bool handle_talk_event(location p, cFramerateLimiter& fps_limiter) {
 	if(p.in(talk_help_rect)) {
-		if(!help_btn->handleClick(p, fps_limiter))
-			return;
-		give_help_and_record(205,6);
-		return;
+		if(help_btn->handleClick(p, fps_limiter))
+			give_help_and_record(205,6);
+		return true;
 	}
 
 	p.x -= 5;
 	p.y -= 5;
 
 	int which_talk_entry = TALK_DUNNO;
+	bool clicked_word = false;
 	for(word_rect_t& word : talk_words) {
 		if(word.node == -1) continue;
 		rectangle wordRect(word.rect);
@@ -1130,9 +1132,11 @@ void handle_talk_event(location p, cFramerateLimiter& fps_limiter) {
 		if(!p.in(wordRect)) continue;
 		click_talk_rect(word);
 		which_talk_entry = word.node;
+		clicked_word = true;
 		break;
 	}
 	handle_talk_node(which_talk_entry);
+	return clicked_word;
 }
 
 //town_num; // Will be 0 - 200 for town, 200 - 290 for outdoors

--- a/src/game/boe.dlgutil.cpp
+++ b/src/game/boe.dlgutil.cpp
@@ -888,10 +888,17 @@ void handle_talk_node(int which_talk_entry) {
 			return;
 			
 		case eTalkNode::SHOP:
-			if(!start_shop_mode(b,a,save_talk_str1,true))
-				save_talk_str1 = "There is nothing to buy from " + save_talk_str1 + ".";
-			else
+			if(!start_shop_mode(b,a,save_talk_str1,true)){
+				// Second string of shop talk node: Custom message for when shop is empty
+				if(!save_talk_str2.empty()){
+					save_talk_str1 = save_talk_str2;
+					save_talk_str2 = "";
+				}else{
+					save_talk_str1 = "There is nothing available to buy.";
+				}
+			}else{
 				can_save_talk = false;
+			}
 			return;
 		case eTalkNode::JOB_BANK:
 			if(a < univ.party.job_banks.size() && univ.party.job_banks[a].anger >= 50) {

--- a/src/game/boe.dlgutil.hpp
+++ b/src/game/boe.dlgutil.hpp
@@ -7,14 +7,14 @@
 
 bool start_shop_mode(short which,short cost_adj,std::string store_name, bool cancel_when_empty = false);
 void end_shop_mode();
-void handle_shop_event(location p, cFramerateLimiter& fps_limiter);
+bool handle_shop_event(location p, cFramerateLimiter& fps_limiter);
 void handle_sale(int i);
 void handle_info_request(int what_picked);
 void set_up_shop_array();
 void start_talk_mode(short m_num,short personality,mon_num_t monst_type,short store_face_pic);
 void end_talk_mode();
 void handle_talk_node(int which_talk_entry);
-void handle_talk_event(location p, cFramerateLimiter& fps_limiter);
+bool handle_talk_event(location p, cFramerateLimiter& fps_limiter);
 void handle_talk_spec(short ttype,char* place_string1,char* place_string2);
 void store_responses();
 void do_sign(short town_num, short which_sign, short sign_type);

--- a/src/game/boe.dlgutil.hpp
+++ b/src/game/boe.dlgutil.hpp
@@ -5,7 +5,7 @@
 #include "dialogxml/dialogs/dialog.hpp"
 #include "scenario/shop.hpp"
 
-void start_shop_mode(short which,short cost_adj,std::string store_name);
+bool start_shop_mode(short which,short cost_adj,std::string store_name, bool cancel_when_empty = false);
 void end_shop_mode();
 void handle_shop_event(location p, cFramerateLimiter& fps_limiter);
 void handle_sale(int i);


### PR DESCRIPTION
I went to make a message print when there are no items available for sale (as suggested in #216 and will fix #216). This wasn't very hard to do.

When a special node starts a shop, it will still display the shop if there are no items. We could change that, too, by printing to the buffer? I don't know if we need to, though.

While implementing this I noticed bug #544 and fixed it (fix #544)