### PR TITLE
Better editing for talk node keys

### DIFF
--- a/rsrc/dialogs/edit-talk-node.xml
+++ b/rsrc/dialogs/edit-talk-node.xml
@@ -5,6 +5,8 @@
 	<field name='who' top='26' left='186' width='64' height='16'/>
 	<field name='key1' top='54' left='165' width='52' height='16'/>
 	<field name='key2' top='54' left='285' width='52' height='16'/>
+	<text top='6' left='350' width='160' height='48'>The in-game "Buy" button checks for these response keys, in order: purc, sale, heal, iden, trai, ench</text>
+	<text relative='pos-in pos' rel-anchor='prev' top='0' left='0' width='160' height='50'>The "Sell" button checks for sell.</text>
 	<field name='extra1' top='114' left='344' width='64' height='16'/>
 	<field name='extra2' top='137' left='344' width='64' height='16'/>
 	<field name='extra3' top='160' left='344' width='64' height='16'/>

--- a/rsrc/dialogs/edit-talk-node.xml
+++ b/rsrc/dialogs/edit-talk-node.xml
@@ -3,8 +3,8 @@
 <dialog defbtn='okay'>
 	<!-- OK button -->
 	<field name='who' top='26' left='186' width='64' height='16'/>
-	<field name='key1' top='54' left='165' width='52' height='16'/>
-	<field name='key2' top='54' left='285' width='52' height='16'/>
+	<field name='key1' top='54' left='165' width='52' height='16' max-chars='4'/>
+	<field name='key2' top='54' left='285' width='52' height='16' max-chars='4'/>
 	<text top='6' left='350' width='160' height='48'>The in-game "Buy" button checks for these response keys, in order: purc, sale, heal, iden, trai, ench</text>
 	<text relative='pos-in pos' rel-anchor='prev' top='0' left='0' width='160' height='50'>The "Sell" button checks for sell.</text>
 	<field name='extra1' top='114' left='344' width='64' height='16'/>

--- a/rsrc/schemas/dialog.xsd
+++ b/rsrc/schemas/dialog.xsd
@@ -150,6 +150,7 @@
 					</xs:simpleType>
 				</xs:attribute>
 				<xs:attribute name="tab-order" type="xs:integer"/>
+				<xs:attribute name="max-chars" type="xs:integer"/>
 				<xs:attributeGroup ref="rect-size"/>
 				<xs:attributeGroup ref="position"/>
 			</xs:extension>

--- a/src/dialogxml/widgets/field.cpp
+++ b/src/dialogxml/widgets/field.cpp
@@ -442,16 +442,18 @@ void cTextField::handleInput(cKey key, bool record) {
 			handleInput(deleteKey);
 			contents = getText();
 		}
-		if(aTextInsert* ins = dynamic_cast<aTextInsert*>(current_action.get()))
-			ins->append(key.c);
-		else {
-			if(current_action) history.add(current_action);
-			aTextInsert* new_ins = new aTextInsert(*this, insertionPoint);
-			new_ins->append(key.c);
-			current_action.reset(new_ins);
+		if(maxChars < 0 || contents.size() < maxChars){
+			if(aTextInsert* ins = dynamic_cast<aTextInsert*>(current_action.get()))
+				ins->append(key.c);
+			else {
+				if(current_action) history.add(current_action);
+				aTextInsert* new_ins = new aTextInsert(*this, insertionPoint);
+				new_ins->append(key.c);
+				current_action.reset(new_ins);
+			}
+			contents.insert(contents.begin() + insertionPoint, char(key.c));
+			selectionPoint = ++insertionPoint;
 		}
-		contents.insert(contents.begin() + insertionPoint, char(key.c));
-		selectionPoint = ++insertionPoint;
 	} else switch(key.k) {
 		case key_enter: break; // Shouldn't be receiving this anyway
 		case key_left: case key_word_left:
@@ -680,6 +682,9 @@ bool cTextField::parseAttribute(ticpp::Attribute& attr, std::string tagName, std
 		return true;
 	} else if(name == "tab-order"){
 		attr.GetValue(&tabOrder);
+		return true;
+	} else if(name == "max-chars"){
+		attr.GetValue(&maxChars);
 		return true;
 	}
 	return cControl::parseAttribute(attr, tagName, fname);

--- a/src/dialogxml/widgets/field.hpp
+++ b/src/dialogxml/widgets/field.hpp
@@ -90,6 +90,10 @@ private:
 	rectangle text_rect;
 	std::vector<snippet_t> snippets;
 	int ip_row, ip_col;
+	/// Setting maxChars AFTER the player has a chance to type in the field would be a bad idea.
+	/// So would calling setText() with a string longer than maxChars.
+	/// Really, it should probably only be set in xml, as the attribute "max-chars".
+	int maxChars = -1;
 	friend class aTextInsert;
 	friend class aTextDelete;
 };

--- a/src/scenedit/scen.townout.cpp
+++ b/src/scenedit/scen.townout.cpp
@@ -945,6 +945,14 @@ static bool check_talk_key(cDialog& me, std::string item_hit, bool losing) {
 		}
 		return true;
 	}
+
+	// I'll always have trouble remembering that it should be 'purc'.
+	// So why not make it easy?
+	if(key == "buy"){
+		me[item_hit].setText("purc");
+		return true;
+	}
+
 	if(key.length() != 4) passes = false;
 	for(size_t i = 0; i < 4; i++) {
 		if(i < key.length() && !islower(key[i]))

--- a/src/scenedit/scen.townout.cpp
+++ b/src/scenedit/scen.townout.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <stack>
 #include <boost/lexical_cast.hpp>
+#include <boost/algorithm/string/trim.hpp>
 #include "scen.global.hpp"
 #include "scenario/scenario.hpp"
 #include "scenario/town.hpp"
@@ -24,6 +25,8 @@
 #include "dialogxml/widgets/scrollpane.hpp"
 #include "fileio/fileio.hpp"
 #include "fileio/resmgr/res_dialog.hpp"
+
+using boost::algorithm::trim;
 
 extern short cen_x, cen_y, overall_mode;
 extern bool mouse_button_held,change_made;
@@ -932,6 +935,16 @@ static bool check_talk_key(cDialog& me, std::string item_hit, bool losing) {
 	if(!losing) return true;
 	std::string key = me[item_hit].getText();
 	bool passes = true;
+
+	// An empty string is fine, it just means there's only one key.
+	if(key.empty()){
+		// But there needs to be at least one.
+		if(me["key1"].getText() == me["key2"].getText()){
+			showError("At least one of the words in this node must be filled.");
+			return false;
+		}
+		return true;
+	}
 	if(key.length() != 4) passes = false;
 	for(size_t i = 0; i < 4; i++) {
 		if(i < key.length() && !islower(key[i]))
@@ -1088,8 +1101,10 @@ static bool save_talk_node(cDialog& me, std::stack<node_ref_t>& talk_edit_stack,
 	talk_node.personality = me["who"].getTextAsNum();
 	
 	std::string link = me["key1"].getText();
+	if(link.empty()) link = "    ";
 	std::copy(link.begin(), link.begin() + 4, talk_node.link1);
 	link = me["key2"].getText();
+	if(link.empty()) link = "    ";
 	std::copy(link.begin(), link.begin() + 4, talk_node.link2);
 	
 	for(int i = 0; i < 4; i++) {
@@ -1118,9 +1133,12 @@ static void put_talk_node_in_dlog(cDialog& me, std::stack<node_ref_t>& talk_edit
 	
 	std::string link = "";
 	for(int i = 0; i < 4; i++) link += talk_node.link1[i];
+	// I don't want 4 spaces in the text fields
+	trim(link);
 	me["key1"].setText(link);
 	link = "";
 	for(int i = 0; i < 4; i++) link += talk_node.link2[i];
+	trim(link);
 	me["key2"].setText(link);
 	
 	int iDescBase = int(talk_node.type) * 7;

--- a/src/scenedit/scen.townout.cpp
+++ b/src/scenedit/scen.townout.cpp
@@ -4,6 +4,7 @@
 #include <stack>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/trim.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 #include "scen.global.hpp"
 #include "scenario/scenario.hpp"
 #include "scenario/town.hpp"
@@ -27,6 +28,7 @@
 #include "fileio/resmgr/res_dialog.hpp"
 
 using boost::algorithm::trim;
+using boost::algorithm::to_lower;
 
 extern short cen_x, cen_y, overall_mode;
 extern bool mouse_button_held,change_made;
@@ -953,13 +955,17 @@ static bool check_talk_key(cDialog& me, std::string item_hit, bool losing) {
 		return true;
 	}
 
+	// We can convert upper-case letters
+	to_lower(key);
+	me[item_hit].setText(key);
 	if(key.length() != 4) passes = false;
 	for(size_t i = 0; i < 4; i++) {
-		if(i < key.length() && !islower(key[i]))
+		if(i < key.length() && !islower(key[i])){
 			passes = false;
+		}
 	}
 	if(!passes) {
-		showError("The words this node is the response to must be 4 characters long, and all characters must be lower case letters.", &me);
+		showError("The words this node is the response to must be 4 characters long, and all characters must be letters.", &me);
 		return false;
 	}
 	return true;


### PR DESCRIPTION
This is a more involved change than anything in my other scenedit PR.

I really don't like the way the 2 talk node keys are handled in the editor. Filling the fields with 4 spaces, expecting the designer to delete them and put in 4 other characters... just awkward. Also, 'purc' is impossible to remember and I never will.

New behavior is:

* The fields start out empty, and it is *allowed* to keep *one of them* empty. (A node only needs one key to be useful, right?
* When the node is saved, empty strings are replaced with `"    "`. If this is not harmless to the game logic, then I'll need to make the game aware that either key might be `"    "`.
* You cannot type more than 4 characters in these fields (unless there's a way to insert characters I'm not aware of).
* If you put 'buy' in a field, it automatically becomes 'purc'.
* There is a note next to the response keys (kind of squished in the corner) enumerating the special logic of the in-game Buy and Sell buttons.
* My other scenedit PR should be merged first, because these notes overlap with a message that I removed in the other PR. If both PRs are merged it will look like this:

<img width="767" alt="Screenshot 2025-01-23 at 8 09 12 PM" src="https://github.com/user-attachments/assets/e7ab0c6e-7b11-4106-8d05-282c907a0a3d" />
