### PR TITLE
Refactor Debug Keys

### DIFF
--- a/rsrc/dialogs/get-num.xml
+++ b/rsrc/dialogs/get-num.xml
@@ -3,6 +3,6 @@
 <dialog defbtn='okay'>
 	<field name="number" type='int' top='33' left='90' width='75' height='16'/>
 	<pict type='dlog' num='2' top='8' left='8'/>
-	<text name='prompt' size='large' top='8' left='49' width='163' height='16'>How many?</text>
+	<text name='prompt' size='large' top='8' left='49' width='193' height='16'>How many?</text>
 	<button name='okay' type='regular' top='63' left='141'>OK</button>
 </dialog>

--- a/rsrc/dialogs/help-debug.xml
+++ b/rsrc/dialogs/help-debug.xml
@@ -3,31 +3,41 @@
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>
 	<text top='8' left='50' width='400' height='16'>DEBUG MODE HELP</text>
-	<text top='22' left='50' width='400' height='250'>
+	<text top='22' left='50' width='400' height='50'>
 		Debug mode is intended to aid you in testing your scenario.
 		While in debug mode, monsters don't move in combat and are killed in one hit.
 		In addition, you have access to a lot of additional hotkeys.<br/><br/>
-		Debug hot keys<br/>
-		  B - Leave town<br/>
-		  C - Get cleaned up (lose negative status effects)<br/>
-		  D - Toggle Debug mode<br/>
-		  E - Stealth, Detect Life, Firewalk<br/>
-		  F - Flight<br/>
-		  G - Toggle Ghost mode (letting you pass through walls)<br/>
-		  H - Heal<br/>
-		  K - Kill everything<br/>
-		  N - End Scenario<br/>
-		  O - Location<br/>
-		  Q - Magic map<br/>
-		  R - Return to Start<br/>
-		  S - Set stuff done flags<br/>
-		  T - Enter Town<br/>
-		  W - Refresh jobs/shops<br/>
-		  = - Heal, increase magic skills<br/>
-		  &lt; - Make one day pass<br/>
-		  &gt; - Reset towns (excludes the one you're in, if any)<br/>
-		  ! - Toggle Special Node Step-through Mode<br/>
-		  / - Bring up this list<br/>
+		Debug hot keys:<br/>
 	</text>
-	<button name='okay' type='regular' top='280' left='387'>OK</button>
+	<button name='btn1' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='3'></button>
+	<button name='btn2' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn3' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn4' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn5' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn6' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn7' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn8' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn9' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn10' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn11' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn12' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn13' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn14' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn15' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn16' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn17' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn18' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn19' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn20' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn21' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn22' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn23' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn24' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn25' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn26' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn27' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn28' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn29' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn30' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='okay' type='regular' top='400' left='387'>OK</button>
 </dialog>

--- a/rsrc/dialogs/select-sector.xml
+++ b/rsrc/dialogs/select-sector.xml
@@ -12,10 +12,10 @@
 	<text top='41' left='68' width='111' height='14'>World height:</text>
 	<text name='height' top='41' left='186' width='37'/>
 	<text name='y' framed='true' top='88' left='142' width='75' height='16'/>
-	<button name='xminus' type='small' top='59' left='77'>-</button>
-	<button name='xplus' type='small' top='59' left='106'>+</button>
-	<button name='yminus' type='small' top='84' left='77'>-</button>
-	<button name='yplus' type='small' top='84' left='106'>+</button>
+	<button name='xminus' type='small' top='59' left='77' def-key='left'>-</button>
+	<button name='xplus' type='small' top='59' left='106' def-key='right'>+</button>
+	<button name='yminus' type='small' top='84' left='77' def-key='up'>-</button>
+	<button name='yplus' type='small' top='84' left='106' def-key='down'>+</button>
 	<text name='title' framed='true' top='111' left='142' width='150' height='16'/>
 	<button name='choose' type='regular' top='111' left='66'>Choose</button>
 </dialog>

--- a/src/dialogxml/keycodes.cpp
+++ b/src/dialogxml/keycodes.cpp
@@ -52,6 +52,16 @@ cKey charToKey(char ch) {
 			return {false, w('.'), mod_shift};
 		case '!':
 			return {false, w('1'), mod_shift};
+		case '@':
+			return {false, w('2'), mod_shift};
+		case '#':
+			return {false, w('3'), mod_shift};
+		case '$':
+			return {false, w('4'), mod_shift};
+		case '%':
+			return {false, w('5'), mod_shift};
+		case '^':
+			return {false, w('6'), mod_shift};
 		case '?':
 			return {false, w('/'), mod_shift};
 	}

--- a/src/dialogxml/keycodes.cpp
+++ b/src/dialogxml/keycodes.cpp
@@ -5,7 +5,9 @@
  *  Created by Celtic Minstrel on 11/05/09.
  *
  */
-
+#include <sstream>
+#include <codecvt>
+#include <locale>
 #include "keycodes.hpp"
 //#include <sstream>
 //#include "dialog.hpp"
@@ -18,26 +20,40 @@
 //#include "cursors.hpp"
 #include "keymods.hpp"
 
+// Windows won't compile if this conversion is not explicit.
+// (Wildly enough, it claims that char->wchar_t is a NARROWING conversion).
+static wchar_t w(char ch) {
+#ifdef SFML_SYSTEM_WINDOWS
+	std::ostringstream sstr;
+	sstr << ch;
+	std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+	std::wstring wide_str = converter.from_bytes(sstr.str());
+	return wide_str[0];
+#else
+	return ch;
+#endif
+}
+
 // NOTE: This only supports a few characters including the ones
 // that are currently used for debug key shortcuts!
 // It is also very hard-coded to the key layout on my laptop (which may only be standard in the US!)
 cKey charToKey(char ch) {
 	if(ch >= 'a' && ch <= 'z'){
-		return {false, ch};
+		return {false, w(ch)};
 	}else if(ch >= 'A' && ch <= 'Z'){
-		return {false, tolower(ch), mod_shift};
+		return {false, w(tolower(ch)), mod_shift};
 	}
 	switch(ch){
 		case '=': case '/':
-			return {false, ch};
+			return {false, w(ch)};
 		case '<':
-			return {false, ',', mod_shift};
+			return {false, w(','), mod_shift};
 		case '>':
-			return {false, '.', mod_shift};
+			return {false, w('.'), mod_shift};
 		case '!':
-			return {false, '1', mod_shift};
+			return {false, w('1'), mod_shift};
 		case '?':
-			return {false, '/', mod_shift};
+			return {false, w('/'), mod_shift};
 	}
 	throw "Tried to convert unsupported char to cKey!";
 }

--- a/src/dialogxml/keycodes.cpp
+++ b/src/dialogxml/keycodes.cpp
@@ -18,6 +18,30 @@
 //#include "cursors.hpp"
 #include "keymods.hpp"
 
+// NOTE: This only supports a few characters including the ones
+// that are currently used for debug key shortcuts!
+// It is also very hard-coded to the key layout on my laptop (which may only be standard in the US!)
+cKey charToKey(char ch) {
+	if(ch >= 'a' && ch <= 'z'){
+		return {false, ch};
+	}else if(ch >= 'A' && ch <= 'Z'){
+		return {false, tolower(ch), mod_shift};
+	}
+	switch(ch){
+		case '=': case '/':
+			return {false, ch};
+		case '<':
+			return {false, ',', mod_shift};
+		case '>':
+			return {false, '.', mod_shift};
+		case '!':
+			return {false, '1', mod_shift};
+		case '?':
+			return {false, '/', mod_shift};
+	}
+	throw "Tried to convert unsupported char to cKey!";
+}
+
 eKeyMod operator + (eKeyMod lhs, eKeyMod rhs){
 	if(lhs == rhs) return lhs;
 	else if(lhs == mod_none) return rhs;

--- a/src/dialogxml/keycodes.hpp
+++ b/src/dialogxml/keycodes.hpp
@@ -57,6 +57,8 @@ struct cKey {
 	eKeyMod mod;
 };
 
+cKey charToKey(char ch);
+
 /// Combine two key modifiers.
 /// @param lhs @param rhs
 /// @return lhs + rhs

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2273,6 +2273,8 @@ void easter_egg(int idx) {
 	print_buf();
 }
 
+// Non-comprehensive list of unused keys:
+// JUXYZ chijklnoqvy @#$%^-_+[]{},.'"`~/\|;:
 bool handle_keystroke(const sf::Event& event, cFramerateLimiter& fps_limiter){
 	bool are_done = false;
 	location pass_point; // TODO: This isn't needed
@@ -2500,6 +2502,8 @@ bool handle_keystroke(const sf::Event& event, cFramerateLimiter& fps_limiter){
 		case 'D':
 			toggle_debug_mode();
 			break;
+
+		// 'z', Really? 'i' is not used
 		case 'z':
 			show_inventory();
 			break;

--- a/src/game/boe.actions.hpp
+++ b/src/game/boe.actions.hpp
@@ -84,6 +84,7 @@ void show_inventory();
 void toggle_debug_mode();
 void init_debug_actions();
 void show_debug_help();
+void debug_fight_encounter(bool wandering);
 void debug_give_item();
 void debug_print_location();
 void debug_step_through();

--- a/src/game/boe.actions.hpp
+++ b/src/game/boe.actions.hpp
@@ -2,10 +2,17 @@
 #ifndef BOE_GAME_ACTIONS_H
 #define BOE_GAME_ACTIONS_H
 
+#include <vector>
 #include <SFML/Window/Event.hpp>
 #include "location.hpp"
 #include "dialogxml/keycodes.hpp"
 #include "tools/framerate_limiter.hpp"
+
+struct key_action_t {
+    std::vector<char> keys;
+    std::string name;
+    void (*action)();
+};
 
 void init_screen_locs();
 bool prime_time();
@@ -75,6 +82,8 @@ void handle_use_space_select(bool& need_reprint);
 void handle_use_space(location destination, bool& did_something, bool& need_redraw);
 void show_inventory();
 void toggle_debug_mode();
+void init_debug_actions();
+void show_debug_help();
 void debug_give_item();
 void debug_print_location();
 void debug_step_through();

--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -251,11 +251,7 @@ effect_pat_type field[8] = {
 
 bool center_on_monst;
 
-
-
-
-
-void start_outdoor_combat(cOutdoors::cCreature encounter,location where,short num_walls) {
+void start_outdoor_combat(cOutdoors::cWandering encounter,location where,short num_walls) {
 	short how_many,num_tries = 0;
 	short low[10] = {15,7,4,3,2,1,1,7,2,1};
 	short high[10] = {30,10,6,5,3,2,1,10,4,1};
@@ -266,7 +262,7 @@ void start_outdoor_combat(cOutdoors::cCreature encounter,location where,short nu
 		nums[i] = get_ran(1,low[i],high[i]);
 	for(short i = 0; i < 3; i++)
 		nums[i + 7] = get_ran(1,low[i + 7],high[i + 7]);
-	notify_out_combat_began(encounter.what_monst,nums);
+	notify_out_combat_began(encounter,nums);
 	print_buf();
 	play_sound(23);
 	
@@ -286,15 +282,15 @@ void start_outdoor_combat(cOutdoors::cCreature encounter,location where,short nu
 	
 	for(short i = 0; i < 7; i++) {
 		how_many = nums[i];
-		if(encounter.what_monst.monst[i] != 0)
+		if(encounter.monst[i] != 0)
 			for(short j = 0; j < how_many; j++)
-				set_up_monst(eAttitude::HOSTILE_A,encounter.what_monst.monst[i]);
+				set_up_monst(eAttitude::HOSTILE_A,encounter.monst[i]);
 	}
 	for(short i = 0; i < 3; i++) {
 		how_many = nums[i + 7];
-		if(encounter.what_monst.friendly[i] != 0)
+		if(encounter.friendly[i] != 0)
 			for(short j = 0; j < how_many; j++)
-				set_up_monst(eAttitude::FRIENDLY,encounter.what_monst.friendly[i]);
+				set_up_monst(eAttitude::FRIENDLY,encounter.friendly[i]);
 	}
 	
 	// place PCs
@@ -369,6 +365,10 @@ void start_outdoor_combat(cOutdoors::cCreature encounter,location where,short nu
 	//clear_map();
 	give_help(48,49);
 	
+}
+
+void start_outdoor_combat(cOutdoors::cCreature encounter,location where,short num_walls) {
+	start_outdoor_combat(encounter.what_monst, where, num_walls);
 }
 
 bool pc_combat_move(location destination) {

--- a/src/game/boe.combat.hpp
+++ b/src/game/boe.combat.hpp
@@ -9,6 +9,9 @@
 #include "boe.global.hpp"
 #include "spell.hpp"
 
+// For debug purposes, allow directly starting an outdoor encounter without
+// a wandering monster
+void start_outdoor_combat(cOutdoors::cWandering encounter,location where,short num_walls);
 void start_outdoor_combat(cOutdoors::cCreature encounter,location where,short num_walls);
 bool pc_combat_move(location destination);
 void char_parry();

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -875,6 +875,8 @@ static void replay_action(Element& action) {
 		easter_egg(boost::lexical_cast<int>(action.GetText()));
 	}else if(t == "show_debug_panel"){
 		show_debug_help();
+	}else if(t == "debug_fight_encounter"){
+		debug_fight_encounter(str_to_bool(action.GetText()));
 	}else if(t == "advance_time"){
 		// This is bad regardless of strictness, because visual changes may have occurred which won't get redrawn/reprinted
 		throw std::string { "Replay system internal error! advance_time() was supposed to be called by the last action, but wasn't: " } + _last_action_type;

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -873,6 +873,8 @@ static void replay_action(Element& action) {
 		cancel_item_target(did_something, need_redraw, need_reprint);
 	}else if(t == "easter_egg"){
 		easter_egg(boost::lexical_cast<int>(action.GetText()));
+	}else if(t == "show_debug_panel"){
+		show_debug_help();
 	}else if(t == "advance_time"){
 		// This is bad regardless of strictness, because visual changes may have occurred which won't get redrawn/reprinted
 		throw std::string { "Replay system internal error! advance_time() was supposed to be called by the last action, but wasn't: " } + _last_action_type;
@@ -942,6 +944,7 @@ void init_boe(int argc, char* argv[]) {
 	cUniverse::print_result = iLiving::print_result = add_string_to_buf;
 	cPlayer::give_help = give_help;
 	init_fileio();
+	init_debug_actions();
 	init_spell_menus();
 	init_mini_map();
 	redraw_screen(REFRESH_NONE);

--- a/src/scenario/outdoors.hpp
+++ b/src/scenario/outdoors.hpp
@@ -44,7 +44,9 @@ public:
 	// Definition of an outdoor combat encounter
 	class cWandering { // formerly out_wandering_type
 	public:
+		// max 7 types of monster per encounter
 		std::array<mon_num_t,7> monst;
+		// max 3 types of friendly npc per encounter
 		std::array<mon_num_t,3> friendly;
 		short spec_on_meet,spec_on_win,spec_on_flee;
 		short end_spec1,end_spec2;

--- a/src/scenario/outdoors.hpp
+++ b/src/scenario/outdoors.hpp
@@ -41,6 +41,7 @@ using bitmap = std::array<std::bitset<y>, x>;
 class cOutdoors : public cArea {
 	cScenario* scenario;
 public:
+	// Definition of an outdoor combat encounter
 	class cWandering { // formerly out_wandering_type
 	public:
 		std::array<mon_num_t,7> monst;
@@ -55,6 +56,7 @@ public:
 		void readFrom(const cTagFile_Page& page);
 		cWandering();
 	};
+	// Instantiation of an outdoor wandering monster on the map
 	class cCreature { // formerly outdoor_creature_type
 	public:
 		bool exists = false;


### PR DESCRIPTION
I wanted to add a new debug action, and then I wanted to have it automatically appear in the help dialog, and I also wanted the debug help dialog to come up in response to `?` because I never remember it's just `/` for the debug one. And I wanted the help dialogue to just let me pick one since the list is open already.

So I did all that.

Putting all the debug actions into a map the way I've done here, is a pattern we could repeat for ALL keyboard shortcuts, although I don't want to do that work if there's no need to. But it would move us towards the dream of #319.

* Just for fun, you can use the arrow keys to pick a new outdoor section in the scenario editor (this is very nice)
* I made a new debug action: press `%` to fight a wandering encounter from the current section, or press `^` to fight a special encounter. 

