### PR TITLE
Modified the UI redraw order in handle_death() to fix #250 and #558.

### DIFF
--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -3230,7 +3230,7 @@ void handle_death() {
 	while(true) {
 		// Use death (or leave Exile) dialog
 		choice = cChoiceDlog("party-death",{"load","new","quit"}).show();
-
+		
 		if(choice == "quit") {
 			All_Done = true;
 			return;

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -3225,11 +3225,12 @@ void handle_death() {
 	std::string choice;
 	
 	overall_mode = MODE_STARTUP;
+	reload_startup();
 	
 	while(true) {
 		// Use death (or leave Exile) dialog
 		choice = cChoiceDlog("party-death",{"load","new","quit"}).show();
-		
+
 		if(choice == "quit") {
 			All_Done = true;
 			return;
@@ -3246,7 +3247,6 @@ void handle_death() {
 		else if(choice == "new") {
 			// TODO: Windows version dumps to main screen without creating a party; which is better?
 			start_new_game();
-			reload_startup();
 			return;
 		}
 	}


### PR DESCRIPTION
Tested on Linux. Unconfirmed on MacOS and Windows.