### PR TITLE
Scons copy bdf fonts.

### DIFF
--- a/rsrc/SConscript
+++ b/rsrc/SConscript
@@ -11,7 +11,7 @@ Import("env platform data_dir install_dir")
 
 env.Install(path.join(data_dir, "cursors"), Glob("cursors/*.gif"))
 env.Install(path.join(data_dir, "dialogs"), Glob("dialogs/*.xml"))
-env.Install(path.join(data_dir, "fonts"), Glob("fonts/*.ttf"))
+env.Install(path.join(data_dir, "fonts"), Glob("fonts/*.ttf") + Glob("fonts/*.bdf"))
 env.Install(path.join(data_dir, "graphics"), Glob("graphics/*.png"))
 env.Install(path.join(data_dir, "sounds"), Glob("sounds/*.wav"))
 env.Install(path.join(data_dir, "strings"), Glob("strings/*.txt"))


### PR DESCRIPTION
I did some experimenting on getting @clort81's ClortSans font into the game.

It turns out that the resource manager had already been updated to support bdf files. The one problem was that Scons would only copy ttf files, so I fixed that, and that should suffice to Fix #229. (Note: they also asked for PCX fonts, but SFML [does not support those](https://www.sfml-dev.org/documentation/2.5.1/classsf_1_1Font.php):

> The supported font formats are: TrueType, Type 1, CFF, OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42. Note that this function knows nothing about the standard fonts installed on the user's system, thus you can't load them directly.

Having made that change, I tried loading ClortSans-12 which can be downloaded here:

https://github.com/calref/cboe/files/4143613/bdftest.tar.gz

I changed the code to use ClortSans wherever `FONT_PLAIN` was requested. This broke an enormous amount of in-game text which tries to render `FONT_PLAIN` in sizes other than 12-point. Unfortunately, in the places where 12-point was requested and it rendered correctly, it didn't look as good in-game as in the mockup images (I assume because of weird rendering issues). It became apparent to me that even if I could make it render well, it would be an enormous amount of work to make sure that all text in the game switched to the bitmap font and still looked good. I'm not interested in doing that work. We also would need the font in a bunch of other sizes that I don't think it exists in.

Also, these other links to ClortSans bitmap fonts are dead:

https://clort.shell.ircnow.org/ClortSans1_0.zip
https://clort.shell.ircnow.org/ClortSansBold1_0.zip

I don't know if they were to variants in any of the other sizes we'd need.