### PR TITLE
Dialogxml fixes/notes/updates

### DIFF
--- a/rsrc/dialogs/1str-lg.xml
+++ b/rsrc/dialogs/1str-lg.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict name='pict' type='dlog' size='large' num='0' top='9' left='9'/>

--- a/rsrc/dialogs/1str-title-lg.xml
+++ b/rsrc/dialogs/1str-title-lg.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict name='pict' type='dlog' size='large' num='0' top='9' left='9'/>

--- a/rsrc/dialogs/1str-title.xml
+++ b/rsrc/dialogs/1str-title.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict name='pict' type='dlog' num='8' top='9' left='9'/>

--- a/rsrc/dialogs/1str.xml
+++ b/rsrc/dialogs/1str.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict name='pict' type='dlog' num='8' top='9' left='9'/>

--- a/rsrc/dialogs/2str-lg.xml
+++ b/rsrc/dialogs/2str-lg.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict name='pict' type='dlog' size='large' num='0' top='9' left='9'/>

--- a/rsrc/dialogs/2str-title-lg.xml
+++ b/rsrc/dialogs/2str-title-lg.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict name='pict' type='dlog' size='large' num='0' top='9' left='9'/>

--- a/rsrc/dialogs/2str-title.xml
+++ b/rsrc/dialogs/2str-title.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict name='pict' type='dlog' num='8' top='9' left='9'/>

--- a/rsrc/dialogs/2str.xml
+++ b/rsrc/dialogs/2str.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict name='pict' type='dlog' num='8' top='9' left='9'/>

--- a/rsrc/dialogs/abort-game.xml
+++ b/rsrc/dialogs/abort-game.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<pict type='dlog' num='23' top='9' left='9'/>

--- a/rsrc/dialogs/add-new-sheet.xml
+++ b/rsrc/dialogs/add-new-sheet.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='new'>
 	<pict type='dlog' num='16' top='6' left='6'/>

--- a/rsrc/dialogs/add-random-items.xml
+++ b/rsrc/dialogs/add-random-items.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='89' left='252'>OK</button>

--- a/rsrc/dialogs/adventure-notes.xml
+++ b/rsrc/dialogs/adventure-notes.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<button name='done' type='done' top='341' left='319'/>

--- a/rsrc/dialogs/attack-friendly.xml
+++ b/rsrc/dialogs/attack-friendly.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<pict type='dlog' num='10' top='6' left='6'/>

--- a/rsrc/dialogs/basic-button.xml
+++ b/rsrc/dialogs/basic-button.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='no'>
 	<button name='no' type='regular' def-key='n' top='39' left='244'>No</button>

--- a/rsrc/dialogs/basic-lever.xml
+++ b/rsrc/dialogs/basic-lever.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='leave'>
 	<pict type='dlog' num='9' top='9' left='8'/>

--- a/rsrc/dialogs/basic-portal.xml
+++ b/rsrc/dialogs/basic-portal.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='no'>
 	<button name='no' type='regular' def-key='n' top='39' left='244'>No</button>

--- a/rsrc/dialogs/basic-slope-down.xml
+++ b/rsrc/dialogs/basic-slope-down.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='leave'>
 	<button name='leave' type='regular' top='35' left='243'>Leave</button>

--- a/rsrc/dialogs/basic-slope-up.xml
+++ b/rsrc/dialogs/basic-slope-up.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='leave'>
 	<button name='leave' type='regular' top='35' left='243'>Leave</button>

--- a/rsrc/dialogs/basic-stair-down.xml
+++ b/rsrc/dialogs/basic-stair-down.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='leave'>
 	<button name='leave' type='regular' top='27' left='242'>Leave</button>

--- a/rsrc/dialogs/basic-stair-up.xml
+++ b/rsrc/dialogs/basic-stair-up.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='leave'>
 	<button name='leave' type='regular' top='27' left='242'>Leave</button>

--- a/rsrc/dialogs/basic-trap.xml
+++ b/rsrc/dialogs/basic-trap.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='no'>
 	<button name='no' type='regular' def-key='n' top='39' left='244'>No</button>

--- a/rsrc/dialogs/boat-bridge.xml
+++ b/rsrc/dialogs/boat-bridge.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='under'>
 	<button name='under' type='regular' top='46' left='246'>Under</button>

--- a/rsrc/dialogs/change-terrain.xml
+++ b/rsrc/dialogs/change-terrain.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/choose-bg.xml
+++ b/rsrc/dialogs/choose-bg.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/choose-pict.xml
+++ b/rsrc/dialogs/choose-pict.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict name='mainpic' type='dlog' num='16' top='6' left='6'/>

--- a/rsrc/dialogs/choose-string.xml
+++ b/rsrc/dialogs/choose-string.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/clear-items-confirm.xml
+++ b/rsrc/dialogs/clear-items-confirm.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='39' left='239'>OK</button>

--- a/rsrc/dialogs/confirm-interrupt-replay.xml
+++ b/rsrc/dialogs/confirm-interrupt-replay.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<pict type='dlog' num='23' top='9' left='9'/>

--- a/rsrc/dialogs/confirm-interrupt-special.xml
+++ b/rsrc/dialogs/confirm-interrupt-special.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<pict type='dlog' num='23' top='9' left='9'/>

--- a/rsrc/dialogs/confirm-reset-help.xml
+++ b/rsrc/dialogs/confirm-reset-help.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='no'>
 	<button name='no' type='regular' def-key='n' top='39' left='244'>No</button>

--- a/rsrc/dialogs/congrats-save.xml
+++ b/rsrc/dialogs/congrats-save.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<button name='cancel' type='regular' top='91' left='234'>Cancel</button>

--- a/rsrc/dialogs/convert-pics-now.xml
+++ b/rsrc/dialogs/convert-pics-now.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='convert'>
 	<pict type='dlog' num='16' top='6' left='6'/>

--- a/rsrc/dialogs/dark-slope-down.xml
+++ b/rsrc/dialogs/dark-slope-down.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='leave'>
 	<button name='leave' type='regular' top='50' left='246'>Leave</button>

--- a/rsrc/dialogs/dark-slope-up.xml
+++ b/rsrc/dialogs/dark-slope-up.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='leave'>
 	<button name='leave' type='regular' top='35' left='243'>Leave</button>

--- a/rsrc/dialogs/data-dump-confirm.xml
+++ b/rsrc/dialogs/data-dump-confirm.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='74' left='255'>OK</button>

--- a/rsrc/dialogs/delete-pc-confirm.xml
+++ b/rsrc/dialogs/delete-pc-confirm.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='no'>
 	<pict type='dlog' num='7' top='6' left='6'/>

--- a/rsrc/dialogs/delete-town-confirm.xml
+++ b/rsrc/dialogs/delete-town-confirm.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='143' left='252'>OK</button>

--- a/rsrc/dialogs/discard-special-node.xml
+++ b/rsrc/dialogs/discard-special-node.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='save'>
 	<pict type='dlog' num='16' top='6' left='6'/>

--- a/rsrc/dialogs/drop-item-confirm.xml
+++ b/rsrc/dialogs/drop-item-confirm.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<pict type='dlog' num='2' top='8' left='8'/>

--- a/rsrc/dialogs/edit-day.xml
+++ b/rsrc/dialogs/edit-day.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name="number" type='uint' top='36' left='133' width='75' height='16'/>

--- a/rsrc/dialogs/edit-dialog-text.xml
+++ b/rsrc/dialogs/edit-dialog-text.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name='str1' top='55' left='57' width='545' height='48'/>

--- a/rsrc/dialogs/edit-intro.xml
+++ b/rsrc/dialogs/edit-intro.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name='str1' top='83' left='57' width='540' height='39'/>

--- a/rsrc/dialogs/edit-item-shortcut.xml
+++ b/rsrc/dialogs/edit-item-shortcut.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name='item1' type='uint' top='188' left='73' width='39' height='16'/>

--- a/rsrc/dialogs/edit-item.xml
+++ b/rsrc/dialogs/edit-item.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/edit-mabil-general.xml
+++ b/rsrc/dialogs/edit-mabil-general.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/edit-mabil-missile.xml
+++ b/rsrc/dialogs/edit-mabil-missile.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/edit-mabil-radiate.xml
+++ b/rsrc/dialogs/edit-mabil-radiate.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/edit-mabil-special.xml
+++ b/rsrc/dialogs/edit-mabil-special.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/edit-mabil-summon.xml
+++ b/rsrc/dialogs/edit-mabil-summon.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/edit-monster-abils.xml
+++ b/rsrc/dialogs/edit-monster-abils.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/edit-monster.xml
+++ b/rsrc/dialogs/edit-monster.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/edit-outdoor-details.xml
+++ b/rsrc/dialogs/edit-outdoor-details.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/edit-outdoor-encounter.xml
+++ b/rsrc/dialogs/edit-outdoor-encounter.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/edit-personality.xml
+++ b/rsrc/dialogs/edit-personality.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/edit-placed-item.xml
+++ b/rsrc/dialogs/edit-placed-item.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/edit-quest.xml
+++ b/rsrc/dialogs/edit-quest.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/edit-save-rects.xml
+++ b/rsrc/dialogs/edit-save-rects.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/edit-scenario-details.xml
+++ b/rsrc/dialogs/edit-scenario-details.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name='ver1' type='uint' top='80' left='181' width='43' height='16'/>

--- a/rsrc/dialogs/edit-scenario-events.xml
+++ b/rsrc/dialogs/edit-scenario-events.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/edit-shop-item.xml
+++ b/rsrc/dialogs/edit-shop-item.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/edit-shop-special.xml
+++ b/rsrc/dialogs/edit-shop-special.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/edit-shop.xml
+++ b/rsrc/dialogs/edit-shop.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/edit-sign.xml
+++ b/rsrc/dialogs/edit-sign.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/edit-sounds.xml
+++ b/rsrc/dialogs/edit-sounds.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='6' left='6'/>

--- a/rsrc/dialogs/edit-special-assign.xml
+++ b/rsrc/dialogs/edit-special-assign.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name='num' type='uint' top='64' left='209' width='75' height='16'/>

--- a/rsrc/dialogs/edit-special-item.xml
+++ b/rsrc/dialogs/edit-special-item.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name='name' top='57' left='195' width='252' height='16'/>

--- a/rsrc/dialogs/edit-special-node.xml
+++ b/rsrc/dialogs/edit-special-node.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/edit-special-text-sm.xml
+++ b/rsrc/dialogs/edit-special-text-sm.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name='str1' top='32' left='53' width='293' height='96'/>

--- a/rsrc/dialogs/edit-special-text.xml
+++ b/rsrc/dialogs/edit-special-text.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name='str1' top='60' left='53' width='293' height='96'/>

--- a/rsrc/dialogs/edit-talk-node.xml
+++ b/rsrc/dialogs/edit-talk-node.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/edit-ter-obj.xml
+++ b/rsrc/dialogs/edit-ter-obj.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/edit-terrain.xml
+++ b/rsrc/dialogs/edit-terrain.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<!--

--- a/rsrc/dialogs/edit-text.xml
+++ b/rsrc/dialogs/edit-text.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name='text' type='text' top='40' left='55' width='293' height='98'/>

--- a/rsrc/dialogs/edit-town-advanced.xml
+++ b/rsrc/dialogs/edit-town-advanced.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/edit-town-advanced.xml
+++ b/rsrc/dialogs/edit-town-advanced.xml
@@ -1,5 +1,4 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/edit-town-details.xml
+++ b/rsrc/dialogs/edit-town-details.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/edit-town-events.xml
+++ b/rsrc/dialogs/edit-town-events.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/edit-town-varying.xml
+++ b/rsrc/dialogs/edit-town-varying.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/edit-town-wandering.xml
+++ b/rsrc/dialogs/edit-town-wandering.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/edit-townperson-advanced.xml
+++ b/rsrc/dialogs/edit-townperson-advanced.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/edit-townperson.xml
+++ b/rsrc/dialogs/edit-townperson.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name='talk' top='189' left='149' width='67' height='16'/>

--- a/rsrc/dialogs/edit-vehicle.xml
+++ b/rsrc/dialogs/edit-vehicle.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/edit-xp.xml
+++ b/rsrc/dialogs/edit-xp.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name="number" type='uint' top='127' left='216' width='75' height='16'/>

--- a/rsrc/dialogs/event-journal.xml
+++ b/rsrc/dialogs/event-journal.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<button name='done' type='done' top='341' left='319'/>

--- a/rsrc/dialogs/get-items.xml
+++ b/rsrc/dialogs/get-items.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<button name='done' type='done' top='408' left='337'/>

--- a/rsrc/dialogs/get-mabil-num.xml
+++ b/rsrc/dialogs/get-mabil-num.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name="number" type='int' top='53' left='60' width='75' height='16'/>

--- a/rsrc/dialogs/get-num.xml
+++ b/rsrc/dialogs/get-num.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name="number" type='int' top='33' left='90' width='75' height='16'/>

--- a/rsrc/dialogs/get-response.xml
+++ b/rsrc/dialogs/get-response.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name='response' type='text' top='34' left='88' width='75' height='16'/>

--- a/rsrc/dialogs/graphic-sheets.xml
+++ b/rsrc/dialogs/graphic-sheets.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='6' left='6'/>

--- a/rsrc/dialogs/graphic-types.xml
+++ b/rsrc/dialogs/graphic-types.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='6' left='6'/>

--- a/rsrc/dialogs/have-no-pics.xml
+++ b/rsrc/dialogs/have-no-pics.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='new'>
 	<pict type='dlog' num='16' top='6' left='6'/>

--- a/rsrc/dialogs/have-only-full-pics.xml
+++ b/rsrc/dialogs/have-only-full-pics.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='new'>
 	<pict type='dlog' num='16' top='6' left='6'/>

--- a/rsrc/dialogs/help-combat.xml
+++ b/rsrc/dialogs/help-combat.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/help-contest.xml
+++ b/rsrc/dialogs/help-contest.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/help-distributing.xml
+++ b/rsrc/dialogs/help-distributing.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/help-editing.xml
+++ b/rsrc/dialogs/help-editing.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/help-hints.xml
+++ b/rsrc/dialogs/help-hints.xml
@@ -1,35 +1,24 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
-	<!--
-	 TODO: This dialog is very disorganized; clean it up
-	 TODO: This dialog contains out-of-date information
-	 -->
 	<pict type='dlog' num='24' top='6' left='6'/>
-	<text size='large' top='6' left='50' width='131' height='18'>Bugs and Stuff:</text>
-	<text top='69' left='50' width='84' height='13'>Need a Hint?</text>
-	<text top='139' left='50' width='473' height='28'>
-		To order Blades of Exile, click on How To Order on the title screen to get full ordering instructions.
-	</text>
-	<text top='174' left='50' width='480' height='65'>
-		COMMENTS:<br/>
-		We LOVE to hear what you have to say.
-		Comments, questions, complaints, etc. can be sent to the addresses on the About Blades of Exile page.
-		Also, be sure to visit Spiderweb Software's web site:<br/>
-		                        http://www.spidweb.com
-	</text>
-	<text top='26' left='50' width='475' height='41'>
-		Alas, though we tried, we probably didn't get all the bugs and typos out of Blades of Exile.
-		Should you find one, a bug report form is enclosed with the game.
-		Also, an E-mail address for comments is on the About Blades of Exile page.
-	</text>
-	<text top='84' left='50' width='474' height='54'>
+	<text size='large' top='6' left='50' width='84' height='13'>Need a Hint?</text>
+	<text relative='pos-in pos' rel-anchor='prev' top='10' left='0' width='474' height='25'>
 		Can't get into the School of Magery?
 		The Valley plague getting you down?
 		Can't get to the end of the Za-Khazi Run in time?
 		Help is available!
-		When you register, the documentation comes with a hint book
-		for the 3 Blades of Exile scenarios!
 	</text>
-	<button name='okay' type='regular' top='242' left='471'>OK</button>
+	<text name='hints' relative='pos-in pos' rel-anchor='prev' top='6' left='16' colour='link' underline='true'>
+		https://openboe.com/docs/game/Hints.html
+	</text>
+	<text size='large' relative='neg pos' rel-anchor='prev' top='5' left='16' width='131' height='18'>Bugs and Stuff:</text>
+	<text relative='pos-in pos' rel-anchor='prev' top='10' left='0' width='475' height='25'>
+		Alas, though we're trying, we haven't gotten all the bugs and typos out of Open Blades of Exile.
+		Should you find one, open a ticket here:
+	</text>
+	<text name=	'issues' relative='pos-in pos' rel-anchor='prev' top='6' left='16' colour='link' underline='true'>
+		https://github.com/calref/cboe/issues
+	</text>
+	<button name='okay' type='regular' top='142' left='471'>OK</button>
 </dialog>

--- a/rsrc/dialogs/help-inventory.xml
+++ b/rsrc/dialogs/help-inventory.xml
@@ -3,7 +3,6 @@
 <dialog defbtn='okay'>
 	<!--
 	 TODO: This dialog is very disorganized; clean it up
-	 TODO: This dialog contains out-of-date information (the recommendation of a sage in Fort Emergence, and the jobs button, though the latter is likely to be reinstated)
 	 -->
 	<button name='okay' type='regular' top='384' left='435'>OK</button>
 	<pict type='dlog' num='24' top='9' left='9'/>
@@ -19,7 +18,7 @@
 	</text>
 	<text top='274' left='63' width='429' height='50'>
 		Items from slain monsters normally appear unidentified.
-		To identify them, take them to a sage (such as Habecker in Fort Emergence).
+		To identify them, take them to a sage.
 		Also, buying Item Lore skill sometimes makes monster's treasure appear already identified.
 	</text>
 	<text top='95' left='63' width='424' height='33'>

--- a/rsrc/dialogs/help-inventory.xml
+++ b/rsrc/dialogs/help-inventory.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/help-magic.xml
+++ b/rsrc/dialogs/help-magic.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/help-outdoor.xml
+++ b/rsrc/dialogs/help-outdoor.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/help-party.xml
+++ b/rsrc/dialogs/help-party.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='24' top='8' left='8'/>

--- a/rsrc/dialogs/help-testing.xml
+++ b/rsrc/dialogs/help-testing.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/help-town.xml
+++ b/rsrc/dialogs/help-town.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/inventory-full.xml
+++ b/rsrc/dialogs/inventory-full.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='2' left='8' top='8'/>

--- a/rsrc/dialogs/item-info.xml
+++ b/rsrc/dialogs/item-info.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict name='pic' type='item' num='0' top='9' left='8'/>

--- a/rsrc/dialogs/job-board.xml
+++ b/rsrc/dialogs/job-board.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict type='dlog' num='3' top='9' left='9'/>

--- a/rsrc/dialogs/keep-stored-items.xml
+++ b/rsrc/dialogs/keep-stored-items.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='yes'>
 	<button name='yes' type='regular' def-key='y' top='64' left='246'>Yes</button>

--- a/rsrc/dialogs/leave-scenario.xml
+++ b/rsrc/dialogs/leave-scenario.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='84' left='251'>OK</button>

--- a/rsrc/dialogs/leave-town.xml
+++ b/rsrc/dialogs/leave-town.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='48' left='252'>OK</button>

--- a/rsrc/dialogs/locked-door-action.xml
+++ b/rsrc/dialogs/locked-door-action.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='leave'>
 	<button name='leave' type='regular' top='36' left='271'>Leave</button>

--- a/rsrc/dialogs/make-scenario1.xml
+++ b/rsrc/dialogs/make-scenario1.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name='name' top='34' left='351' width='125' height='32'>Scenario name</field>

--- a/rsrc/dialogs/make-scenario2.xml
+++ b/rsrc/dialogs/make-scenario2.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK Button -->

--- a/rsrc/dialogs/many-str.xml
+++ b/rsrc/dialogs/many-str.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<!-- Unexpected picture item -->

--- a/rsrc/dialogs/monster-info.xml
+++ b/rsrc/dialogs/monster-info.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<text size='large' top='257' left='21' width='87' height='16'>Resistances:</text>

--- a/rsrc/dialogs/must-delete-in-order.xml
+++ b/rsrc/dialogs/must-delete-in-order.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<pict type='dlog' num='16' top='6' left='6'/>

--- a/rsrc/dialogs/need-party.xml
+++ b/rsrc/dialogs/need-party.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='52' left='256'>OK</button>

--- a/rsrc/dialogs/new-party.xml
+++ b/rsrc/dialogs/new-party.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='161' left='248'>Create</button>

--- a/rsrc/dialogs/new-town.xml
+++ b/rsrc/dialogs/new-town.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK Button -->

--- a/rsrc/dialogs/not-at-edge.xml
+++ b/rsrc/dialogs/not-at-edge.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='37' left='256'>OK</button>

--- a/rsrc/dialogs/not-split.xml
+++ b/rsrc/dialogs/not-split.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='25' left='246'>OK</button>

--- a/rsrc/dialogs/party-death.xml
+++ b/rsrc/dialogs/party-death.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='load'>
 	<!--

--- a/rsrc/dialogs/pc-alchemy-info.xml
+++ b/rsrc/dialogs/pc-alchemy-info.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<text size='large' top='10' left='54' width='163' height='15'>Alchemy known:</text>

--- a/rsrc/dialogs/pc-info.xml
+++ b/rsrc/dialogs/pc-info.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<button name='done' type='done' top='339' left='418'/>

--- a/rsrc/dialogs/pc-spell-info.xml
+++ b/rsrc/dialogs/pc-spell-info.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<!--

--- a/rsrc/dialogs/pick-pc-name.xml
+++ b/rsrc/dialogs/pick-pc-name.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- Unexpected OK button -->

--- a/rsrc/dialogs/pick-potion.xml
+++ b/rsrc/dialogs/pick-potion.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<button name='cancel' type='regular' def-key='esc' top='303' left='415'>Cancel</button>

--- a/rsrc/dialogs/pick-race-abil.xml
+++ b/rsrc/dialogs/pick-race-abil.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<text size='large' top='9' left='55' width='181' height='16'>Special Characteristics:</text>

--- a/rsrc/dialogs/pick-scenario.xml
+++ b/rsrc/dialogs/pick-scenario.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<text size='large' top='9' left='130' width='126' height='17'>Start a Scenario:</text>

--- a/rsrc/dialogs/pick-spec-type.xml
+++ b/rsrc/dialogs/pick-spec-type.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/quest-info.xml
+++ b/rsrc/dialogs/quest-info.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict type='dlog' num='21' top='8' left='8'/>

--- a/rsrc/dialogs/quit-confirm-nosave.xml
+++ b/rsrc/dialogs/quit-confirm-nosave.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<pict type='dlog' num='23' top='9' left='9'/>

--- a/rsrc/dialogs/quit-confirm-save.xml
+++ b/rsrc/dialogs/quit-confirm-save.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='save'>
 	<pict type='dlog' num='23' top='9' left='9'/>

--- a/rsrc/dialogs/removed-special-items.xml
+++ b/rsrc/dialogs/removed-special-items.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='50' left='246'>OK</button>

--- a/rsrc/dialogs/reset-story.xml
+++ b/rsrc/dialogs/reset-story.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='reset'>
 	<button name='reset' type='regular' top='50' left='246'>Reset</button>

--- a/rsrc/dialogs/resize-outdoors.xml
+++ b/rsrc/dialogs/resize-outdoors.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>

--- a/rsrc/dialogs/restart-game.xml
+++ b/rsrc/dialogs/restart-game.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<pict type='dlog' num='23' top='9' left='9'/>

--- a/rsrc/dialogs/reunite-first.xml
+++ b/rsrc/dialogs/reunite-first.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='49' left='251'>OK</button>

--- a/rsrc/dialogs/reunited.xml
+++ b/rsrc/dialogs/reunited.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='86' left='261'>OK</button>

--- a/rsrc/dialogs/save-before-close.xml
+++ b/rsrc/dialogs/save-before-close.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='save'>
 	<button name='save' type='regular' top='43' left='240'>Save</button>

--- a/rsrc/dialogs/save-before-launch.xml
+++ b/rsrc/dialogs/save-before-launch.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='save'>
 	<button name='save' type='regular' top='43' left='240'>OK</button>

--- a/rsrc/dialogs/save-before-load.xml
+++ b/rsrc/dialogs/save-before-load.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='save'>
 	<button name='save' type='regular' top='43' left='240'>Save</button>

--- a/rsrc/dialogs/save-before-quit.xml
+++ b/rsrc/dialogs/save-before-quit.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='save'>
 	<button name='save' type='regular' top='43' left='240'>Save</button>

--- a/rsrc/dialogs/save-before-revert.xml
+++ b/rsrc/dialogs/save-before-revert.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<button name='cancel' type='regular' def-key='esc' top='43' left='240'>Cancel</button>

--- a/rsrc/dialogs/save-close.xml
+++ b/rsrc/dialogs/save-close.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='save'>
 	<button name='save' type='large' top='31' left='230'>Save First</button>

--- a/rsrc/dialogs/save-legacy-scen.xml
+++ b/rsrc/dialogs/save-legacy-scen.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='update'>
 	<pict type='dlog' num='16' top='6' left='6'/>

--- a/rsrc/dialogs/save-open.xml
+++ b/rsrc/dialogs/save-open.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='save'>
 	<button name='save' type='large' top='41' left='233'>Save First</button>

--- a/rsrc/dialogs/save-quit.xml
+++ b/rsrc/dialogs/save-quit.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='save'>
 	<button name='save' type='large' top='31' left='230'>Save First</button>

--- a/rsrc/dialogs/save-revert.xml
+++ b/rsrc/dialogs/save-revert.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='41' left='272'>Revert</button>

--- a/rsrc/dialogs/scen-version-mismatch.xml
+++ b/rsrc/dialogs/scen-version-mismatch.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!--

--- a/rsrc/dialogs/select-import-town.xml
+++ b/rsrc/dialogs/select-import-town.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK Button -->

--- a/rsrc/dialogs/select-pc.xml
+++ b/rsrc/dialogs/select-pc.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<text top='190' left='11' width='184' height='18'>Hit a button or type '1'-'6'.</text>

--- a/rsrc/dialogs/select-sector.xml
+++ b/rsrc/dialogs/select-sector.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/select-town-edit.xml
+++ b/rsrc/dialogs/select-town-edit.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/select-town-enter.xml
+++ b/rsrc/dialogs/select-town-enter.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<!-- OK button -->

--- a/rsrc/dialogs/set-area-desc.xml
+++ b/rsrc/dialogs/set-area-desc.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<field name='area' top='34' left='55' width='332' height='16'/>

--- a/rsrc/dialogs/set-not-owned.xml
+++ b/rsrc/dialogs/set-not-owned.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='54' left='240'>OK</button>

--- a/rsrc/dialogs/set-sdf.xml
+++ b/rsrc/dialogs/set-sdf.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='set'>
 	<pict type='dlog' num='7' top='8' left='8'/>

--- a/rsrc/dialogs/shift-outdoor-section.xml
+++ b/rsrc/dialogs/shift-outdoor-section.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='no'>
 	<button name='no' type='regular' def-key='n' top='39' left='244'>No</button>

--- a/rsrc/dialogs/shift-town-entrance.xml
+++ b/rsrc/dialogs/shift-town-entrance.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='no'>
 	<button name='no' type='regular' def-key='n' top='39' left='244'>No</button>

--- a/rsrc/dialogs/show-map.xml
+++ b/rsrc/dialogs/show-map.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='276' left='232'>OK</button>

--- a/rsrc/dialogs/skill-info.xml
+++ b/rsrc/dialogs/skill-info.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<pict type='dlog' num='24' top='8' left='8'/>

--- a/rsrc/dialogs/slimy-stair-down.xml
+++ b/rsrc/dialogs/slimy-stair-down.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='leave'>
 	<button name='leave' type='regular' top='45' left='243'>Leave</button>

--- a/rsrc/dialogs/slimy-stair-up.xml
+++ b/rsrc/dialogs/slimy-stair-up.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='leave'>
 	<button name='leave' type='regular' top='37' left='242'>Leave</button>

--- a/rsrc/dialogs/slimy-stair-up.xml
+++ b/rsrc/dialogs/slimy-stair-up.xml
@@ -5,9 +5,6 @@
 	<button name='leave' type='regular' top='37' left='242'>Leave</button>
 	<button name='climb' type='regular' top='37' left='176'>Climb</button>
 	<pict type='dlog' num='19' top='8' left='8'/>
-	<!--
-	 TODO: This one is cut off at the bottom in the browser; verify this doesn't also happen in-game.
-	 -->
 	<text top='3' left='50' width='250' height='32'>
 		You find a stairway heading up.
 		The steps are covered with a thin layer of slick, unpleasant slime.

--- a/rsrc/dialogs/soul-crystal.xml
+++ b/rsrc/dialogs/soul-crystal.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<button name='cancel' type='regular' def-key='esc' top='145' left='238'>Cancel</button>

--- a/rsrc/dialogs/spell-info.xml
+++ b/rsrc/dialogs/spell-info.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<!-- Unknown offscreen PICT element -->

--- a/rsrc/dialogs/spend-xp.xml
+++ b/rsrc/dialogs/spend-xp.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog>
 	<!--

--- a/rsrc/dialogs/steal-item.xml
+++ b/rsrc/dialogs/steal-item.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <!--DOCTYPE dialog SYSTEM	"dialog.dtd"-->
 <dialog defbtn='leave'>

--- a/rsrc/dialogs/steal-item.xml
+++ b/rsrc/dialogs/steal-item.xml
@@ -3,9 +3,6 @@
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <!--DOCTYPE dialog SYSTEM	"dialog.dtd"-->
 <dialog defbtn='leave'>
-	<!--
-	 TODO: The defbtn value about should be 'leave'; I left it like this to see if xmllint could catch it.
-	 -->
 	<pict type='monst' num='12' top='6' left='6'/>
 	<text top='6' left='48' width='246' height='35'>
 		This item is clearly someone's property.

--- a/rsrc/dialogs/talk-notes.xml
+++ b/rsrc/dialogs/talk-notes.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<button name='done' type='done' top='285' left='250'/>

--- a/rsrc/dialogs/text-dump-confirm.xml
+++ b/rsrc/dialogs/text-dump-confirm.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<button name='okay' type='regular' top='105' left='254'>OK</button>

--- a/rsrc/dialogs/tip-of-day.xml
+++ b/rsrc/dialogs/tip-of-day.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='done'>
 	<button name='done' type='done' top='158' left='242'/>

--- a/rsrc/dialogs/view-sign.xml
+++ b/rsrc/dialogs/view-sign.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- NOTE: This file should be updated to use relative positioning the next time it changes. -->
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='okay'>
 	<pict name='ter' type='ter' num='0' top='10' left='9'/>

--- a/src/scenedit/scen.main.cpp
+++ b/src/scenedit/scen.main.cpp
@@ -427,9 +427,16 @@ void redraw_everything() {
 	restore_cursor();
 }
 
+void show_outdated_warning() {
+	std::string outdated_help1 = "The information in the following help window is extremely outdated! The most up-to-date documentation for OpenBoE is here:";
+	std::string outdated_help2 = "https://openboe.com/docs";
+
+	showWarning(outdated_help1, outdated_help2);
+}
+
 void handle_menu_choice(eMenu item_hit) {
 	extern cUndoList undo_list;
-	bool isEdit = false, isHelp = false;
+	bool isEdit = false, isHelp = false, isOutdated = false;
 	std::string helpDlog;
 	fs::path file_to_load;
 	cKey editKey = {true};
@@ -741,18 +748,22 @@ void handle_menu_choice(eMenu item_hit) {
 		case eMenu::HELP_START:
 			helpDlog = "help-editing";
 			isHelp = true;
+			isOutdated = true;
 			break;
 		case eMenu::HELP_TEST:
 			helpDlog = "help-testing";
 			isHelp = true;
+			isOutdated = true;
 			break;
 		case eMenu::HELP_DIST:
 			helpDlog = "help-distributing";
 			isHelp = true;
+			isOutdated = true;
 			break;
 		case eMenu::HELP_CONTEST:
 			helpDlog = "help-contest";
 			isHelp = true;
+			isOutdated = true;
 			break;
 	}
 	if(isEdit) {
@@ -769,8 +780,12 @@ void handle_menu_choice(eMenu item_hit) {
 			redraw_screen();
 		}
 	}
-	if(isHelp)
+	if(isHelp){
+		if(isOutdated){
+			show_outdated_warning();
+		}
 		cChoiceDlog(helpDlog).show();
+	}
 	redraw_screen();
 }
 


### PR DESCRIPTION
We have 4 help windows in the scenario editor that are very outdated (including #495) -- I added a cautionary dialog that warns the user the info is outdated and has the URL for openboe.com. (This is temporary and these will eventually probably call launchDocs instead of opening a help dialog at all.)

I fixed up the Hints dialog in the main game so it's up-to-date.

I removed an out-of-date Exile 3 reference from help-inventory and a TODO comment that's not relevant anymore because we do have a JOBS button.

Went through and exhaustively added a note about which dialogxmls should eventually get relative positioning if we ever need to change them. This marks the work that would be required for #300, which is not necessarily worth actually doing for the many many dialogs that just might stay the same forever.