### PR TITLE
Launch terrain type documentation for help button

### DIFF
--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -1304,15 +1304,11 @@ void close_program() {
 	sync_prefs();
 }
 
-extern fs::path progDir;
-
 void handle_help_toc() {
 	if(recording){
 		record_action("handle_help_toc", "");
 	}
-	if(fs::is_directory(progDir/"doc"))
-		launchURL("file://" + (progDir/"doc/game/Contents.html").string());
-	else launchURL("http://openboe.com/docs/game/Contents.html");
+	launchDocs("game/Contents.html");
 }
 
 void menu_give_help(short help1){

--- a/src/pcedit/pc.main.cpp
+++ b/src/pcedit/pc.main.cpp
@@ -77,7 +77,6 @@ void save_prefs();
 bool prefs_event_filter (cDialog& me, std::string id, eKeyMod);
 
 extern bool cur_scen_is_mac;
-extern fs::path progDir;
 short specials_res_id;
 char start_name[256];
 
@@ -436,9 +435,7 @@ void handle_menu_choice(eMenu item_hit) {
 			edit_stuff_done();
 			break;
 		case eMenu::HELP_TOC:
-			if(fs::is_directory(progDir/"doc"))
-				launchURL("file://" + (progDir/"doc/game/Editor.html").string());
-			else launchURL("http://openboe.com/docs/game/Editor.html");
+			launchDocs("game/Editor.html");
 			break;
 	}
 }

--- a/src/scenedit/scen.core.cpp
+++ b/src/scenedit/scen.core.cpp
@@ -605,7 +605,10 @@ bool edit_ter_type(ter_num_t which) {
 	ter_dlg.attachClickHandlers(std::bind(finish_editing_ter,_1,_2,std::ref(which)), {"left", "right", "done"});
 	ter_dlg["picktrim"].attachClickHandler(std::bind(pick_string,"trim-names", _1, "trim", ""));
 	ter_dlg["pickarena"].attachClickHandler(std::bind(pick_string,"arena-names", _1, "arena", ""));
-	ter_dlg["help"].attachClickHandler(std::bind(show_help, "ter-type-help", _1, 16));
+	ter_dlg["help"].attachClickHandler([](cDialog&, std::string, eKeyMod) -> bool {
+		launchDocs("editor/Terrain.html");
+		return true;
+	});
 	ter_dlg["sound"].attachFocusHandler(play_ter_step_sound);
 	ter_dlg.attachClickHandlers(pick_ter_flag, {"pickflag1", "pickflag2", "pickflag3", "editspec", "picktrans"});
 	ter_dlg["picktown"].attachClickHandler([](cDialog& me, std::string, eKeyMod) -> bool {

--- a/src/scenedit/scen.main.cpp
+++ b/src/scenedit/scen.main.cpp
@@ -427,7 +427,6 @@ void redraw_everything() {
 	restore_cursor();
 }
 
-extern fs::path progDir;
 void handle_menu_choice(eMenu item_hit) {
 	extern cUndoList undo_list;
 	bool isEdit = false, isHelp = false;
@@ -737,9 +736,7 @@ void handle_menu_choice(eMenu item_hit) {
 			isHelp = true;
 			break;
 		case eMenu::HELP_TOC:
-			if(fs::is_directory(progDir/"doc"))
-				launchURL("file://" + (progDir/"doc/editor/Contents.html").string());
-			else launchURL("http://openboe.com/docs/editor/Contents.html");
+			launchDocs("editor/Contents.html");
 			break;
 		case eMenu::HELP_START:
 			helpDlog = "help-editing";

--- a/src/tools/winutil.cpp
+++ b/src/tools/winutil.cpp
@@ -1,5 +1,6 @@
 #include "winutil.hpp"
 
+#include <boost/filesystem/operations.hpp>
 #include "keymods.hpp"
 
 // The default scale should be the largest that the user's screen can fit all three
@@ -48,4 +49,14 @@ bool pollEvent(sf::Window& win, sf::Event& event){
 
 bool pollEvent(sf::Window* win, sf::Event& event){
     return pollEvent(*win, event);
+}
+
+extern fs::path progDir;
+
+void launchDocs(std::string relative_url) {
+	if(fs::is_directory(progDir/"doc")){
+		launchURL("file://" + (progDir/"doc"/relative_url).string());
+	}else{
+		launchURL("http://openboe.com/docs/" + relative_url);
+	}
 }

--- a/src/tools/winutil.hpp
+++ b/src/tools/winutil.hpp
@@ -29,6 +29,9 @@ bool pollEvent(sf::Window* win, sf::Event& event);
 
 void init_fileio();
 void launchURL(std::string url);
+// Open a documentation page relative to packaged HTML if available,
+// or openboe.com if not
+void launchDocs(std::string relative_url);
 
 // Optionally do some platform-specific preprocessing on the command-line arguments before parsing them.
 // If preprocessing is needed, the expectation is that they will be modified in-place.


### PR DESCRIPTION
This adds a reusable function to launch documentation URLs.

Fix #553 - help button launches terrain type documentation page.