### PR TITLE
Fixed typos for Resurrection Balm and Leather Baldric

### DIFF
--- a/rsrc/bases/bladbase/items.xml
+++ b/rsrc/bases/bladbase/items.xml
@@ -2332,7 +2332,7 @@
         <bonus>0</bonus>
         <protection>0</protection>
         <pic>14</pic>
-        <name>Leather Baldri</name>
+        <name>Leather Baldric</name>
         <full-name>Leather Baldric</full-name>
         <treasure>0</treasure>
         <value>4</value>
@@ -7321,7 +7321,7 @@
         <charges>1</charges>
         <pic>61</pic>
         <name>Balm</name>
-        <full-name>Ressurection Balm</full-name>
+        <full-name>Resurrection Balm</full-name>
         <treasure>2</treasure>
         <value>200</value>
         <weight>3</weight>

--- a/rsrc/scenarios/busywork/items.xml
+++ b/rsrc/scenarios/busywork/items.xml
@@ -2332,7 +2332,7 @@
         <bonus>0</bonus>
         <protection>0</protection>
         <pic>14</pic>
-        <name>Leather Baldri</name>
+        <name>Leather Baldric</name>
         <full-name>Leather Baldric</full-name>
         <treasure>0</treasure>
         <value>4</value>
@@ -7311,7 +7311,7 @@
         <charges>1</charges>
         <pic>61</pic>
         <name>Balm</name>
-        <full-name>Ressurection Balm</full-name>
+        <full-name>Resurrection Balm</full-name>
         <treasure>2</treasure>
         <value>200</value>
         <weight>3</weight>

--- a/rsrc/scenarios/stealth/items.xml
+++ b/rsrc/scenarios/stealth/items.xml
@@ -2332,7 +2332,7 @@
         <bonus>0</bonus>
         <protection>0</protection>
         <pic>14</pic>
-        <name>Leather Baldri</name>
+        <name>Leather Baldric</name>
         <full-name>Leather Baldric</full-name>
         <treasure>0</treasure>
         <value>4</value>
@@ -7311,7 +7311,7 @@
         <charges>1</charges>
         <pic>61</pic>
         <name>Balm</name>
-        <full-name>Ressurection Balm</full-name>
+        <full-name>Resurrection Balm</full-name>
         <treasure>2</treasure>
         <value>200</value>
         <weight>3</weight>

--- a/rsrc/scenarios/valleydy/items.xml
+++ b/rsrc/scenarios/valleydy/items.xml
@@ -2339,7 +2339,7 @@
         <bonus>0</bonus>
         <protection>0</protection>
         <pic>14</pic>
-        <name>Leather Baldri</name>
+        <name>Leather Baldric</name>
         <full-name>Leather Baldric</full-name>
         <treasure>0</treasure>
         <value>4</value>
@@ -7318,7 +7318,7 @@
         <charges>1</charges>
         <pic>61</pic>
         <name>Balm</name>
-        <full-name>Ressurection Balm</full-name>
+        <full-name>Resurrection Balm</full-name>
         <treasure>2</treasure>
         <value>200</value>
         <weight>3</weight>

--- a/rsrc/scenarios/zakhazi/items.xml
+++ b/rsrc/scenarios/zakhazi/items.xml
@@ -2346,7 +2346,7 @@
         <bonus>0</bonus>
         <protection>0</protection>
         <pic>14</pic>
-        <name>Leather Baldri</name>
+        <name>Leather Baldric</name>
         <full-name>Leather Baldric</full-name>
         <treasure>0</treasure>
         <value>4</value>
@@ -7325,7 +7325,7 @@
         <charges>1</charges>
         <pic>61</pic>
         <name>Balm</name>
-        <full-name>Ressurection Balm</full-name>
+        <full-name>Resurrection Balm</full-name>
         <treasure>2</treasure>
         <value>200</value>
         <weight>3</weight>

--- a/test/files/town/townrectUniversal/items.xml
+++ b/test/files/town/townrectUniversal/items.xml
@@ -2332,7 +2332,7 @@
         <bonus>0</bonus>
         <protection>0</protection>
         <pic>14</pic>
-        <name>Leather Baldri</name>
+        <name>Leather Baldric</name>
         <full-name>Leather Baldric</full-name>
         <treasure>0</treasure>
         <value>4</value>
@@ -7321,7 +7321,7 @@
         <charges>1</charges>
         <pic>61</pic>
         <name>Balm</name>
-        <full-name>Ressurection Balm</full-name>
+        <full-name>Resurrection Balm</full-name>
         <treasure>2</treasure>
         <value>200</value>
         <weight>3</weight>

--- a/test/replays/scenarios/use-special-terrain/items.xml
+++ b/test/replays/scenarios/use-special-terrain/items.xml
@@ -2332,7 +2332,7 @@
         <bonus>0</bonus>
         <protection>0</protection>
         <pic>14</pic>
-        <name>Leather Baldri</name>
+        <name>Leather Baldric</name>
         <full-name>Leather Baldric</full-name>
         <treasure>0</treasure>
         <value>4</value>
@@ -7321,7 +7321,7 @@
         <charges>1</charges>
         <pic>61</pic>
         <name>Balm</name>
-        <full-name>Ressurection Balm</full-name>
+        <full-name>Resurrection Balm</full-name>
         <treasure>2</treasure>
         <value>200</value>
         <weight>3</weight>


### PR DESCRIPTION
See title. Changes the unidentified name for Leather Baldric (which was "Leather Baldri") and fixes a typo in the name of Resurrection Balm (was "Ressurection Balm").