### PR TITLE
Him/her -> them

### DIFF
--- a/doc/documentation.lyx
+++ b/doc/documentation.lyx
@@ -324,7 +324,7 @@ Now that you have some armor and weapons, it's time to put on your new gear.
  Click on another PC's name.
  It will become the active character, and that PC's inventory will appear
  below.
- You can also type the PC's number to make him/her active, a very useful
+ You can also type the PC's number to make them active, a very useful
  shortcut.
 \end_layout
 
@@ -359,7 +359,7 @@ Talking to people
 \begin_layout Standard
 To get anywhere in Blades of Exile, you'll need to talk to many, many people.
  Might as well try this now.
- Hit 't' and then click on a person to talk to him/her/it.
+ Hit 't' and then click on a person to talk to them.
  The talking window will appear.
 \end_layout
 
@@ -2462,7 +2462,7 @@ Dead people can be brought back to life.
  This can be done using certain priest spells, or at the healers you will
  find in some of the towns.
  If the killing blow does enough damage, it will turn the PC into dust.
- It will then be much more difficult to raise him/her from the dead.
+ It will then be much more difficult to raise them from the dead.
 \end_layout
 
 \begin_layout Subsection

--- a/doc/game/Combat.html
+++ b/doc/game/Combat.html
@@ -121,7 +121,7 @@ they immediately drop to the ground.<br>
 Dead people can be brought back to life. This can be done using certain priest spells,
 or at the healers you will find in some of the towns. If the killing blow does enough
 damage, it will turn the PC into dust. It will then be much more difficult to raise
-him/her from the dead.</dd>
+them from the dead.</dd>
 <dt>Killing Enemies:</dt>
 <dd>Whenever you kill an enemy, the person dealing the death blow gets
 some experience, and everyone else gets a much smaller amount. Should this experience give

--- a/doc/game/Editor.html
+++ b/doc/game/Editor.html
@@ -46,7 +46,7 @@ information or a new item, but very risky to take things away.</li>
 <h3>Using the Main Screen</h3>
 <p>Once you've opened a save file, you'll see your party displayed on the main screen. One
 character's button will be blue. This is the active character. Click on another character
-to make him/her active.</p>
+to make them active.</p>
 <p>To the right is the active character's inventory. To drop an item, click the D button.
 To identify an item, click the I button.</p>
 <p>To the right are the five buttons you can use to edit this character:</p>

--- a/doc/game/Mage.html
+++ b/doc/game/Mage.html
@@ -88,7 +88,7 @@ several targets. The number of missiles increases with the level of the caster. 
 don't want to use all the missiles, hit space to cast the spell.</li>
 <li>Web: (C 6, R 8) This spell covers a large circle with icky webs, slowing down everyone
 inside. The webs last until torn down.</li>
-<li>Resist Magic: (C 4) You can cast this spell on another PC to make him/her resistant to
+<li>Resist Magic: (C 4) You can cast this spell on another PC to make them resistant to
 magical damage and effects. Note this does not help against damage from fire and
 cold.</li>
 </ul>

--- a/doc/game/Priest.html
+++ b/doc/game/Priest.html
@@ -28,7 +28,7 @@ selected PC.</li>
 amount of damage to it. It has no effect on non-undead.</li>
 <li>Location: (C 1) Returns the party's x-y location in the town or outdoors.</li>
 <li>Sanctuary: (C 1) The target of this spell becomes magically shielded.</li>
-<li>For a time, monsters probably won't be able to attack him/her. The effects disappears
+<li>For a time, monsters probably won't be able to attack them. The effects disappears
 when the PC attacks someone.</li>
 <li>Symbiosis: (C 3) This spell has the caster absorb the damage taken by another
 character. The higher the caster's level, the less damage the caster takes per health
@@ -60,7 +60,7 @@ fight for the party. The chance of it working drops sharply with the level of th
 monster.</li>
 <li>Disease: (C 4, R 6) The victim of this spell is afflicted by a disease, which slowly
 weakens it. The disease lasts a long time.</li>
-<li>Awaken: (C 2) Casting this on a character immediately wakes him/her up.</li>
+<li>Awaken: (C 2) Casting this on a character immediately wakes them up.</li>
 </ul>
 
 <h2 id='L3'>Level 3</h2>

--- a/doc/game/Tips.html
+++ b/doc/game/Tips.html
@@ -75,7 +75,7 @@ screen, listing your party, is to the upper right. One of your characters' names
 in italics. This is the active character. This character's inventory is given in the item
 screen below it. Click on another PC's name. It will become the active character, and that
 PC's inventory will appear below. You can also type the PC's number (using the numbers
-along the top of the keyboard, not the keypad) to make him/her active, a very useful
+along the top of the keyboard, not the keypad) to make them active, a very useful
 shortcut.</p>
 <p>Go to one of your PCs inventory pages. Click on the name of, say, a suit of armor. The
 name of that item will now appear in italics. That means you're wearing it! Click it again
@@ -90,7 +90,7 @@ go out and kill something.</p>
 <h3>Talking to people</h3>
 <p>To get anywhere in Blades of Exile, you'll need to talk to many, many people. Might as
 well try this now. Click the mouth button (or hit <span class='key'>t</span>) and then
-click on a person to talk to him/her/it. The talking window will appear.</p>
+click on a person to talk to them. The talking window will appear.</p>
 <p>Notice the buttons at the bottom of this area. Click on Name and Job, and you'll get
 the basic information that character has to say.</p>
 <p>To ask someone about something, click on the word after they say it. If someone says "I

--- a/rsrc/dialogs/help-combat.xml
+++ b/rsrc/dialogs/help-combat.xml
@@ -10,7 +10,7 @@
 	<text top='26' left='66' width='473' height='49'>
 		Your PCs will act one at a time.
 		To move, click on the terrain screen in the direction you want to move, or use the keypad.
-		To have the PC stand ready, click on him/her.
+		To have the PC stand ready, click on them.
 		The buttons on the bottom act as follows:
 	</text>
 	<text top='348' left='66' width='476' height='49'>

--- a/rsrc/dialogs/help-magic.xml
+++ b/rsrc/dialogs/help-magic.xml
@@ -38,7 +38,7 @@
 		Note that spell effects are cumulative.
 		Two poison spells do more than twice the damage of one poison spell.
 		If a fear spell doesn't work, the next one will be more likely to.
-		Casting 3 bless spells on a PC will make him/her a powerhouse.
+		Casting 3 bless spells on a PC will make them a powerhouse.
 	</text>
 	<text top='81' left='77' width='397' height='54'>
 		SPELL MENUS -

--- a/rsrc/strings/help.txt
+++ b/rsrc/strings/help.txt
@@ -6,8 +6,8 @@ Everyone responds to 'Look', 'Name', and 'Job' (use the buttons at the bottom). 
 Shortcuts: To get previous response, press the Back button (or hit space). You can press any of the bottom buttons by typing the first letter in the word. Hit Record to write notes in journal, and hit Bye (or type Escape) to stop talking.
 To cast a spell, first click on the number of the person to cast (to the upper left). Then click on the button by the spell to cast (hit Space to see other spells). Finally, if it's a spell cast on a party member, click on the correct Target button.
 Shortcut: Typing the letter after a spell picks the spell, and typing '1'-'6' picks a caster. Option clicking a spell button brings up a spell description. Finally, you can often cast spells faster using the Mage Spells and Priest spells menus.
-This menu always contains all the spells an active PC can cast. Click on the name of a PC to make him/her active. Then select a spell from this menu to cast. Then, if you need to pick someone to cast the spell on, a window will come up for you to do so.
-This is where you improve a character's skills when creating or training him/her. Press the '+' button to buy a skill, and the '-' button to undo the choice. The Cancel button undoes your work, and Keep keeps your choices.
+This menu always contains all the spells an active PC can cast. Click on the name of a PC to make them active. Then select a spell from this menu to cast. Then, if you need to pick someone to cast the spell on, a window will come up for you to do so.
+This is where you improve a character's skills when creating or training them. Press the '+' button to buy a skill, and the '-' button to undo the choice. The Cancel button undoes your work, and Keep keeps your choices.
 Option-click the buttons by a skill to get a description of the skill and advice on how much to buy. When training a character, you need both gold and skill points (which you get by killing things and getting experience).
 This menu contains the monsters you have magically obtained information about. To make a monster appear here, cast Scry Monster on it.
 

--- a/rsrc/strings/mage-spells.txt
+++ b/rsrc/strings/mage-spells.txt
@@ -27,7 +27,7 @@ This powerful spell creates a line of force walls, which are like fire walls but
 When cast, a group of monsters appears and attacks all enemies of the caster. The number of monsters depends on the level of the caster. After a time, they disappear.
 This spell is like flame, but the caster gets to select several targets. The number of missiles increases with the level of the caster. If you don't want to use all the missiles, hit the space bar to cast the spell.
 This spell covers a large circle with icky webs, slowing down everyone inside. The webs last until torn down.
-You can cast this spell on another PC to make him/her resistant to magical damage and effects. Note this does not help against damage from fire or cold.
+You can cast this spell on another PC to make them resistant to magical damage and effects. Note this does not help against damage from fire or cold.
 This makes poison run thick in the veins of the target. Repeated castings will have a devastating effect.
 Slams the target with a heavy, pointed bolt of ice. Effective against monsters who are resistant to fire. Damage increases as the level of the caster increases.
 Makes all monsters within a 12 space radius move at half speed for a time.

--- a/rsrc/strings/priest-spells.txt
+++ b/rsrc/strings/priest-spells.txt
@@ -3,7 +3,7 @@ Increases the health of the selected PC a small amount, up to the PC's	maximum h
 Reduces the amount of poison running around in the veins of the	selected PC.
 When cast on an undead creature, it usually does a reasonable	amount of damage to it. It has no effect on non-undead.
 Displays the party's x-y location in the town.
-The target of this spell becomes magically shielded. For a time, monsters probably won't be able to attack him/her. The effects disappear when the PC attacks someone.
+The target of this spell becomes magically shielded. For a time, monsters probably won't be able to attack them. The effects disappear when the PC attacks someone.
 This spell has the caster absorb the damage taken by another character. The higher the level, the less damage the caster takes per health point healed.
 Casting this spell gives the party a little more food.
 When cast on a location filled with evil magic, the location receives a blessing. This might drive out the evil magic. Then again, it might not.

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -1839,7 +1839,7 @@ static bool pick_spell_caster(cDialog& me, std::string id, const eSkill store_si
 
 static bool pick_spell_target(cDialog& me, std::string id, const eSkill store_situation, short& last_darkened, const short store_spell) {
 	static const char*const no_target = " No target needed.";
-	static const char*const bad_target = " Can't cast on him/her.";
+	static const char*const bad_target = " Can't cast on them.";
 	static const char*const got_target = " Target selected.";
 	short item_hit = id[id.length() - 1] - '1';
 	std::string casting = id;


### PR DESCRIPTION
I noticed the documentation/spell descriptions use `him/her` which is an awkward grammatical construction. I grepped for that phrase and changed it to `them` everywhere I found.