### PR TITLE
Fix armor level 0

### DIFF
--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -2341,7 +2341,10 @@ short damage_pc(cPlayer& which_pc,short how_much,eDamageType damage_type,eRace t
 			const cItem& item = which_pc.items[i];
 			if(item.variety != eItemType::NO_ITEM && which_pc.equip[i]) {
 				if((*item.variety).is_armour) {
-					short defense = get_ran(1,1,item.item_level);
+					short defense = 0;
+					if(item.item_level > 0){
+						defense = get_ran(1,1,item.item_level);
+					}
 					
 					// bonus for magical items
 					if(item.bonus > 0) {

--- a/src/scenario/item.cpp
+++ b/src/scenario/item.cpp
@@ -143,11 +143,17 @@ std::string cItem::interesting_string() const {
 		case eItemType::HELM:
 		case eItemType::GLOVES:
 		case eItemType::SHIELD_2:
-		case eItemType::BOOTS:
-			sout << "Blocks " << 1 + min_defense_bonus(bonus) + sgn(protection);
-			sout << '-' << max(1,item_level) + max_defense_bonus(bonus) + protection;
+		case eItemType::BOOTS:{
+			short min_defense = 0;
+			if(item_level > 0) min_defense = 1;
+			min_defense += (min_defense_bonus(bonus) + sgn(protection));
+			short max_defense = item_level + max_defense_bonus(bonus) + protection;
+			sout << "Blocks " << min_defense;
+			if(max_defense != min_defense){
+				sout << '-' << max(min_defense,item_level);
+			}
 			sout << " damage";
-			break;
+		} break;
 		case eItemType::BOW:
 		case eItemType::CROSSBOW:
 			sout << "Bonus: +" << bonus << " to hit";


### PR DESCRIPTION
Armor items with item level 0, will have a base defense value of 0 instead of 1, and display their defense value as such in the get items screen.

Fix #245 