### PR TITLE
Fix text size and underline in dialogxml

### DIFF
--- a/rsrc/dialogs/drop-item-confirm.xml
+++ b/rsrc/dialogs/drop-item-confirm.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
 <dialog defbtn='cancel'>
 	<pict type='dlog' num='2' top='8' left='8'/>
-	<text size='large' top='2' left='48' width='248' height='33'>
+	<text size='large' top='8' left='48' width='248' height='33'>
 		This item will be gone forever. Still drop it?
 	</text>
 	<button name='cancel' type='regular' def-key='esc' top='42' left='238'>Cancel</button>

--- a/rsrc/dialogs/edit-sign.xml
+++ b/rsrc/dialogs/edit-sign.xml
@@ -4,7 +4,7 @@
 	<!-- OK button -->
 	<field name='text' top='34' left='55' width='293' height='98'/>
 	<button name='cancel' type='regular' top='141' left='222' def-key='esc'>Cancel</button>
-	<text top='142' left='7' width='198' height='15'>Use a '|' to indicate a line break.</text>
+	<text top='142' left='7' width='198' height='15' show-pipes='true'>Use a '|' to indicate a line break.</text>
 	<text name='num' top='8' left='287' width='37' height='14'/>
 	<pict name='pic' type='dlog' num='16' top='8' left='12'/>
 	<text size='large' top='6' left='50' width='138' height='17'>Editing Sign</text>

--- a/rsrc/dialogs/preferences.xml
+++ b/rsrc/dialogs/preferences.xml
@@ -46,7 +46,7 @@
 		<led name='target-adjacent' relative='pos-in pos' anchor='keyshift-head' top='4' left='15'>Select adjacent tiles</led>
 		<led name='screen-shift' relative='pos pos-in' anchor='target-adjacent' top='0' left='15'>Move the screen</led>
 	</group>
-	<text name='keyshift-note' size='large' relative='pos-in pos' anchor='keyshift-head' top='20' left='15' width='300' height='17'>(Holding Shift while using directional keys will do the opposite.)</text>
+	<text name='keyshift-note' relative='pos-in pos' anchor='keyshift-head' top='20' left='15' width='300' height='17'>(Holding Shift while using directional keys will do the opposite.)</text>
 	<text name='misc-head' size='large' relative='neg pos' anchor='keyshift-note' top='15' left='15' width='182' height='17'>Miscellaneous:</text>
 	<led name='nosound' relative='pos-in pos' anchor='misc-head' top='6' left='15'>No Sounds</led>
 	<led name='repeatdesc' relative='pos-in pos' rel-anchor='prev' top='10' left='0'>Show room descriptions more than once</led>

--- a/rsrc/schemas/dialog.xsd
+++ b/rsrc/schemas/dialog.xsd
@@ -125,11 +125,18 @@
 		</xs:attribute>
 		<xs:attribute name="size" default="small">
 			<xs:simpleType>
-				<xs:restriction base="xs:token">
-					<xs:enumeration value="small"/>
-					<xs:enumeration value="large"/>
-					<xs:enumeration value="title"/>
-				</xs:restriction>
+				<xs:union>
+					<xs:simpleType>
+						<xs:restriction base="xs:token">
+							<xs:enumeration value="small"/>
+							<xs:enumeration value="large"/>
+							<xs:enumeration value="title"/>
+						</xs:restriction>
+					</xs:simpleType>
+					<xs:simpleType>
+						<xs:restriction base="xs:integer"/>
+					</xs:simpleType>
+				</xs:union>
 			</xs:simpleType>
 		</xs:attribute>
 		<xs:attribute name="color"/>

--- a/rsrc/schemas/dialog.xsd
+++ b/rsrc/schemas/dialog.xsd
@@ -186,6 +186,7 @@
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
+		<xs:attribute name="show-pipes" type="xs:boolean" default="false"/>
 		<xs:attribute ref="def-key"/>
 		<xs:attribute name="fromlist" default="none" type="xs:string"/>
 		<xs:attributeGroup ref="rect-size"/>

--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -1152,12 +1152,14 @@ void preview_dialog_xml() {
 	fs::path dialog_xml = nav_get_rsrc({"xml"});
 	std::unique_ptr<DialogDefn> defn(load_dialog_defn(dialog_xml));
 	cDialog dialog(*defn);
-	// Make every control's click event close the dialog
+	// Make every clickable control's click event close the dialog
 	for (auto control : dialog){
-		control.second->attachClickHandler([](cDialog& me, std::string item_hit, eKeyMod mod) -> bool {
-			me.toast(false);
-			return true;
-		});
+		try{
+			control.second->attachClickHandler([](cDialog& me, std::string item_hit, eKeyMod mod) -> bool {
+				me.toast(false);
+				return true;
+			});
+		}catch(...){}
 	}
 	dialog.run();
 }

--- a/src/dialogxml/widgets/control.cpp
+++ b/src/dialogxml/widgets/control.cpp
@@ -535,7 +535,16 @@ bool cControl::parseAttribute(ticpp::Attribute& attr, std::string tagName, std::
 		if(val == "small") setFormat(TXT_SIZE, 10);
 		else if(val == "large") setFormat(TXT_SIZE, 12);
 		else if(val == "title") setFormat(TXT_SIZE, 18);
-		else throw xBadVal(tagName, name, val, attr.Row(), attr.Column(), fname);
+		else{
+			auto err = xBadVal(tagName, name, val, attr.Row(), attr.Column(), fname);
+			try{
+				setFormat(TXT_SIZE, std::stoi(val));
+			}catch(std::invalid_argument& e){
+				throw err;
+			}catch(std::out_of_range& e){
+				throw err;
+			}
+		}
 		return true;
 	}
 	if(name == "wrap" && canFormat(TXT_WRAP)) {

--- a/src/dialogxml/widgets/message.cpp
+++ b/src/dialogxml/widgets/message.cpp
@@ -65,6 +65,9 @@ bool cTextMsg::parseAttribute(ticpp::Attribute& attr, std::string tagName, std::
 		else if(val == "left") right_align = false;
 		else throw xBadVal(tagName, attr.Name(), val, attr.Row(), attr.Column(), fname);
 		return true;
+	}else if(attr.Name() == "show-pipes"){
+		style.showPipes = str_to_bool(attr.Value());
+		return true;
 	}
 	return cControl::parseAttribute(attr, tagName, fname);
 }

--- a/src/dialogxml/widgets/message.cpp
+++ b/src/dialogxml/widgets/message.cpp
@@ -130,14 +130,13 @@ void cTextMsg::calculate_layout() {
 }
 
 void cTextMsg::recalcRect() {
+	style.pointSize = textSize;
+	style.underline = underlined;
+	style.font = textFont;
 	if(fixedWidth && fixedHeight){
 		calculate_layout();
 		return;
 	}
-	TextStyle style;
-	style.font = textFont;
-	style.pointSize = textSize;
-	style.underline = underlined;
 	style.lineHeight = textSize + 2;
 	std::string test = getText();
 	size_t lines = 1, cur_line_chars = 0, max_line_chars = 0;

--- a/src/doxy/mainpage.md
+++ b/src/doxy/mainpage.md
@@ -343,9 +343,7 @@ values.
 `bold`, `dungeon`, `maidenword`. It defaults to `bold`. The latter two
 options are fantasy-style scripts such as that used for the conversation
 screen.
-* `size` - Although the dialog engine supports any font size, the XML
-specification simplifies it to three keywords: `small`, `large`, and
-`title`, representing 10pt, 12pt, and 18pt font, respectively.
+* `size` - The point size of the text. An integer, or one of three presets: `small` (10pt), `large` (12pt), and `title` (18pt).
 * `color` or `colour` - This is the only truly unrestricted attribute,
 accepting any HTML colour code. It understands three-digit hex codes (eg
 `#333`, which is equivalent to `#333333`), six-digit hex codes, and the

--- a/src/doxy/mainpage.md
+++ b/src/doxy/mainpage.md
@@ -90,6 +90,7 @@ The `<text>` tag accepts the following attributes:
 
 * `framed` - See **Common Attributes** above. Defaults to `false`.
 * `outline` - See **Common Attributes** above.
+* `show-pipes` - If true the | character will appear literally.
 * `underline` - If true, the text will be underlined.
 * `align` - `right` or `left`. Defaults to `left`.
 * `fromlist`, `font`, `size`, `color`, `colour`, `def-key` -

--- a/src/gfx/render_text.cpp
+++ b/src/gfx/render_text.cpp
@@ -112,7 +112,7 @@ break_info_t calculate_line_wrapping(rectangle dest_rect, std::string str, TextS
 	for(i = 0; text_len(i) != text_len(i + 1) && i < str_len; i++) {
 		unsigned short line_width = text_len(i) - text_len(last_line_break);
 		if(((line_width > (dest_rect.width() - 6))
-			&& (last_word_break >= last_line_break)) || (str[i] == '|')) {
+			&& (last_word_break >= last_line_break)) || (str[i] == '|' && !style.showPipes)) {
 			if(str[i] == '|') {
 				last_word_break = i + 1;
 			} else if(last_line_break == last_word_break)
@@ -151,7 +151,7 @@ static void win_draw_string(sf::RenderTarget& dest_window,rectangle dest_rect,st
 	eTextMode mode = options.mode;
 	if(mode == eTextMode::WRAP && total_width < dest_rect.width() && !options.right_align)
 		mode = eTextMode::LEFT_TOP;
-	if(mode == eTextMode::LEFT_TOP && str.find('|') != std::string::npos)
+	if(mode == eTextMode::LEFT_TOP && !options.style.showPipes && str.find('|') != std::string::npos)
 		mode = eTextMode::WRAP;
 	
 	// Special stuff
@@ -164,7 +164,7 @@ static void win_draw_string(sf::RenderTarget& dest_window,rectangle dest_rect,st
 	// to calculate_line_wrapping() or frame calculation is
 	// broken.
 	std::string str_with_pipes = str;
-	if(!options.showBreaks){
+	if(!options.showBreaks && !options.style.showPipes){
 		for(int i=0; i < str.length(); ++i){
 			if(str[i] == '|') str[i] = ' ';
 		}

--- a/src/gfx/render_text.hpp
+++ b/src/gfx/render_text.hpp
@@ -31,6 +31,7 @@ enum eFont {
 
 struct TextStyle {
 	bool italic = false, underline = false;
+	bool showPipes = false;
 	eFont font = FONT_BOLD;
 	int pointSize = 10, lineHeight = 10;
 	sf::Color colour;


### PR DESCRIPTION
This should fix #246 ...

However, it does not, because for some reason, message controls are ignoring their text size. (This goes for the preset sizes that already existed, too.)