### PR TITLE
Fix invis

### DIFF
--- a/doc/game/Priest.html
+++ b/doc/game/Priest.html
@@ -28,7 +28,7 @@ selected PC.</li>
 amount of damage to it. It has no effect on non-undead.</li>
 <li>Location: (C 1) Returns the party's x-y location in the town or outdoors.</li>
 <li>Sanctuary: (C 1) The target of this spell becomes magically shielded.</li>
-<li>For a time, monsters probably won't be able to attack them. The effects disappears
+<li>For a time, monsters probably won't be able to attack them. The effects disappear
 when the PC attacks someone.</li>
 <li>Symbiosis: (C 3) This spell has the caster absorb the damage taken by another
 character. The higher the caster's level, the less damage the caster takes per health

--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -2806,8 +2806,8 @@ void monster_attack(short who_att,iLiving* target) {
 		r1 = get_ran(1,1,100);
 		if(r1 > hit_chance[attacker->level / 2]) {
 			add_string_to_buf("  Can't find target!");
+			return;
 		}
-		return;
 	}
 	
 	for(short i = 0; i < attacker->a.size(); i++) {

--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -2801,9 +2801,11 @@ void monster_attack(short who_att,iLiving* target) {
 	cCreature* m_target = dynamic_cast<cCreature*>(target);
 	cPlayer* pc_target = dynamic_cast<cPlayer*>(target);
 	
-	// Check sanctuary
+	// Check sanctuary for melee
 	if(target->status[eStatus::INVISIBLE] > 0 || (m_target != nullptr && m_target->invisible)) {
 		r1 = get_ran(1,1,100);
+		// Usually hit_chance would be indexed by the weapon skill, not monster level.
+		// Indexing by monster level is usually a debuff, and half-level moreso.
 		if(r1 > hit_chance[attacker->level / 2]) {
 			add_string_to_buf("  Can't find target!");
 			return;
@@ -3077,7 +3079,10 @@ void monst_fire_missile(short m_num,short bless,std::pair<eMonstAbil,uAbility> a
 			snd = 12;
 		if(abil.second.missile.pic < 0) play_sound(snd);
 		else run_a_missile(source, targ_space, abil.second.missile.pic, 1, snd, 0, 0, 100);
+		// Check sanctuary for missile attack
 		if(target->status[eStatus::INVISIBLE] > 0 || (m_target != nullptr && m_target->invisible)) {
+			// Usually hit_chance would be indexed by the weapon skill, not monster level.
+			// Indexing by monster level is usually a debuff.
 			if(get_ran(1,1,100) > hit_chance[univ.town.monst[m_num].level]) {
 				add_string_to_buf("  Can't find target!");
 				return;


### PR DESCRIPTION
I consulted with Slarty on how this spell was probably supposed to work based on the code. Slarty explained how indexing the hit_chance array by monster level can be a debuff even if monster level isn't halved (as in the case of the ranged attack on an invisible target). The only real bug here is that in melee cases, an early return would happen even if the roll failed and no text was printed.

Fix #110 