### PR TITLE
fix scons validation warning

### DIFF
--- a/rsrc/SConscript
+++ b/rsrc/SConscript
@@ -66,7 +66,7 @@ if have_xmllint: # This is separate so that alternate xml validators could be us
 			cmd_line = xmllint_command + (src_name,)
 			print(*cmd_line)
 			p = subprocess.Popen(cmd_line,
-				bufsize=1, stdin=PIPE, stdout=PIPE, stderr=PIPE,
+				stdin=PIPE, stdout=PIPE, stderr=PIPE,
 				cwd=source[0].Dir('.').abspath
 			)
 			out, err = p.communicate()


### PR DESCRIPTION
From scons builds running `xmllint` we get a *ton* of the same warning message:

https://github.com/calref/cboe/actions/runs/13340575223/job/37264370598#step:4:3334
> /usr/local/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/subprocess.py:1020: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
>  self.stdin = io.open(p2cwrite, 'wb', bufsize)

I don't know what it means, or whether the `bufsize` argument might have an important intended purpose. But removing it gets rid of this warning.