### PR TITLE
Fix Visual Studio undefined behavior test errors

### DIFF
--- a/proj/vs2013/OBoE Tests/OBoE Tests.vcxproj.user
+++ b/proj/vs2013/OBoE Tests/OBoE Tests.vcxproj.user
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)/../../test</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)/../../test</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+</Project>

--- a/proj/vs2017/Tests/Tests.vcxproj.user
+++ b/proj/vs2017/Tests/Tests.vcxproj.user
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)/../../test</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)/../../test</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)/../../test</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)/../../test</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+</Project>

--- a/test/item_legacy.cpp
+++ b/test/item_legacy.cpp
@@ -14,8 +14,13 @@
 #include "race.hpp"
 
 static void set_item_name(legacy::item_record_type& item, const std::string& full, const std::string& name) {
-	std::copy_n(full.begin(), std::min<size_t>(25, 1 + full.size()), item.full_name);
-	std::copy_n(name.begin(), std::min<size_t>(15, 1 + name.size()), item.name);
+	size_t full_size = std::min<size_t>(24, full.size());
+	std::copy_n(full.begin(), full_size, item.full_name);
+	item.full_name[full_size] = '\0';
+
+	size_t name_size = std::min<size_t>(14, name.size());
+	std::copy_n(name.begin(), name_size, item.name);
+	item.name[name_size] = '\0';
 }
 
 TEST_CASE("Converting items from legacy scenarios") {

--- a/test/out_write.cpp
+++ b/test/out_write.cpp
@@ -80,6 +80,8 @@ TEST_CASE("Saving an outdoors sector") {
 		wand.friendly[1] = 12;
 		wand.end_spec1 = 210;
 		wand.end_spec2 = 22;
+		wand.cant_flee = true;
+		wand.forced = true;
 		
 		REQUIRE(out.special_enc.size() >= 1);
 		out.special_enc[0] = spec;

--- a/test/town_legacy.cpp
+++ b/test/town_legacy.cpp
@@ -19,7 +19,7 @@
 
 TEST_CASE("Converting legacy town data") {
 	cScenario scen;
-	scen.ter_types.resize(5);
+	scen.ter_types.resize(16);
 	legacy::town_record_type old_town = {0};
 	
 	SECTION("With basic data") {


### PR DESCRIPTION
This stages Visual Studio project configuration that makes the tests launch in the correct working directory.

Then it fixes some test crashes that were happening to me locally because of undefined behavior.

I hope it doesn't break the tests on other targets.