### PR TITLE
Fix line breaks being ignored. Fix #608

### DIFF
--- a/rsrc/dialogs/edit-monster.xml
+++ b/rsrc/dialogs/edit-monster.xml
@@ -42,8 +42,8 @@
 	<field name='priest' top='226' left='206' width='51' height='16'/>
 	
 	<text size='large' top='82' left='273' width='158' height='16'>Hand to hand combat:</text>
-	<text top='102' left='350' width='56' height='40'>Number of dice:<br/>(0 - 20)</text>
-	<text top='102' left='410' width='56' height='40'>Number of sides:<br/>(1-50)</text>
+	<text top='102' left='343' width='72' height='40'>Number of dice:<br/>(0 - 20)</text>
+	<text top='102' left='403' width='72' height='40'>Number of sides:<br/>(1-50)</text>
 	<text top='128' left='470' width='56' height='14'>Type</text>
 	
 	<text top='150' left='283' width='50' height='14'>Attack 1:</text>

--- a/rsrc/dialogs/help-debug.xml
+++ b/rsrc/dialogs/help-debug.xml
@@ -3,7 +3,7 @@
 <dialog defbtn='okay'>
 	<pict type='dlog' num='16' top='8' left='8'/>
 	<text top='8' left='50' width='400' height='16'>DEBUG MODE HELP</text>
-	<text top='22' left='50' width='400' height='50'>
+	<text top='22' left='50' width='400' height='64'>
 		Debug mode is intended to aid you in testing your scenario.
 		While in debug mode, monsters don't move in combat and are killed in one hit.
 		In addition, you have access to a lot of additional hotkeys.<br/><br/>

--- a/rsrc/dialogs/preview-dialogs-confirm.xml
+++ b/rsrc/dialogs/preview-dialogs-confirm.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
+<dialog defbtn='no'>
+	<pict type='dlog' num='7' top='6' left='6'/>
+	<text name='msg' top='6' left='48' width='249' height='67'>
+		You are about to preview all {{num}} dialog layouts in the game and its editors.<br/>
+		<br/>
+		Are you sure you want to do this?
+	</text>
+	<button name='no' type='regular' def-key='n' top='84' left='239'>No</button>
+	<button name='yes' type='regular' def-key='y' top='84' left='172'>Yes</button>
+</dialog>

--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -16,6 +16,7 @@
 #include "gfx/tiling.hpp" // for bg
 #include "fileio/resmgr/res_dialog.hpp"
 #include "sounds.hpp"
+#include "dialogxml/dialogs/choicedlog.hpp"
 #include "dialogxml/widgets/pict.hpp"
 #include "dialogxml/widgets/button.hpp"
 #include "dialogxml/widgets/field.hpp"
@@ -1154,8 +1155,7 @@ void cDialogIterator::increment() {
 	}
 }
 
-void preview_dialog_xml() {
-	fs::path dialog_xml = nav_get_rsrc({"xml"});
+void preview_dialog_xml(fs::path dialog_xml) {
 	std::unique_ptr<DialogDefn> defn(load_dialog_defn(dialog_xml));
 	cDialog dialog(*defn);
 	// Make every clickable control's click event close the dialog

--- a/src/dialogxml/dialogs/dialog.hpp
+++ b/src/dialogxml/dialogs/dialog.hpp
@@ -28,6 +28,7 @@
 #include "location.hpp"
 #include <boost/any.hpp>
 #include <boost/iterator/iterator_facade.hpp>
+#include <boost/filesystem/path.hpp>
 #include "tools/prefs.hpp"
 #include "tools/framerate_limiter.hpp"
 
@@ -380,6 +381,6 @@ public:
 //}
 
 // For development/debugging only.
-void preview_dialog_xml();
+void preview_dialog_xml(fs::path dialog_xml);
 
 #endif

--- a/src/dialogxml/widgets/message.cpp
+++ b/src/dialogxml/widgets/message.cpp
@@ -119,7 +119,7 @@ void cTextMsg::calculate_layout() {
 		cControl& ctrl = key ? parent->getControl(*key) : *this;
 		msg.replace(pos, 1, ctrl.getAttachedKeyDescription());
 	}
-	if(to_rect.bottom - to_rect.top < 20) { // essentially, it's a single line
+	if(to_rect.bottom - to_rect.top < 20 && msg.find("|") == std::string::npos){
 		style.lineHeight = 12;
 		to_rect.left += 3;
 		text_mode = eTextMode::LEFT_BOTTOM;
@@ -136,12 +136,12 @@ void cTextMsg::recalcRect() {
 	style.pointSize = textSize;
 	style.underline = underlined;
 	style.font = textFont;
-	if(fixedWidth && fixedHeight){
+	std::string test = getText();
+	if(fixedWidth && fixedHeight && test.find("|") == std::string::npos){
 		calculate_layout();
 		return;
 	}
 	style.lineHeight = textSize + 2;
-	std::string test = getText();
 	size_t lines = 1, cur_line_chars = 0, max_line_chars = 0;
 	// Substitute | with newlines for measuring
 	for(auto& c : test) {

--- a/src/game/boe.actions.hpp
+++ b/src/game/boe.actions.hpp
@@ -115,5 +115,7 @@ void close_map(bool record = false);
 void cancel_item_target(bool& did_something, bool& need_redraw, bool& need_reprint);
 void update_item_stats_area(bool& need_reprint);
 void easter_egg(int idx);
+void preview_dialog_xml();
+void preview_every_dialog_xml();
 
 #endif

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -904,6 +904,8 @@ static void replay_action(Element& action) {
 		show_debug_help();
 	}else if(t == "debug_fight_encounter"){
 		debug_fight_encounter(str_to_bool(action.GetText()));
+	}else if(t == "preview_every_dialog_xml"){
+		preview_every_dialog_xml();
 	}else if(t == "advance_time"){
 		// This is bad regardless of strictness, because visual changes may have occurred which won't get redrawn/reprinted
 		throw std::string { "Replay system internal error! advance_time() was supposed to be called by the last action, but wasn't: " } + _last_action_type;


### PR DESCRIPTION
Fix #608

I noticed 'Number of Dice' and 'Number of Sides' texts need to be widened in edit-monster--is that something you're working on or should I push my fix?