### PR TITLE
Fix pcedit gold limit & remove os string

### DIFF
--- a/rsrc/bases/bladbase/scenario.xml
+++ b/rsrc/bases/bladbase/scenario.xml
@@ -25,7 +25,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os>Microsoft Windows 7 Service Pack 1</os>
     </creator>
     <game>
         <num-towns>1</num-towns>

--- a/rsrc/scenarios/busywork/scenario.xml
+++ b/rsrc/scenarios/busywork/scenario.xml
@@ -40,7 +40,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os>Apple Mac OS X Version 10.7.5 (Build 11G63)</os>
     </creator>
     <game>
         <num-towns>4</num-towns>

--- a/rsrc/scenarios/stealth/scenario.xml
+++ b/rsrc/scenarios/stealth/scenario.xml
@@ -43,7 +43,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os>Apple Mac OS X Version 10.7.5 (Build 11G63)</os>
     </creator>
     <game>
         <num-towns>21</num-towns>

--- a/rsrc/scenarios/valleydy/scenario.xml
+++ b/rsrc/scenarios/valleydy/scenario.xml
@@ -40,7 +40,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os>Apple Mac OS X Version 10.7.5 (Build 11G63)</os>
     </creator>
     <game>
         <num-towns>21</num-towns>

--- a/rsrc/scenarios/zakhazi/scenario.xml
+++ b/rsrc/scenarios/zakhazi/scenario.xml
@@ -43,7 +43,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os>Apple Mac OS X Version 10.7.5 (Build 11G63)</os>
     </creator>
     <game>
         <num-towns>23</num-towns>

--- a/rsrc/schemas/readme.md
+++ b/rsrc/schemas/readme.md
@@ -162,7 +162,6 @@ the following subtags:
 	format, you would use a different string here to let mainline OBoE know that it's
 	incompatible.
 	* `<version>` - The version of OBoE that the scenario was last edited with.
-	* `<os>` - The operating system on which the scenario was last edited.
 * `<game>` - Contains the bulk of global information about the scenario.
 * `<editor>` - Contains several details of the scenario that aren't relevant to gameplay,
 but are instead used by the scenario editor to enhance your editing experience.

--- a/rsrc/schemas/scenario.xsd
+++ b/rsrc/schemas/scenario.xsd
@@ -80,7 +80,6 @@
 		<xs:sequence>
 			<xs:element name="type" type="xs:string"/>
 			<xs:element name="version" type="xs:string"/>
-			<xs:element name="os" type="xs:string"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="shopEntries">

--- a/src/game/boe.items.cpp
+++ b/src/game/boe.items.cpp
@@ -55,44 +55,38 @@ bool silent_GTP(short item_num) {
 	cItem item = univ.scenario.get_stored_item(item_num);
 	return univ.party.give_item(item,false);
 }
+
 void give_gold(short amount,bool print_result) {
 	if(amount < 0) return;
 	univ.party.gold += amount;
-	if(print_result)
-		put_pc_screen();
+	if(print_result) put_pc_screen();
 }
 
 bool take_gold(short amount,bool print_result) {
 	if(univ.party.gold < amount)
 		return false;
 	univ.party.gold -= amount;
-	if(print_result)
-		put_pc_screen();
+	if(print_result) put_pc_screen();
 	return true;
 }
 
 void give_food(short amount,bool print_result) {
 	if(amount < 0) return;
 	univ.party.food = univ.party.food + amount;
-	if(print_result)
-		put_pc_screen();
+	if(print_result) put_pc_screen();
 }
 
 short take_food(short amount,bool print_result) {
-	short diff;
-	
-	diff = amount - univ.party.food;
-	if(diff > 0) {
+	short shortfall = amount - univ.party.food;
+	if(shortfall > 0) {
 		univ.party.food = 0;
-		if(print_result)
-			put_pc_screen();
-		return diff;
+	}else{
+		univ.party.food -= amount;
+		shortfall = 0;
 	}
 	
-	univ.party.food = univ.party.food - amount;
-	if(print_result)
-		put_pc_screen();
-	return 0;
+	if(print_result) put_pc_screen();
+	return shortfall;
 }
 
 void equip_item(short pc_num,short item_num) {

--- a/src/game/boe.items.hpp
+++ b/src/game/boe.items.hpp
@@ -4,10 +4,14 @@
 
 bool GTP(short item_num);
 bool silent_GTP(short item_num);
+
 void give_gold(short amount,bool print_result);
-bool take_gold(short amount,bool print_result);
 void give_food(short amount,bool print_result);
+// Try to take gold, but take none and return false if the party can't afford it.
+bool take_gold(short amount,bool print_result);
+// Take food until the party has 0, returning the amount of their deficiency
 short take_food(short amount,bool print_result);
+
 void equip_item(short pc_num,short item_num);
 void drop_item(short pc_num,short item_num,location where_drop);
 bool place_item(cItem item,location where,bool try_contained = false);

--- a/src/game/boe.town.cpp
+++ b/src/game/boe.town.cpp
@@ -1105,16 +1105,16 @@ void elim_monst(unsigned short which,short spec_a,short spec_b) {
 //short print_mes; // 0 - no 1 - yes
 void dump_gold(short print_mes) {
 	// Mildly kludgy gold check
-	if(univ.party.gold > 30000) {
-		univ.party.gold = 30000;
+	if(univ.party.gold > MAX_GOLD) {
+		univ.party.gold = MAX_GOLD;
 		if(print_mes == 1) {
 			put_pc_screen();
 			add_string_to_buf("Excess gold dropped.");
 			print_buf();
 		}
 	}
-	if(univ.party.food > 25000) {
-		univ.party.food = 25000;
+	if(univ.party.food > MAX_FOOD) {
+		univ.party.food = MAX_FOOD;
 		if(print_mes == 1) {
 			put_pc_screen();
 			add_string_to_buf("Excess food dropped.");

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -35,6 +35,9 @@ namespace boost { namespace filesystem {} namespace process {}}
 namespace fs = boost::filesystem;
 namespace bp = boost::process;
 
+// Limits
+const int MAX_GOLD = 30000;
+const int MAX_FOOD = 25000;
 
 inline bool str_to_bool(std::string str) {
 	return str == "true";

--- a/src/pcedit/pc.action.cpp
+++ b/src/pcedit/pc.action.cpp
@@ -115,7 +115,7 @@ void edit_gold_or_food(short which_to_edit) {
 	dlog["number"].setTextToNum((which_to_edit == 0) ? univ.party.gold : univ.party.food);
 	
 	dlog.run();
-	int dialog_answer = minmax(0,25000,dlog.getResult<long long>());
+	int dialog_answer = minmax(0,which_to_edit == 0 ? MAX_GOLD : MAX_FOOD,dlog.getResult<long long>());
 	if(which_to_edit == 0)
 		univ.party.gold = dialog_answer;
 	else

--- a/src/pcedit/pc.action.cpp
+++ b/src/pcedit/pc.action.cpp
@@ -141,17 +141,6 @@ void edit_day() {
 	univ.party.age = (long long) (3700) * (long long) (dialog_answer);
 }
 
-void give_gold(short amount,bool /*print_result*/) {
-	univ.party.gold = univ.party.gold + amount;
-}
-
-bool take_gold(short amount,bool /*print_result*/) {
-	if(univ.party.gold < amount)
-		return false;
-	univ.party.gold = univ.party.gold - amount;
-	return true;
-}
-
 void edit_xp(cPlayer *pc) {
 	location view_loc;
 	

--- a/src/pcedit/pc.editors.hpp
+++ b/src/pcedit/pc.editors.hpp
@@ -1,8 +1,6 @@
 
 class cDialog;
 
-void give_gold(short amount,bool print_result);
-bool take_gold(short amount,bool print_result);
 void give_spec_items();
 void pick_race_abil(cPlayer *pc,short mode,cDialog* parent = nullptr);
 void reset_boats();

--- a/src/scenedit/scen.fileio.cpp
+++ b/src/scenedit/scen.fileio.cpp
@@ -160,7 +160,6 @@ void writeScenarioToXml(ticpp::Printer&& data, cScenario& scenario) {
 	data.OpenElement("creator");
 	data.PushElement("type", "oboe");
 	data.PushElement("version", scenario.format_ed_version());
-	data.PushElement("os", get_os_version());
 	data.CloseElement("creator");
 	data.OpenElement("game");
 	data.PushElement("num-towns", scenario.towns.size());

--- a/test/files/scenario/bad_editor_node.xml
+++ b/test/files/scenario/bad_editor_node.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/bad_format.xml
+++ b/test/files/scenario/bad_format.xml
@@ -26,6 +26,5 @@
     <creator>
         <type>unknown</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
 </scenario>

--- a/test/files/scenario/bad_game_node.xml
+++ b/test/files/scenario/bad_game_node.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <bad/>

--- a/test/files/scenario/bad_graphics1.xml
+++ b/test/files/scenario/bad_graphics1.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/bad_graphics2.xml
+++ b/test/files/scenario/bad_graphics2.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/bad_graphics3.xml
+++ b/test/files/scenario/bad_graphics3.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/bad_graphics4.xml
+++ b/test/files/scenario/bad_graphics4.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/bad_graphics5.xml
+++ b/test/files/scenario/bad_graphics5.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/bad_snd_name.xml
+++ b/test/files/scenario/bad_snd_name.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/bad_townmod1.xml
+++ b/test/files/scenario/bad_townmod1.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/bad_townmod2.xml
+++ b/test/files/scenario/bad_townmod2.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/bad_townmod3.xml
+++ b/test/files/scenario/bad_townmod3.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/bad_townmod4.xml
+++ b/test/files/scenario/bad_townmod4.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/extra_teaser.xml
+++ b/test/files/scenario/extra_teaser.xml
@@ -27,7 +27,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/intro.xml
+++ b/test/files/scenario/intro.xml
@@ -27,7 +27,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/intro_overflow.xml
+++ b/test/files/scenario/intro_overflow.xml
@@ -32,7 +32,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/minimal.xml
+++ b/test/files/scenario/minimal.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/missing_editor.xml
+++ b/test/files/scenario/missing_editor.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/missing_game.xml
+++ b/test/files/scenario/missing_game.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game/>
 </scenario>

--- a/test/files/scenario/optional.xml
+++ b/test/files/scenario/optional.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/quest-bad_attr.xml
+++ b/test/files/scenario/quest-bad_attr.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/quest-bad_deadline.xml
+++ b/test/files/scenario/quest-bad_deadline.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/quest-bad_elem.xml
+++ b/test/files/scenario/quest-bad_elem.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/quest-bad_reward.xml
+++ b/test/files/scenario/quest-bad_reward.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/quest-extra_bank.xml
+++ b/test/files/scenario/quest-extra_bank.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/quest-missing_elem.xml
+++ b/test/files/scenario/quest-missing_elem.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/quest.xml
+++ b/test/files/scenario/quest.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/quest2.xml
+++ b/test/files/scenario/quest2.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/rect_bad_attr.xml
+++ b/test/files/scenario/rect_bad_attr.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <store-items bad='0'/>

--- a/test/files/scenario/rect_missing_bottom.xml
+++ b/test/files/scenario/rect_missing_bottom.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <store-items town='0' top='0' left='0' right='10'/>

--- a/test/files/scenario/rect_missing_left.xml
+++ b/test/files/scenario/rect_missing_left.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <store-items town='0' top='0' bottom='10' right='10'/>

--- a/test/files/scenario/rect_missing_right.xml
+++ b/test/files/scenario/rect_missing_right.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <store-items town='0' top='0' left='0' bottom='10'/>

--- a/test/files/scenario/rect_missing_top.xml
+++ b/test/files/scenario/rect_missing_top.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <store-items town='0' left='0' bottom='10' right='10'/>

--- a/test/files/scenario/rect_missing_town.xml
+++ b/test/files/scenario/rect_missing_town.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <store-items top='0' left='0' bottom='10' right='10'/>

--- a/test/files/scenario/shop-bad_entry.xml
+++ b/test/files/scenario/shop-bad_entry.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/shop-bad_item.xml
+++ b/test/files/scenario/shop-bad_item.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/shop-bad_node.xml
+++ b/test/files/scenario/shop-bad_node.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/shop-bad_spec.xml
+++ b/test/files/scenario/shop-bad_spec.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/shop-incomplete_spec.xml
+++ b/test/files/scenario/shop-incomplete_spec.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/shop-missing_node.xml
+++ b/test/files/scenario/shop-missing_node.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/shop.xml
+++ b/test/files/scenario/shop.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/special_item-bad_attr.xml
+++ b/test/files/scenario/special_item-bad_attr.xml
@@ -22,7 +22,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/special_item-bad_elem.xml
+++ b/test/files/scenario/special_item-bad_elem.xml
@@ -22,7 +22,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/special_item-missing_elem.xml
+++ b/test/files/scenario/special_item-missing_elem.xml
@@ -22,7 +22,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/special_item.xml
+++ b/test/files/scenario/special_item.xml
@@ -22,7 +22,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>0</num-towns>

--- a/test/files/scenario/storage-bad_attr.xml
+++ b/test/files/scenario/storage-bad_attr.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/storage-bad_node.xml
+++ b/test/files/scenario/storage-bad_node.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/storage-missing_chance.xml
+++ b/test/files/scenario/storage-missing_chance.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/storage-missing_ter.xml
+++ b/test/files/scenario/storage-missing_ter.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/storage-too_many.xml
+++ b/test/files/scenario/storage-too_many.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/storage-too_many_items.xml
+++ b/test/files/scenario/storage-too_many_items.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/storage.xml
+++ b/test/files/scenario/storage.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <num-towns>3</num-towns>

--- a/test/files/scenario/timer_bad_attr.xml
+++ b/test/files/scenario/timer_bad_attr.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <timer bad="100">15</timer>

--- a/test/files/scenario/timer_missing_freq.xml
+++ b/test/files/scenario/timer_missing_freq.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <timer>15</timer>

--- a/test/files/scenario/too_many_flags.xml
+++ b/test/files/scenario/too_many_flags.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <town-flag town="1" add-x="16" add-y="21"/>

--- a/test/files/scenario/too_many_rects.xml
+++ b/test/files/scenario/too_many_rects.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <store-items town="0" top="12" left="13" bottom="20" right="36"/>

--- a/test/files/scenario/too_many_timers.xml
+++ b/test/files/scenario/too_many_timers.xml
@@ -26,7 +26,6 @@
     <creator>
         <type>oboe</type>
         <version>2.5.3</version>
-        <os></os>
     </creator>
     <game>
         <timer freq="100">15</timer>

--- a/test/files/town/townrectUniversal/scenario.xml
+++ b/test/files/town/townrectUniversal/scenario.xml
@@ -25,7 +25,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os>Apple Mac OS X Version 14.5 (Build 23F79)</os>
     </creator>
     <game>
         <num-towns>1</num-towns>

--- a/test/replays/scenarios/use-special-terrain/scenario.xml
+++ b/test/replays/scenarios/use-special-terrain/scenario.xml
@@ -25,7 +25,6 @@
     <creator>
         <type>oboe</type>
         <version>2.0.0</version>
-        <os>Apple Mac OS X Version 14.5 (Build 23F79)</os>
     </creator>
     <game>
         <num-towns>2</num-towns>


### PR DESCRIPTION
Remove give/take gold/food function redefinitions from the PC Editor where they weren't being used anyway. DRY up the ones in the game code.

Make the PC editor's gold limit match the game's gold limit. Fix #79 

Unrelatedly, Remove the `<os>` string from scenarios (but don't make validation fail for old ones). Fix #522 