### PR TITLE
When party is off-center, draw_party_symbol offset them. Fix #628

### DIFF
--- a/src/game/boe.graphutil.cpp
+++ b/src/game/boe.graphutil.cpp
@@ -436,7 +436,10 @@ void draw_party_symbol(location center) {
 		return;
 	if((is_town()) && (univ.party.town_loc.x > 70))
 		return;
-	if(overall_mode == MODE_LOOK_TOWN || cartoon_happening) {
+
+	if(center != univ.party.town_loc) {
+		if(!is_on_screen(univ.party.town_loc, center)) return;
+
 		target.x += univ.party.town_loc.x - center.x;
 		target.y += univ.party.town_loc.y - center.y;
 	}


### PR DESCRIPTION
This change fixes the bug where enemy ranged attacks in peace mode show the player at the wrong position.

I can imagine that it might have unintended consequences--I have *no idea* how many edge cases come across this code path, or why they would want to force the party to appear at the center even if they're not.

Fix #628