### PR TITLE
when dumpfound/sleep status is 0 bound low to 0. Fix #138

### DIFF
--- a/src/universe/living.cpp
+++ b/src/universe/living.cpp
@@ -40,7 +40,7 @@ void iLiving::apply_status(eStatus which, int how_much) {
 	if(which == eStatus::ASLEEP || which == eStatus::DUMB) {
 		// No "wrapping" allowed for these effects.
 		if(status[which] < 0) hi = 0;
-		else if(status[which] > 0) lo = 0;
+		else if(status[which] >= 0) lo = 0;
 	}
 	
 	status[which] = minmax(lo,hi,status[which] + how_much);


### PR DESCRIPTION
There already was a check to prevent this bug. I don't fully understand it.
Changing `>` to `>=` fixes the problem. But does it break these statuses in other contexts?

Fix #138