### PR TITLE
Fix another crash on page 2 of spell picker

### DIFF
--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -1564,6 +1564,7 @@ bool pc_can_cast_spell(const cPlayer& pc,eSkill type) {
 }
 
 bool pc_can_cast_spell(const cPlayer& pc,eSpell spell_num) {
+	if(spell_num == eSpell::NONE) return false;
 	short level,store_w_cast;
 	eSkill type = (*spell_num).type;
 	


### PR DESCRIPTION
Page 2 of the spell picker has always been touch-and-go... I found a new crash today because of trying to assign an LED status to a button which would be hidden on page 2. We simply can say that a PC cannot cast the None spell, to fix this.