### PR TITLE
Default controls keep their hotkey AND the enter key

### DIFF
--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -160,7 +160,6 @@ cDialog::cDialog(const DialogDefn& file, cDialog* p) : parent(p) {
 
 extern fs::path progDir;
 void cDialog::loadFromFile(const DialogDefn& file){
-	static const cKey enterKey = {true, key_enter};
 	bg = defaultBackground;
 	fname = file.id;
 	try{
@@ -328,7 +327,7 @@ void cDialog::loadFromFile(const DialogDefn& file){
 		
 		// Set the default button.
 		if(hasControl(defaultButton))
-			getControl(defaultButton).attachKey(enterKey);
+			getControl(defaultButton).setDefault(true);
 		
 		// Sort by tab order
 		// First, fill any gaps that might have been left, using ones that had no specific tab order
@@ -886,8 +885,11 @@ bool cDialog::addLabelFor(std::string key, std::string label, eLabelPos where, s
 
 void cDialog::process_keystroke(cKey keyHit){
 	ctrlIter iter = controls.begin();
+	bool enterKeyHit = keyHit.spec && keyHit.k == key_enter;
 	while(iter != controls.end()){
-		if(iter->second->isVisible() && iter->second->isClickable() && iter->second->getAttachedKey() == keyHit){
+		if(iter->second->isVisible() && iter->second->isClickable()
+			&& iter->second->getAttachedKey() == keyHit || (iter->second->isDefault() && enterKeyHit)){
+
 			iter->second->setActive(true);
 			draw();
 			iter->second->playClickSound();

--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -887,8 +887,8 @@ void cDialog::process_keystroke(cKey keyHit){
 	ctrlIter iter = controls.begin();
 	bool enterKeyHit = keyHit.spec && keyHit.k == key_enter;
 	while(iter != controls.end()){
-		if(iter->second->isVisible() && iter->second->isClickable()
-			&& iter->second->getAttachedKey() == keyHit || (iter->second->isDefault() && enterKeyHit)){
+		if((iter->second->isVisible() && iter->second->isClickable())
+			&& (iter->second->getAttachedKey() == keyHit || (iter->second->isDefault() && enterKeyHit))){
 
 			iter->second->setActive(true);
 			draw();

--- a/src/dialogxml/widgets/control.hpp
+++ b/src/dialogxml/widgets/control.hpp
@@ -165,6 +165,8 @@ public:
 	/// Retrieve the control's current keyboard shortcut as a human-readable string.
 	/// @return the currently-assigned keyboard shortcut, or an empty string if none is assigned.
 	std::string getAttachedKeyDescription() const;
+	inline void setDefault(bool value) { isDefaultControl = value; }
+	inline bool isDefault() { return isDefaultControl; }
 	/// Attach an event handler to this control.
 	/// @tparam t The type of event to attach.
 	/// @param handler The event handler function or functor. Its signature depends on the event type.
@@ -443,6 +445,9 @@ protected:
 	eFrameStyle frameStyle;
 	/// The control's attached key.
 	cKey key;
+	/// Whether the control is the default control of its dialog.
+	bool isDefaultControl = false;
+
 	/// Draw a frame around the control.
 	/// @param amt How much to offset the frame from the control's bounding rect.
 	/// @param med_or_lt true to use a darker colour for the frame.


### PR DESCRIPTION
I have certain UI expectations, like for the Yes/No dialogs to all respond to both the Y or N key. If there's a default button that responds to Enter, I want it to do that without clobbering its existing hotkey.

Fix #600 