### PR TITLE
Fix text appearing out of alignment with adjusted booms

### DIFF
--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -4022,10 +4022,14 @@ bool monst_cast_priest(cCreature *caster,short targ) {
 }
 
 short damage_target(short target,short dam,eDamageType type,short sound_type, bool do_print, short who_hit, eRace race) {
-	if(target == 6) return 0;
-	if(target < 6)
-		return damage_pc(univ.party[target],dam,type,race,sound_type, do_print);
-	else return damage_monst(univ.town.monst[target - 100], who_hit, dam, type,sound_type, do_print);
+	if(target >= 6 && target < 100) return 0;
+	if(target < 6){
+		return damage_pc(univ.party[target], dam, type, race, sound_type, do_print);
+	}else{
+		int monst_idx = target - 100;
+		if(monst_idx >= univ.town.monst.size()) return 0;
+		return damage_monst(univ.town.monst[monst_idx], who_hit, dam, type, sound_type, do_print);
+	}
 }
 
 short damage_target(iLiving& target,short dam,eDamageType type,short sound_type, bool do_print, short who_hit, eRace race) {

--- a/src/game/boe.combat.hpp
+++ b/src/game/boe.combat.hpp
@@ -34,7 +34,8 @@ void monst_basic_abil(short m_num, std::pair<eMonstAbil,uAbility> abil, iLiving*
 bool monst_breathe(cCreature *caster,location targ_space,uAbility dam_type);
 bool monst_cast_mage(cCreature *caster,short targ);
 bool monst_cast_priest(cCreature *caster,short targ);
-void damage_target(short target,short dam,eDamageType type,short sound_type = 0);
+short damage_target(short target,short dam,eDamageType type,short sound_type = 0, bool do_print = true, short who_hit = 7, eRace race = eRace::UNKNOWN);
+short damage_target(iLiving& target,short dam,eDamageType type,short sound_type = 0, bool do_print = true, short who_hit = 7, eRace race = eRace::UNKNOWN);
 location find_fireball_loc(location where,short radius,short mode,short *m);
 location closest_pc_loc(location where);
 short count_levels(location where,short radius);

--- a/src/game/boe.graphics.cpp
+++ b/src/game/boe.graphics.cpp
@@ -1441,7 +1441,6 @@ void boom_space(location where,short mode,short type,short damage,short sound) {
 		text_rect = dest_rect;
 		text_rect.top += 13;
 		text_rect.height() = 10;
-		text_rect.offset(x_adj,y_adj);
 		std::string dam_str = std::to_string(damage);
 		style.colour = sf::Color::White;
 		text_rect.offset(-1,-1);


### PR DESCRIPTION
This fixes the rendering of melee damage booms on enemies larger than 1x1. It also doesn't break spell booms (which already worked).

I saw a place to do a refactor which I thought would make it easier to debug this. The fix (in the second commit) could be cherry-picked without the refactor if it looks like I got that wrong.

Fix #127