### PR TITLE
-1 is supposed to be no face pic

### DIFF
--- a/src/game/boe.newgraph.cpp
+++ b/src/game/boe.newgraph.cpp
@@ -888,7 +888,7 @@ static void place_talk_face() {
 	face_rect.offset(talk_area_rect.topLeft());
 	mainPtr.setActive();
 	short face_to_draw = univ.scenario.scen_monsters[store_monst_type].default_facial_pic;
-	if(store_talk_face_pic >= 0)
+	if(store_talk_face_pic >= -1)
 		face_to_draw = store_talk_face_pic;
 	if(store_talk_face_pic >= 1000) {
 		cPict::drawAt(mainPtr, face_rect, store_talk_face_pic, PIC_CUSTOM_TALK, false);


### PR DESCRIPTION
Fix #74

According to the text in the editor, a facial picture value of `-1` means use the monster's regular graphic. Default facial pic is used by the editor when placing monsters.