### PR TITLE
Wrap use of RenderTarget.setActive() for correctness.

### DIFF
--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -14,6 +14,7 @@
 #include <map>
 #include "dialog.hpp"
 #include "gfx/tiling.hpp" // for bg
+#include "gfx/render_image.hpp"
 #include "fileio/resmgr/res_dialog.hpp"
 #include "sounds.hpp"
 #include "dialogxml/dialogs/choicedlog.hpp"
@@ -1052,7 +1053,7 @@ xBadVal::~xBadVal() throw(){
 bool cDialog::doAnimations = false;
 
 void cDialog::draw(){
-	win.setActive(false);
+	disableGL(win);
 	tileImage(win,winRect,::bg[bg]);
 	if(doAnimations && animTimer.getElapsedTime().asMilliseconds() >= 500) {
 		cPict::advanceAnim();
@@ -1070,7 +1071,7 @@ void cDialog::draw(){
 		iter++;
 	}
 	
-	win.setActive();
+	enableGL(win);
 	win.display();
 }
 

--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -1053,7 +1053,7 @@ xBadVal::~xBadVal() throw(){
 bool cDialog::doAnimations = false;
 
 void cDialog::draw(){
-	disableGL(win);
+	DISABLEGL(win);
 	tileImage(win,winRect,::bg[bg]);
 	if(doAnimations && animTimer.getElapsedTime().asMilliseconds() >= 500) {
 		cPict::advanceAnim();
@@ -1071,7 +1071,7 @@ void cDialog::draw(){
 		iter++;
 	}
 	
-	enableGL(win);
+	ENABLEGL(win);
 	win.display();
 }
 

--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -1053,7 +1053,6 @@ xBadVal::~xBadVal() throw(){
 bool cDialog::doAnimations = false;
 
 void cDialog::draw(){
-	DISABLEGL(win);
 	tileImage(win,winRect,::bg[bg]);
 	if(doAnimations && animTimer.getElapsedTime().asMilliseconds() >= 500) {
 		cPict::advanceAnim();
@@ -1071,7 +1070,6 @@ void cDialog::draw(){
 		iter++;
 	}
 	
-	ENABLEGL(win);
 	win.display();
 }
 

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2293,7 +2293,7 @@ void close_map(bool record) {
 	}
 	mini_map.setVisible(false);
 	map_visible = false;
-	enableGL(mainPtr);
+	ENABLEGL(mainPtr);
 }
 
 void cancel_item_target(bool& did_something, bool& need_redraw, bool& need_reprint) {

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2293,7 +2293,6 @@ void close_map(bool record) {
 	}
 	mini_map.setVisible(false);
 	map_visible = false;
-	ENABLEGL(mainPtr);
 }
 
 void cancel_item_target(bool& did_something, bool& need_redraw, bool& need_reprint) {

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -42,6 +42,7 @@
 #include "tools/prefs.hpp"
 #include "gfx/render_shapes.hpp"
 #include "tools/enum_map.hpp"
+#include "gfx/render_image.hpp"
 #include <string>
 #include <boost/lexical_cast.hpp>
 #include <sstream>
@@ -2292,7 +2293,7 @@ void close_map(bool record) {
 	}
 	mini_map.setVisible(false);
 	map_visible = false;
-	mainPtr.setActive();
+	enableGL(mainPtr);
 }
 
 void cancel_item_target(bool& did_something, bool& need_redraw, bool& need_reprint) {

--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -27,6 +27,7 @@
 #include "tools/prefs.hpp"
 #include "utility.hpp"
 #include "replay.hpp"
+#include "gfx/render_image.hpp"
 
 extern eGameMode overall_mode;
 extern short which_combat_type;
@@ -267,7 +268,7 @@ void start_outdoor_combat(cOutdoors::cWandering encounter,location where,short n
 	print_buf();
 	play_sound(23);
 	
-	mainPtr.setActive();
+	enableGL(mainPtr);
 	which_combat_type = 0;
 	overall_mode = MODE_COMBAT;
 	

--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -268,7 +268,7 @@ void start_outdoor_combat(cOutdoors::cWandering encounter,location where,short n
 	print_buf();
 	play_sound(23);
 	
-	enableGL(mainPtr);
+	ENABLEGL(mainPtr);
 	which_combat_type = 0;
 	overall_mode = MODE_COMBAT;
 	

--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -268,7 +268,6 @@ void start_outdoor_combat(cOutdoors::cWandering encounter,location where,short n
 	print_buf();
 	play_sound(23);
 	
-	ENABLEGL(mainPtr);
 	which_combat_type = 0;
 	overall_mode = MODE_COMBAT;
 	

--- a/src/game/boe.graphics.cpp
+++ b/src/game/boe.graphics.cpp
@@ -450,7 +450,6 @@ void arrow_button_click(rectangle button_rect) {
 		// is recorded afterward
 		record_action("arrow_button_click", boost::lexical_cast<std::string>(button_rect));
 	}
-	ENABLEGL(mainPtr);
 	clip_rect(mainPtr, button_rect);
 	// TODO: Mini-event loop so that the click doesn't happen until releasing the mouse button
 	
@@ -661,7 +660,6 @@ void draw_text_bar() {
 }
 
 void put_text_bar(std::string str, std::string right_str) {
-	DISABLEGL(text_bar_gworld);
 	auto& bar_gw = *ResMgr::graphics.get("textbar");
 	rect_draw_some_item(bar_gw, rectangle(bar_gw), text_bar_gworld, rectangle(bar_gw));
 	clear_scale_aware_text(text_bar_gworld);
@@ -694,14 +692,11 @@ void put_text_bar(std::string str, std::string right_str) {
 		}
 	}
 	
-	ENABLEGL(text_bar_gworld);
 	text_bar_gworld.display();
 }
 
 void refresh_text_bar() {
-	DISABLEGL(mainPtr);
 	rect_draw_some_item(text_bar_gworld, rectangle(text_bar_gworld), mainPtr, win_to_rects[WINRECT_STATUS]);
-	ENABLEGL(mainPtr);
 }
 
 // this is used for determinign whether to round off walkway corners
@@ -748,9 +743,7 @@ void draw_terrain(short mode) {
 		}
 		mode = 0;
 	}
-	
-	ENABLEGL(mainPtr);
-	
+
 	int max_dim_x, max_dim_y;
 	if(is_out()){
 		max_dim_x = min(96, 48 * univ.scenario.outdoors.width());
@@ -1604,7 +1597,6 @@ void draw_targeting_line(location where_curs) {
 			
 			if((can_see_light(from_loc,which_space,sight_obscurity) < 5)
 				&& (dist(from_loc,which_space) <= current_spell_range)) {
-				DISABLEGL(mainPtr);
 				clip_rect(mainPtr, on_screen_terrain_area);
 				draw_line(mainPtr, where_curs, location(xBound, yBound), 2, {128,128,128}, sf::BlendAdd);
 				redraw_rect.left = min(where_curs.x,xBound) - 4;
@@ -1645,7 +1637,6 @@ void draw_targeting_line(location where_curs) {
 					}
 				
 				redraw_rect2.inset(-5,-5);
-				ENABLEGL(mainPtr);
 				undo_clip(mainPtr);
 			}
 		}

--- a/src/game/boe.graphics.cpp
+++ b/src/game/boe.graphics.cpp
@@ -450,7 +450,7 @@ void arrow_button_click(rectangle button_rect) {
 		// is recorded afterward
 		record_action("arrow_button_click", boost::lexical_cast<std::string>(button_rect));
 	}
-	enableGL(mainPtr);
+	ENABLEGL(mainPtr);
 	clip_rect(mainPtr, button_rect);
 	// TODO: Mini-event loop so that the click doesn't happen until releasing the mouse button
 	
@@ -661,7 +661,7 @@ void draw_text_bar() {
 }
 
 void put_text_bar(std::string str, std::string right_str) {
-	disableGL(text_bar_gworld);
+	DISABLEGL(text_bar_gworld);
 	auto& bar_gw = *ResMgr::graphics.get("textbar");
 	rect_draw_some_item(bar_gw, rectangle(bar_gw), text_bar_gworld, rectangle(bar_gw));
 	clear_scale_aware_text(text_bar_gworld);
@@ -694,14 +694,14 @@ void put_text_bar(std::string str, std::string right_str) {
 		}
 	}
 	
-	enableGL(text_bar_gworld);
+	ENABLEGL(text_bar_gworld);
 	text_bar_gworld.display();
 }
 
 void refresh_text_bar() {
-	disableGL(mainPtr);
+	DISABLEGL(mainPtr);
 	rect_draw_some_item(text_bar_gworld, rectangle(text_bar_gworld), mainPtr, win_to_rects[WINRECT_STATUS]);
-	enableGL(mainPtr);
+	ENABLEGL(mainPtr);
 }
 
 // this is used for determinign whether to round off walkway corners
@@ -749,7 +749,7 @@ void draw_terrain(short mode) {
 		mode = 0;
 	}
 	
-	enableGL(mainPtr);
+	ENABLEGL(mainPtr);
 	
 	int max_dim_x, max_dim_y;
 	if(is_out()){
@@ -1604,7 +1604,7 @@ void draw_targeting_line(location where_curs) {
 			
 			if((can_see_light(from_loc,which_space,sight_obscurity) < 5)
 				&& (dist(from_loc,which_space) <= current_spell_range)) {
-				disableGL(mainPtr);
+				DISABLEGL(mainPtr);
 				clip_rect(mainPtr, on_screen_terrain_area);
 				draw_line(mainPtr, where_curs, location(xBound, yBound), 2, {128,128,128}, sf::BlendAdd);
 				redraw_rect.left = min(where_curs.x,xBound) - 4;
@@ -1645,7 +1645,7 @@ void draw_targeting_line(location where_curs) {
 					}
 				
 				redraw_rect2.inset(-5,-5);
-				enableGL(mainPtr);
+				ENABLEGL(mainPtr);
 				undo_clip(mainPtr);
 			}
 		}

--- a/src/game/boe.graphics.cpp
+++ b/src/game/boe.graphics.cpp
@@ -450,7 +450,7 @@ void arrow_button_click(rectangle button_rect) {
 		// is recorded afterward
 		record_action("arrow_button_click", boost::lexical_cast<std::string>(button_rect));
 	}
-	mainPtr.setActive();
+	enableGL(mainPtr);
 	clip_rect(mainPtr, button_rect);
 	// TODO: Mini-event loop so that the click doesn't happen until releasing the mouse button
 	
@@ -661,7 +661,7 @@ void draw_text_bar() {
 }
 
 void put_text_bar(std::string str, std::string right_str) {
-	text_bar_gworld.setActive(false);
+	disableGL(text_bar_gworld);
 	auto& bar_gw = *ResMgr::graphics.get("textbar");
 	rect_draw_some_item(bar_gw, rectangle(bar_gw), text_bar_gworld, rectangle(bar_gw));
 	clear_scale_aware_text(text_bar_gworld);
@@ -694,14 +694,14 @@ void put_text_bar(std::string str, std::string right_str) {
 		}
 	}
 	
-	text_bar_gworld.setActive();
+	enableGL(text_bar_gworld);
 	text_bar_gworld.display();
 }
 
 void refresh_text_bar() {
-	mainPtr.setActive(false);
+	disableGL(mainPtr);
 	rect_draw_some_item(text_bar_gworld, rectangle(text_bar_gworld), mainPtr, win_to_rects[WINRECT_STATUS]);
-	mainPtr.setActive();
+	enableGL(mainPtr);
 }
 
 // this is used for determinign whether to round off walkway corners
@@ -749,7 +749,7 @@ void draw_terrain(short mode) {
 		mode = 0;
 	}
 	
-	mainPtr.setActive();
+	enableGL(mainPtr);
 	
 	int max_dim_x, max_dim_y;
 	if(is_out()){
@@ -1604,7 +1604,7 @@ void draw_targeting_line(location where_curs) {
 			
 			if((can_see_light(from_loc,which_space,sight_obscurity) < 5)
 				&& (dist(from_loc,which_space) <= current_spell_range)) {
-				mainPtr.setActive(false);
+				disableGL(mainPtr);
 				clip_rect(mainPtr, on_screen_terrain_area);
 				draw_line(mainPtr, where_curs, location(xBound, yBound), 2, {128,128,128}, sf::BlendAdd);
 				redraw_rect.left = min(where_curs.x,xBound) - 4;
@@ -1645,7 +1645,7 @@ void draw_targeting_line(location where_curs) {
 					}
 				
 				redraw_rect2.inset(-5,-5);
-				mainPtr.setActive();
+				enableGL(mainPtr);
 				undo_clip(mainPtr);
 			}
 		}

--- a/src/game/boe.menus.win.cpp
+++ b/src/game/boe.menus.win.cpp
@@ -75,7 +75,7 @@ void init_menubar() {
 	mainProc = SetWindowLongPtr(winHandle, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(&menuProc));
 	SetMenu(winHandle, menuHandle);
 
-	enableGL(mainPtr);
+	ENABLEGL(mainPtr);
 	
 	// And now initialize the mapping from Windows menu commands to eMenu constants
 	static bool inited = false;

--- a/src/game/boe.menus.win.cpp
+++ b/src/game/boe.menus.win.cpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <sstream>
 #include <SFML/Graphics/RenderWindow.hpp>
+#include "gfx/render_image.hpp"
 #include "boeresource.h"
 #include "universe.hpp"
 #include "boe.party.hpp"
@@ -74,7 +75,7 @@ void init_menubar() {
 	mainProc = SetWindowLongPtr(winHandle, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(&menuProc));
 	SetMenu(winHandle, menuHandle);
 
-	mainPtr.setActive();
+	enableGL(mainPtr);
 	
 	// And now initialize the mapping from Windows menu commands to eMenu constants
 	static bool inited = false;

--- a/src/game/boe.menus.win.cpp
+++ b/src/game/boe.menus.win.cpp
@@ -74,8 +74,6 @@ void init_menubar() {
 	// We replace SFML's window procedure with our own, which checks for menu events and then forwards to SFML's procedure.
 	mainProc = SetWindowLongPtr(winHandle, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(&menuProc));
 	SetMenu(winHandle, menuHandle);
-
-	ENABLEGL(mainPtr);
 	
 	// And now initialize the mapping from Windows menu commands to eMenu constants
 	static bool inited = false;

--- a/src/game/boe.newgraph.cpp
+++ b/src/game/boe.newgraph.cpp
@@ -182,9 +182,7 @@ void apply_light_mask(bool onWindow) {
 		return;
 	
 	if(onWindow) {
-		DISABLEGL(mainPtr);
 		fill_region(mainPtr, dark_mask_region, sf::Color::Black);
-		ENABLEGL(mainPtr);
 		return;
 	}
 	
@@ -397,8 +395,6 @@ void do_missile_anim(short num_steps,location missile_origin,short sound_num) {
 	auto ter_rects = terrain_screen_rects();
 	rect_draw_some_item(terrain_screen_gworld.getTexture(),ter_rects.from,mainPtr,ter_rects.to);
 	
-	DISABLEGL(mainPtr);
-	
 	// init missile paths
 	screen_ul.x = center.x - 4; screen_ul.y = center.y - 4;
 	start_point.x = 13 + 14 + 28 * (short) (missile_origin.x - screen_ul.x);
@@ -500,7 +496,6 @@ void do_missile_anim(short num_steps,location missile_origin,short sound_num) {
 					rect_draw_some_item(*from_gw,from_rect, mainPtr,temp_rect,ter_rects.in_frame,sf::BlendAlpha);
 				}
 			}
-		ENABLEGL(mainPtr);
 		mainPtr.display();
 		sf::sleep(sf::milliseconds(2 + 5 * get_int_pref("GameSpeed")));
 	}
@@ -577,7 +572,6 @@ void do_explosion_anim(short /*sound_num*/,short special_draw, short snd) {
 	style.font = FONT_BOLD;
 	style.pointSize = 10;
 	style.lineHeight = 10;
-	DISABLEGL(mainPtr);
 	
 	// init missile paths
 	screen_ul.x = center.x - 4; screen_ul.y = center.y - 4;
@@ -638,12 +632,10 @@ void do_explosion_anim(short /*sound_num*/,short special_draw, short snd) {
 						style.colour = Colours::BLACK; 
 						text_rect.offset(-1,-1);
 						win_draw_string(mainPtr,text_rect,dam_str,eTextMode::CENTRE,style);
-						ENABLEGL(mainPtr);
 					}
 				}
 			}
 		//if(((PSD[SDF_GAME_SPEED] == 1) && (t % 3 == 0)) || ((PSD[SDF_GAME_SPEED] == 2) && (t % 2 == 0)))
-		ENABLEGL(mainPtr);
 		mainPtr.display();
 		sf::sleep(time_in_ticks(2 * (1 + get_int_pref("GameSpeed"))));
 	}
@@ -707,7 +699,6 @@ void draw_shop_graphics(bool item_pressed, bool item_help_pressed, rectangle cli
 	style.pointSize = 18;
 	
 	area_rect = rectangle(talk_gworld);
-	DISABLEGL(talk_gworld);
 
 	// Only re-render on top of the item that is clicked:
 	if(item_pressed || item_help_pressed) {
@@ -863,7 +854,6 @@ void draw_shop_graphics(bool item_pressed, bool item_help_pressed, rectangle cli
 	win_draw_string(talk_gworld,bottom_help_rects[3],"'I' button brings up description.",eTextMode::WRAP,style);
 	
 	undo_clip(talk_gworld);
-	ENABLEGL(talk_gworld);
 	talk_gworld.display();
 	
 	refresh_shopping();
@@ -886,7 +876,6 @@ void refresh_shopping() {
 static void place_talk_face() {
 	rectangle face_rect = {6,6,38,38};
 	face_rect.offset(talk_area_rect.topLeft());
-	ENABLEGL(mainPtr);
 	short face_to_draw = univ.scenario.scen_monsters[store_monst_type].default_facial_pic;
 	if(store_talk_face_pic >= -1)
 		face_to_draw = store_talk_face_pic;
@@ -907,7 +896,6 @@ void click_talk_rect(word_rect_t word) {
 	}
 
 	rectangle talkRect(talk_gworld), wordRect(word.rect);
-	ENABLEGL(mainPtr);
 	rect_draw_some_item(talk_gworld,talkRect,mainPtr,talk_area_rect);
 	wordRect.offset(talk_area_rect.topLeft());
 	wordRect.width() += 10; // Arbitrary extra space fixes #481 and shouldn't cause any problems
@@ -932,14 +920,11 @@ void place_talk_str(std::string str_to_place,std::string str_to_place2,short col
 	rectangle title_rect = {19,48,42,260};
 	rectangle dest_rect,help_from = {46,60,59,76};
 	
-	DISABLEGL(talk_gworld);
-	
 	TextStyle style;
 	style.font = FONT_DUNGEON;
 	style.pointSize = TALK_WORD_SIZE;
 	
-	if(c_rect.right > 0) {
-		DISABLEGL(mainPtr);
+	if(c_rect.right > 0){
 		c_rect.offset(talk_area_rect.topLeft());
 		clip_rect(mainPtr, c_rect);
 	}
@@ -1006,13 +991,11 @@ void place_talk_str(std::string str_to_place,std::string str_to_place2,short col
 		}
 	}
 	
-	ENABLEGL(talk_gworld);
 	rectangle oldRect(talk_gworld);
 	undo_clip(talk_gworld);
 	talk_gworld.display();
 	
 	// Finally place processed graphics
-	ENABLEGL(mainPtr);
 	rect_draw_some_item(talk_gworld,oldRect,mainPtr,talk_area_rect);
 	// I have no idea what this check is for; I'm jsut preserving it in case it was important
 	if(c_rect.right == 0) place_talk_face();

--- a/src/game/boe.newgraph.cpp
+++ b/src/game/boe.newgraph.cpp
@@ -182,9 +182,9 @@ void apply_light_mask(bool onWindow) {
 		return;
 	
 	if(onWindow) {
-		mainPtr.setActive(false);
+		disableGL(mainPtr);
 		fill_region(mainPtr, dark_mask_region, sf::Color::Black);
-		mainPtr.setActive();
+		enableGL(mainPtr);
 		return;
 	}
 	
@@ -397,7 +397,7 @@ void do_missile_anim(short num_steps,location missile_origin,short sound_num) {
 	auto ter_rects = terrain_screen_rects();
 	rect_draw_some_item(terrain_screen_gworld.getTexture(),ter_rects.from,mainPtr,ter_rects.to);
 	
-	mainPtr.setActive(false);
+	disableGL(mainPtr);
 	
 	// init missile paths
 	screen_ul.x = center.x - 4; screen_ul.y = center.y - 4;
@@ -500,7 +500,7 @@ void do_missile_anim(short num_steps,location missile_origin,short sound_num) {
 					rect_draw_some_item(*from_gw,from_rect, mainPtr,temp_rect,ter_rects.in_frame,sf::BlendAlpha);
 				}
 			}
-		mainPtr.setActive();
+		enableGL(mainPtr);
 		mainPtr.display();
 		sf::sleep(sf::milliseconds(2 + 5 * get_int_pref("GameSpeed")));
 	}
@@ -577,7 +577,7 @@ void do_explosion_anim(short /*sound_num*/,short special_draw, short snd) {
 	style.font = FONT_BOLD;
 	style.pointSize = 10;
 	style.lineHeight = 10;
-	mainPtr.setActive(false);
+	disableGL(mainPtr);
 	
 	// init missile paths
 	screen_ul.x = center.x - 4; screen_ul.y = center.y - 4;
@@ -638,12 +638,12 @@ void do_explosion_anim(short /*sound_num*/,short special_draw, short snd) {
 						style.colour = Colours::BLACK; 
 						text_rect.offset(-1,-1);
 						win_draw_string(mainPtr,text_rect,dam_str,eTextMode::CENTRE,style);
-						mainPtr.setActive();
+						enableGL(mainPtr);
 					}
 				}
 			}
 		//if(((PSD[SDF_GAME_SPEED] == 1) && (t % 3 == 0)) || ((PSD[SDF_GAME_SPEED] == 2) && (t % 2 == 0)))
-		mainPtr.setActive();
+		enableGL(mainPtr);
 		mainPtr.display();
 		sf::sleep(time_in_ticks(2 * (1 + get_int_pref("GameSpeed"))));
 	}
@@ -707,7 +707,7 @@ void draw_shop_graphics(bool item_pressed, bool item_help_pressed, rectangle cli
 	style.pointSize = 18;
 	
 	area_rect = rectangle(talk_gworld);
-	talk_gworld.setActive(false);
+	disableGL(talk_gworld);
 
 	// Only re-render on top of the item that is clicked:
 	if(item_pressed || item_help_pressed) {
@@ -863,7 +863,7 @@ void draw_shop_graphics(bool item_pressed, bool item_help_pressed, rectangle cli
 	win_draw_string(talk_gworld,bottom_help_rects[3],"'I' button brings up description.",eTextMode::WRAP,style);
 	
 	undo_clip(talk_gworld);
-	talk_gworld.setActive();
+	enableGL(talk_gworld);
 	talk_gworld.display();
 	
 	refresh_shopping();
@@ -886,7 +886,7 @@ void refresh_shopping() {
 static void place_talk_face() {
 	rectangle face_rect = {6,6,38,38};
 	face_rect.offset(talk_area_rect.topLeft());
-	mainPtr.setActive();
+	enableGL(mainPtr);
 	short face_to_draw = univ.scenario.scen_monsters[store_monst_type].default_facial_pic;
 	if(store_talk_face_pic >= -1)
 		face_to_draw = store_talk_face_pic;
@@ -907,7 +907,7 @@ void click_talk_rect(word_rect_t word) {
 	}
 
 	rectangle talkRect(talk_gworld), wordRect(word.rect);
-	mainPtr.setActive();
+	enableGL(mainPtr);
 	rect_draw_some_item(talk_gworld,talkRect,mainPtr,talk_area_rect);
 	wordRect.offset(talk_area_rect.topLeft());
 	wordRect.width() += 10; // Arbitrary extra space fixes #481 and shouldn't cause any problems
@@ -932,14 +932,14 @@ void place_talk_str(std::string str_to_place,std::string str_to_place2,short col
 	rectangle title_rect = {19,48,42,260};
 	rectangle dest_rect,help_from = {46,60,59,76};
 	
-	talk_gworld.setActive(false);
+	disableGL(talk_gworld);
 	
 	TextStyle style;
 	style.font = FONT_DUNGEON;
 	style.pointSize = TALK_WORD_SIZE;
 	
 	if(c_rect.right > 0) {
-		mainPtr.setActive(false);
+		disableGL(mainPtr);
 		c_rect.offset(talk_area_rect.topLeft());
 		clip_rect(mainPtr, c_rect);
 	}
@@ -1006,13 +1006,13 @@ void place_talk_str(std::string str_to_place,std::string str_to_place2,short col
 		}
 	}
 	
-	talk_gworld.setActive();
+	enableGL(talk_gworld);
 	rectangle oldRect(talk_gworld);
 	undo_clip(talk_gworld);
 	talk_gworld.display();
 	
 	// Finally place processed graphics
-	mainPtr.setActive();
+	enableGL(mainPtr);
 	rect_draw_some_item(talk_gworld,oldRect,mainPtr,talk_area_rect);
 	// I have no idea what this check is for; I'm jsut preserving it in case it was important
 	if(c_rect.right == 0) place_talk_face();

--- a/src/game/boe.newgraph.cpp
+++ b/src/game/boe.newgraph.cpp
@@ -182,9 +182,9 @@ void apply_light_mask(bool onWindow) {
 		return;
 	
 	if(onWindow) {
-		disableGL(mainPtr);
+		DISABLEGL(mainPtr);
 		fill_region(mainPtr, dark_mask_region, sf::Color::Black);
-		enableGL(mainPtr);
+		ENABLEGL(mainPtr);
 		return;
 	}
 	
@@ -397,7 +397,7 @@ void do_missile_anim(short num_steps,location missile_origin,short sound_num) {
 	auto ter_rects = terrain_screen_rects();
 	rect_draw_some_item(terrain_screen_gworld.getTexture(),ter_rects.from,mainPtr,ter_rects.to);
 	
-	disableGL(mainPtr);
+	DISABLEGL(mainPtr);
 	
 	// init missile paths
 	screen_ul.x = center.x - 4; screen_ul.y = center.y - 4;
@@ -500,7 +500,7 @@ void do_missile_anim(short num_steps,location missile_origin,short sound_num) {
 					rect_draw_some_item(*from_gw,from_rect, mainPtr,temp_rect,ter_rects.in_frame,sf::BlendAlpha);
 				}
 			}
-		enableGL(mainPtr);
+		ENABLEGL(mainPtr);
 		mainPtr.display();
 		sf::sleep(sf::milliseconds(2 + 5 * get_int_pref("GameSpeed")));
 	}
@@ -577,7 +577,7 @@ void do_explosion_anim(short /*sound_num*/,short special_draw, short snd) {
 	style.font = FONT_BOLD;
 	style.pointSize = 10;
 	style.lineHeight = 10;
-	disableGL(mainPtr);
+	DISABLEGL(mainPtr);
 	
 	// init missile paths
 	screen_ul.x = center.x - 4; screen_ul.y = center.y - 4;
@@ -638,12 +638,12 @@ void do_explosion_anim(short /*sound_num*/,short special_draw, short snd) {
 						style.colour = Colours::BLACK; 
 						text_rect.offset(-1,-1);
 						win_draw_string(mainPtr,text_rect,dam_str,eTextMode::CENTRE,style);
-						enableGL(mainPtr);
+						ENABLEGL(mainPtr);
 					}
 				}
 			}
 		//if(((PSD[SDF_GAME_SPEED] == 1) && (t % 3 == 0)) || ((PSD[SDF_GAME_SPEED] == 2) && (t % 2 == 0)))
-		enableGL(mainPtr);
+		ENABLEGL(mainPtr);
 		mainPtr.display();
 		sf::sleep(time_in_ticks(2 * (1 + get_int_pref("GameSpeed"))));
 	}
@@ -707,7 +707,7 @@ void draw_shop_graphics(bool item_pressed, bool item_help_pressed, rectangle cli
 	style.pointSize = 18;
 	
 	area_rect = rectangle(talk_gworld);
-	disableGL(talk_gworld);
+	DISABLEGL(talk_gworld);
 
 	// Only re-render on top of the item that is clicked:
 	if(item_pressed || item_help_pressed) {
@@ -863,7 +863,7 @@ void draw_shop_graphics(bool item_pressed, bool item_help_pressed, rectangle cli
 	win_draw_string(talk_gworld,bottom_help_rects[3],"'I' button brings up description.",eTextMode::WRAP,style);
 	
 	undo_clip(talk_gworld);
-	enableGL(talk_gworld);
+	ENABLEGL(talk_gworld);
 	talk_gworld.display();
 	
 	refresh_shopping();
@@ -886,7 +886,7 @@ void refresh_shopping() {
 static void place_talk_face() {
 	rectangle face_rect = {6,6,38,38};
 	face_rect.offset(talk_area_rect.topLeft());
-	enableGL(mainPtr);
+	ENABLEGL(mainPtr);
 	short face_to_draw = univ.scenario.scen_monsters[store_monst_type].default_facial_pic;
 	if(store_talk_face_pic >= -1)
 		face_to_draw = store_talk_face_pic;
@@ -907,7 +907,7 @@ void click_talk_rect(word_rect_t word) {
 	}
 
 	rectangle talkRect(talk_gworld), wordRect(word.rect);
-	enableGL(mainPtr);
+	ENABLEGL(mainPtr);
 	rect_draw_some_item(talk_gworld,talkRect,mainPtr,talk_area_rect);
 	wordRect.offset(talk_area_rect.topLeft());
 	wordRect.width() += 10; // Arbitrary extra space fixes #481 and shouldn't cause any problems
@@ -932,14 +932,14 @@ void place_talk_str(std::string str_to_place,std::string str_to_place2,short col
 	rectangle title_rect = {19,48,42,260};
 	rectangle dest_rect,help_from = {46,60,59,76};
 	
-	disableGL(talk_gworld);
+	DISABLEGL(talk_gworld);
 	
 	TextStyle style;
 	style.font = FONT_DUNGEON;
 	style.pointSize = TALK_WORD_SIZE;
 	
 	if(c_rect.right > 0) {
-		disableGL(mainPtr);
+		DISABLEGL(mainPtr);
 		c_rect.offset(talk_area_rect.topLeft());
 		clip_rect(mainPtr, c_rect);
 	}
@@ -1006,13 +1006,13 @@ void place_talk_str(std::string str_to_place,std::string str_to_place2,short col
 		}
 	}
 	
-	enableGL(talk_gworld);
+	ENABLEGL(talk_gworld);
 	rectangle oldRect(talk_gworld);
 	undo_clip(talk_gworld);
 	talk_gworld.display();
 	
 	// Finally place processed graphics
-	enableGL(mainPtr);
+	ENABLEGL(mainPtr);
 	rect_draw_some_item(talk_gworld,oldRect,mainPtr,talk_area_rect);
 	// I have no idea what this check is for; I'm jsut preserving it in case it was important
 	if(c_rect.right == 0) place_talk_face();

--- a/src/game/boe.text.cpp
+++ b/src/game/boe.text.cpp
@@ -96,7 +96,7 @@ void put_pc_screen() {
 	rectangle bottom_bar_rect = {99,0,116,271};
 	rectangle info_from = {0,1,12,13}, switch_from = {0, 13, 12, 25};
 	
-	pc_stats_gworld.setActive(false);
+	disableGL(pc_stats_gworld);
 	clear_scale_aware_text(pc_stats_gworld);
 	
 	// First clean up gworld with pretty patterns
@@ -199,7 +199,7 @@ void put_pc_screen() {
 	to_draw_rect = {101,251,114,267};
 	rect_draw_some_item(invenbtn_gworld, help_from_rect, pc_stats_gworld, to_draw_rect, sf::BlendAlpha);
 	
-	pc_stats_gworld.setActive();
+	enableGL(pc_stats_gworld);
 	pc_stats_gworld.display();
 	
 	// Sometimes this gets called when character is slain. when that happens, if items for
@@ -219,7 +219,7 @@ void put_item_screen(eItemWinMode screen_num) {
 	rectangle erase_rect = {17,2,122,255},dest_rect;
 	rectangle upper_frame_rect = {3,3,15,268};
 	
-	item_stats_gworld.setActive(false);
+	disableGL(item_stats_gworld);
 	clear_scale_aware_text(item_stats_gworld);
 	
 	// First clean up gworld with pretty patterns
@@ -360,7 +360,7 @@ void put_item_screen(eItemWinMode screen_num) {
 	undo_clip(item_stats_gworld);
 	
 	place_item_bottom_buttons();
-	item_stats_gworld.setActive();
+	enableGL(item_stats_gworld);
 	item_stats_gworld.display();
 }
 
@@ -1069,7 +1069,7 @@ void print_buf () {
 	long start_print_point;
 	rectangle store_text_rect,dest_rect,erase_rect = {2,2,136,255};
 	
-	text_area_gworld.setActive(false);
+	disableGL(text_area_gworld);
 	clear_scale_aware_text(text_area_gworld);
 	
 	// First clean up gworld with pretty patterns
@@ -1100,7 +1100,7 @@ void print_buf () {
 		
 	}
 	
-	text_area_gworld.setActive();
+	enableGL(text_area_gworld);
 	text_area_gworld.display();
 }
 

--- a/src/game/boe.text.cpp
+++ b/src/game/boe.text.cpp
@@ -96,7 +96,7 @@ void put_pc_screen() {
 	rectangle bottom_bar_rect = {99,0,116,271};
 	rectangle info_from = {0,1,12,13}, switch_from = {0, 13, 12, 25};
 	
-	disableGL(pc_stats_gworld);
+	DISABLEGL(pc_stats_gworld);
 	clear_scale_aware_text(pc_stats_gworld);
 	
 	// First clean up gworld with pretty patterns
@@ -199,7 +199,7 @@ void put_pc_screen() {
 	to_draw_rect = {101,251,114,267};
 	rect_draw_some_item(invenbtn_gworld, help_from_rect, pc_stats_gworld, to_draw_rect, sf::BlendAlpha);
 	
-	enableGL(pc_stats_gworld);
+	ENABLEGL(pc_stats_gworld);
 	pc_stats_gworld.display();
 	
 	// Sometimes this gets called when character is slain. when that happens, if items for
@@ -219,7 +219,7 @@ void put_item_screen(eItemWinMode screen_num) {
 	rectangle erase_rect = {17,2,122,255},dest_rect;
 	rectangle upper_frame_rect = {3,3,15,268};
 	
-	disableGL(item_stats_gworld);
+	DISABLEGL(item_stats_gworld);
 	clear_scale_aware_text(item_stats_gworld);
 	
 	// First clean up gworld with pretty patterns
@@ -360,7 +360,7 @@ void put_item_screen(eItemWinMode screen_num) {
 	undo_clip(item_stats_gworld);
 	
 	place_item_bottom_buttons();
-	enableGL(item_stats_gworld);
+	ENABLEGL(item_stats_gworld);
 	item_stats_gworld.display();
 }
 
@@ -1069,7 +1069,7 @@ void print_buf () {
 	long start_print_point;
 	rectangle store_text_rect,dest_rect,erase_rect = {2,2,136,255};
 	
-	disableGL(text_area_gworld);
+	DISABLEGL(text_area_gworld);
 	clear_scale_aware_text(text_area_gworld);
 	
 	// First clean up gworld with pretty patterns
@@ -1100,7 +1100,7 @@ void print_buf () {
 		
 	}
 	
-	enableGL(text_area_gworld);
+	ENABLEGL(text_area_gworld);
 	text_area_gworld.display();
 }
 

--- a/src/game/boe.text.cpp
+++ b/src/game/boe.text.cpp
@@ -96,7 +96,6 @@ void put_pc_screen() {
 	rectangle bottom_bar_rect = {99,0,116,271};
 	rectangle info_from = {0,1,12,13}, switch_from = {0, 13, 12, 25};
 	
-	DISABLEGL(pc_stats_gworld);
 	clear_scale_aware_text(pc_stats_gworld);
 	
 	// First clean up gworld with pretty patterns
@@ -199,7 +198,6 @@ void put_pc_screen() {
 	to_draw_rect = {101,251,114,267};
 	rect_draw_some_item(invenbtn_gworld, help_from_rect, pc_stats_gworld, to_draw_rect, sf::BlendAlpha);
 	
-	ENABLEGL(pc_stats_gworld);
 	pc_stats_gworld.display();
 	
 	// Sometimes this gets called when character is slain. when that happens, if items for
@@ -219,7 +217,6 @@ void put_item_screen(eItemWinMode screen_num) {
 	rectangle erase_rect = {17,2,122,255},dest_rect;
 	rectangle upper_frame_rect = {3,3,15,268};
 	
-	DISABLEGL(item_stats_gworld);
 	clear_scale_aware_text(item_stats_gworld);
 	
 	// First clean up gworld with pretty patterns
@@ -360,7 +357,6 @@ void put_item_screen(eItemWinMode screen_num) {
 	undo_clip(item_stats_gworld);
 	
 	place_item_bottom_buttons();
-	ENABLEGL(item_stats_gworld);
 	item_stats_gworld.display();
 }
 
@@ -1069,7 +1065,6 @@ void print_buf () {
 	long start_print_point;
 	rectangle store_text_rect,dest_rect,erase_rect = {2,2,136,255};
 	
-	DISABLEGL(text_area_gworld);
 	clear_scale_aware_text(text_area_gworld);
 	
 	// First clean up gworld with pretty patterns
@@ -1100,7 +1095,6 @@ void print_buf () {
 		
 	}
 	
-	ENABLEGL(text_area_gworld);
 	text_area_gworld.display();
 }
 

--- a/src/game/boe.town.cpp
+++ b/src/game/boe.town.cpp
@@ -1371,13 +1371,6 @@ void draw_map(bool need_refresh) {
 		canMap = false;
 	}
 	else if(need_refresh) {
-		// CHECKME: unsure, but on osx, if this is not called,
-		// the following code does not update the gworld texture if we are
-		// called just after closing a dialog
-		ENABLEGL(mainPtr);
-
-		ENABLEGL(map_gworld);
-		
 		fill_rect(map_gworld, map_world_rect, sf::Color::Black);
 		
 		// Now, if shopping or talking, just don't touch anything.
@@ -1464,8 +1457,6 @@ void draw_map(bool need_refresh) {
 		glFlush();
 	}
 	
-	DISABLEGL(mini_map);
-	
 	// Now place terrain map gworld
 	TextStyle style;
 	style.font = FONT_BOLD;
@@ -1519,11 +1510,7 @@ void draw_map(bool need_refresh) {
 		}
 	}
 	
-	DISABLEGL(mini_map);
 	mini_map.display();
-	
-	// Now exit gracefully
-	ENABLEGL(mainPtr);
 }
 
 

--- a/src/game/boe.town.cpp
+++ b/src/game/boe.town.cpp
@@ -1371,12 +1371,12 @@ void draw_map(bool need_refresh) {
 		canMap = false;
 	}
 	else if(need_refresh) {
-		// CHECKME: unsure, but on osx, if mainPtr.setActive() is not called,
+		// CHECKME: unsure, but on osx, if this is not called,
 		// the following code does not update the gworld texture if we are
 		// called just after closing a dialog
-		mainPtr.setActive();
+		enableGL(mainPtr);
 
-		map_gworld.setActive();
+		enableGL(map_gworld);
 		
 		fill_rect(map_gworld, map_world_rect, sf::Color::Black);
 		
@@ -1464,7 +1464,7 @@ void draw_map(bool need_refresh) {
 		glFlush();
 	}
 	
-	mini_map.setActive(false);
+	disableGL(mini_map);
 	
 	// Now place terrain map gworld
 	TextStyle style;
@@ -1519,12 +1519,11 @@ void draw_map(bool need_refresh) {
 		}
 	}
 	
-	mini_map.setActive(false);
+	disableGL(mini_map);
 	mini_map.display();
 	
 	// Now exit gracefully
-	mainPtr.setActive();
-	
+	enableGL(mainPtr);
 }
 
 

--- a/src/game/boe.town.cpp
+++ b/src/game/boe.town.cpp
@@ -1374,9 +1374,9 @@ void draw_map(bool need_refresh) {
 		// CHECKME: unsure, but on osx, if this is not called,
 		// the following code does not update the gworld texture if we are
 		// called just after closing a dialog
-		enableGL(mainPtr);
+		ENABLEGL(mainPtr);
 
-		enableGL(map_gworld);
+		ENABLEGL(map_gworld);
 		
 		fill_rect(map_gworld, map_world_rect, sf::Color::Black);
 		
@@ -1464,7 +1464,7 @@ void draw_map(bool need_refresh) {
 		glFlush();
 	}
 	
-	disableGL(mini_map);
+	DISABLEGL(mini_map);
 	
 	// Now place terrain map gworld
 	TextStyle style;
@@ -1519,11 +1519,11 @@ void draw_map(bool need_refresh) {
 		}
 	}
 	
-	disableGL(mini_map);
+	DISABLEGL(mini_map);
 	mini_map.display();
 	
 	// Now exit gracefully
-	enableGL(mainPtr);
+	ENABLEGL(mainPtr);
 }
 
 

--- a/src/game/boe.ui.cpp
+++ b/src/game/boe.ui.cpp
@@ -59,7 +59,7 @@ eToolbarButton cToolbar::button_hit(sf::RenderWindow& win, location click, cFram
 			if(click.in(toolbar[i].bounds)) {
 				sf::Event e;
 				bool done = false, clicked = false;
-				enableGL(win);
+				ENABLEGL(win);
 				active = i;
 				while(!done){
 					redraw_screen(REFRESH_NONE);

--- a/src/game/boe.ui.cpp
+++ b/src/game/boe.ui.cpp
@@ -59,7 +59,7 @@ eToolbarButton cToolbar::button_hit(sf::RenderWindow& win, location click, cFram
 			if(click.in(toolbar[i].bounds)) {
 				sf::Event e;
 				bool done = false, clicked = false;
-				win.setActive();
+				enableGL(win);
 				active = i;
 				while(!done){
 					redraw_screen(REFRESH_NONE);

--- a/src/game/boe.ui.cpp
+++ b/src/game/boe.ui.cpp
@@ -59,7 +59,6 @@ eToolbarButton cToolbar::button_hit(sf::RenderWindow& win, location click, cFram
 			if(click.in(toolbar[i].bounds)) {
 				sf::Event e;
 				bool done = false, clicked = false;
-				ENABLEGL(win);
 				active = i;
 				while(!done){
 					redraw_screen(REFRESH_NONE);

--- a/src/gfx/render_image.cpp
+++ b/src/gfx/render_image.cpp
@@ -95,7 +95,7 @@ void rect_draw_some_item(const sf::Texture& src_gworld,rectangle src_rect,sf::Re
 	src_rect &= src_gworld_rect;
 	targ_rect &= targ_gworld_rect;
 	if(src_rect.empty() || targ_rect.empty()) return;
-	setActiveRenderTarget(targ_gworld);
+	enableGL(targ_gworld);
 	sf::Sprite tile(src_gworld, src_rect);
 	tile.setPosition(targ_rect.left, targ_rect.top);
 	double xScale = targ_rect.width(), yScale = targ_rect.height();
@@ -164,11 +164,15 @@ void rect_draw_some_item(sf::RenderTexture& src_render_gworld,rectangle src_rect
 	draw_stored_scale_aware_text(src_render_gworld, targ_gworld, targ_rect);
 }
 
-void setActiveRenderTarget(sf::RenderTarget& where) {
-	const std::type_info& type = typeid(where);
-	if(type == typeid(sf::RenderWindow&))
-		dynamic_cast<sf::RenderWindow&>(where).setActive();
-	else if(type == typeid(sf::RenderTexture&))
-		dynamic_cast<sf::RenderTexture&>(where).setActive();
-	else throw std::bad_cast();
+void setActiveRenderTarget(sf::RenderTarget& where, bool active) {
+	if(!where.setActive(active))
+		throw std::string {"Failed to set RenderTarget active for OpenGL operations!"};
+}
+
+void enableGL(sf::RenderTarget& where) {
+	setActiveRenderTarget(where, true);
+}
+
+void disableGL(sf::RenderTarget& where) {
+	setActiveRenderTarget(where, false);
 }

--- a/src/gfx/render_image.cpp
+++ b/src/gfx/render_image.cpp
@@ -95,7 +95,6 @@ void rect_draw_some_item(const sf::Texture& src_gworld,rectangle src_rect,sf::Re
 	src_rect &= src_gworld_rect;
 	targ_rect &= targ_gworld_rect;
 	if(src_rect.empty() || targ_rect.empty()) return;
-	ENABLEGL(targ_gworld);
 	sf::Sprite tile(src_gworld, src_rect);
 	tile.setPosition(targ_rect.left, targ_rect.top);
 	double xScale = targ_rect.width(), yScale = targ_rect.height();

--- a/src/gfx/render_image.hpp
+++ b/src/gfx/render_image.hpp
@@ -27,6 +27,8 @@ void rect_draw_some_item(const sf::Texture& src_gworld,rectangle src_rect,const 
 void rect_draw_some_item(sf::RenderTexture& src_render_gworld,rectangle src_rect,const sf::Texture& mask_gworld,sf::RenderTarget& targ_gworld,rectangle targ_rect);
 void draw_splash(const sf::Texture& splash, sf::RenderWindow& targ, rectangle dest_rect);
 
-void setActiveRenderTarget(sf::RenderTarget& where);
+// NEVER call setActive() directly.
+void enableGL(sf::RenderTarget& where);
+void disableGL(sf::RenderTarget& where);
 
 #endif

--- a/src/gfx/render_image.hpp
+++ b/src/gfx/render_image.hpp
@@ -28,7 +28,10 @@ void rect_draw_some_item(sf::RenderTexture& src_render_gworld,rectangle src_rect
 void draw_splash(const sf::Texture& splash, sf::RenderWindow& targ, rectangle dest_rect);
 
 // NEVER call setActive() directly.
-void enableGL(sf::RenderTarget& where);
-void disableGL(sf::RenderTarget& where);
+void enableGL(sf::RenderTarget& targ, std::string name, fs::path file, int line);
+void disableGL(sf::RenderTarget& targ, std::string name);
+#define ENABLEGL(targ) enableGL(targ, #targ, __FILE__, __LINE__)
+#define DISABLEGL(targ) disableGL(targ, #targ)
 
 #endif
+

--- a/src/gfx/render_shapes.cpp
+++ b/src/gfx/render_shapes.cpp
@@ -117,7 +117,7 @@ void draw_line(sf::RenderTarget& target, location from, location to, int thickne
 	line[0].color = colour;
 	line[1].position = to;
 	line[1].color = colour;
-	setActiveRenderTarget(target);
+	enableGL(target);
 	float saveThickness;
 	glGetFloatv(GL_LINE_WIDTH, &saveThickness);
 	glLineWidth(thickness);
@@ -128,7 +128,7 @@ void draw_line(sf::RenderTarget& target, location from, location to, int thickne
 static void fill_shape(sf::RenderTarget& target, sf::Shape& shape, int x, int y, sf::Color colour) {
 	shape.setPosition(x, y);
 	shape.setFillColor(colour);
-	setActiveRenderTarget(target);
+	enableGL(target);
 	target.draw(shape);
 	
 }
@@ -222,7 +222,7 @@ rectangle Region::getEnclosingRect() {
 // Could request it in dialogs, but currently don't
 // SFML does not appear to allow requesting it for render textures
 void Region::setStencil(sf::RenderWindow& where) {
-	where.setActive();
+	enableGL(where);
 	glClearStencil(0);
 	glClear(GL_STENCIL_BUFFER_BIT);
 	glEnable(GL_STENCIL_TEST);
@@ -255,7 +255,7 @@ void clip_rect(sf::RenderTarget& where, rectangle rect) {
 	}
 
 	// TODO: Make sure this works for the scissor test...
-	setActiveRenderTarget(where);
+	enableGL(where);
 	auto viewport = where.getView().getViewport();
 	rectangle winRect(where);
 	location pivot = rect.bottomLeft();
@@ -274,7 +274,7 @@ void undo_clip(sf::RenderTarget& where) {
 		store_clip_rects.erase(p);
 	}
 
-	setActiveRenderTarget(where);
+	enableGL(where);
 	glDisable(GL_SCISSOR_TEST);
 	glDisable(GL_STENCIL_TEST);
 }

--- a/src/gfx/render_shapes.cpp
+++ b/src/gfx/render_shapes.cpp
@@ -117,7 +117,7 @@ void draw_line(sf::RenderTarget& target, location from, location to, int thickne
 	line[0].color = colour;
 	line[1].position = to;
 	line[1].color = colour;
-	enableGL(target);
+	ENABLEGL(target);
 	float saveThickness;
 	glGetFloatv(GL_LINE_WIDTH, &saveThickness);
 	glLineWidth(thickness);
@@ -128,7 +128,7 @@ void draw_line(sf::RenderTarget& target, location from, location to, int thickne
 static void fill_shape(sf::RenderTarget& target, sf::Shape& shape, int x, int y, sf::Color colour) {
 	shape.setPosition(x, y);
 	shape.setFillColor(colour);
-	enableGL(target);
+	ENABLEGL(target);
 	target.draw(shape);
 	
 }
@@ -222,7 +222,7 @@ rectangle Region::getEnclosingRect() {
 // Could request it in dialogs, but currently don't
 // SFML does not appear to allow requesting it for render textures
 void Region::setStencil(sf::RenderWindow& where) {
-	enableGL(where);
+	ENABLEGL(where);
 	glClearStencil(0);
 	glClear(GL_STENCIL_BUFFER_BIT);
 	glEnable(GL_STENCIL_TEST);
@@ -255,7 +255,7 @@ void clip_rect(sf::RenderTarget& where, rectangle rect) {
 	}
 
 	// TODO: Make sure this works for the scissor test...
-	enableGL(where);
+	ENABLEGL(where);
 	auto viewport = where.getView().getViewport();
 	rectangle winRect(where);
 	location pivot = rect.bottomLeft();
@@ -274,7 +274,7 @@ void undo_clip(sf::RenderTarget& where) {
 		store_clip_rects.erase(p);
 	}
 
-	enableGL(where);
+	ENABLEGL(where);
 	glDisable(GL_SCISSOR_TEST);
 	glDisable(GL_STENCIL_TEST);
 }

--- a/src/gfx/render_shapes.hpp
+++ b/src/gfx/render_shapes.hpp
@@ -43,7 +43,7 @@ void frame_rect(sf::RenderTarget& target, rectangle rect, sf::Color colour);
 void frame_circle(sf::RenderTarget& target, rectangle rect, sf::Color colour);
 void frame_roundrect(sf::RenderTarget& target, rectangle rect, int rad, sf::Color colour);
 
-void draw_line(sf::RenderTarget& target, location from, location to, int thickness, sf::Color colour, sf::BlendMode mode = sf::BlendNone);
+void draw_line(sf::RenderTarget& target, location from, location to, int thickness, sf::Color colour, sf::BlendMode mode = sf::BlendNone, bool must_enable_gl = false);
 
 void clip_rect(sf::RenderTarget& where, rectangle rect);
 void clip_region(sf::RenderWindow& where, Region& region);

--- a/src/gfx/tiling.cpp
+++ b/src/gfx/tiling.cpp
@@ -68,7 +68,6 @@ void tileImage(sf::RenderTarget& target, rectangle area, tessel_ref_t tessel, sf
 	tesselShape.setTextureRect(area);
 	tesselShape.setPosition(area.left, area.top);
 	sf::RenderStates renderMode(mode);
-	ENABLEGL(target);
 	clip_rect(target, clipArea);
 	target.draw(tesselShape, renderMode);
 	undo_clip(target);

--- a/src/gfx/tiling.cpp
+++ b/src/gfx/tiling.cpp
@@ -68,7 +68,7 @@ void tileImage(sf::RenderTarget& target, rectangle area, tessel_ref_t tessel, sf
 	tesselShape.setTextureRect(area);
 	tesselShape.setPosition(area.left, area.top);
 	sf::RenderStates renderMode(mode);
-	enableGL(target);
+	ENABLEGL(target);
 	clip_rect(target, clipArea);
 	target.draw(tesselShape, renderMode);
 	undo_clip(target);

--- a/src/gfx/tiling.cpp
+++ b/src/gfx/tiling.cpp
@@ -68,7 +68,7 @@ void tileImage(sf::RenderTarget& target, rectangle area, tessel_ref_t tessel, sf
 	tesselShape.setTextureRect(area);
 	tesselShape.setPosition(area.left, area.top);
 	sf::RenderStates renderMode(mode);
-	setActiveRenderTarget(target);
+	enableGL(target);
 	clip_rect(target, clipArea);
 	target.draw(tesselShape, renderMode);
 	undo_clip(target);


### PR DESCRIPTION
A few months ago when I asked for help with a graphics bug in the SFML Discord, folks there immediately thought the problem must be our use of RenderTarget.setActive() and setActive(false) all over the place. Apparently most SFML devs use those functions almost never.

[The documentation of setActive() says this:](https://www.sfml-dev.org/documentation/2.5.1/classsf_1_1RenderTarget.php#adc225ead22a70843ffa9b7eebefa0ce1)

> This function makes the render target's context current for future OpenGL rendering operations (so you shouldn't care about it if you're not doing direct OpenGL stuff). A render target's context is active only on the current thread, if you want to make it active on another thread you have to deactivate it on the previous thread first if it was active. Only one context can be current in a thread, so if you want to draw OpenGL geometry to another render target don't forget to activate it again. Activating a render target will automatically deactivate the previously active context (if any).

So, setActive() is *only needed* prior to direct OpenGL operations, and when it is called, the state of being "active" is *snatched* from whatever had it before. That means we're calling it in tons of unnecessary places, which can potentially cause a place where it *is* necessary, to not be active as expected.

I decided to wrap the setActive() function in a way that tracks which RenderTarget is the active one, and makes it illegal to activate a different target before the other one is finished. This led me to seeing that we could remove almost all of our setActive() calls harmlessly, and only have it called within functions that do OpenGL stuff.

Honestly I thought fixing up the usage of setActive() would magically fix #602 because by all appearances it has to do with texture/buffer corruption somehow. It did not.

Maybe `display()` is actually the key to that problem...