### PR TITLE
linux: let SFML handle makeFrontWindow()

### DIFF
--- a/src/tools/winutil.linux.cpp
+++ b/src/tools/winutil.linux.cpp
@@ -93,6 +93,7 @@ std::string get_os_version() {
 }
 
 void makeFrontWindow(sf::Window& win) {
+	win.requestFocus();
 }
 
 void setWindowFloating(sf::Window& win, bool floating) {


### PR DESCRIPTION
Well, the last PR which I made into a draft turned into a big disappointment. But I did notice one thing, which is that Linux does *nothing* to try to bring the right window to the front. So I just added a call to SFML's function for that. Maybe this fixes issue #183.