### PR TITLE
Fix scaled text offset in fullscreen modes. 

### DIFF
--- a/src/gfx/render_text.hpp
+++ b/src/gfx/render_text.hpp
@@ -57,6 +57,7 @@ enum class eTextMode {
 
 std::vector<rectangle> draw_string_hilite(sf::RenderTarget& dest_window,rectangle dest_rect,std::string str,TextStyle style,std::vector<hilite_t> hilites,sf::Color hiliteClr);
 std::vector<snippet_t> draw_string_sel(sf::RenderTarget& dest_window,rectangle dest_rect,std::string str,TextStyle style,std::vector<hilite_t> hilites,sf::Color hiliteClr);
+sf::Vector2f scaled_view_top_left(sf::RenderTarget& dest_window, sf::View& scaled_view);
 void draw_scale_aware_text(sf::RenderTarget& dest_window, sf::Text str_to_draw);
 void clear_scale_aware_text(sf::RenderTexture& texture);
 void win_draw_string(sf::RenderTarget& dest_window,rectangle dest_rect,std::string str,eTextMode mode,TextStyle style,bool right_align = false);


### PR DESCRIPTION
Fix #651

Here's a fullscreen window mode shown fixed:

<img width="1440" alt="Screenshot 2025-02-22 at 8 47 43 AM" src="https://github.com/user-attachments/assets/042d91bc-8e90-4df8-9c45-5c71a34bcf9c" />
