### PR TITLE
Fix the Use Special item button.

### DIFF
--- a/src/game/boe.text.cpp
+++ b/src/game/boe.text.cpp
@@ -265,8 +265,11 @@ void put_item_screen(eItemWinMode screen_num) {
 					
 					place_item_button(i,ITEMBTN_INFO);
 					if((univ.scenario.special_items[spec_item_array[i_num]].flags % 10 == 1)
-						&& (!(is_combat())))
-						place_item_button(i,ITEMBTN_DROP); // TODO: Shouldn't this be ITEMBTN_USE?
+						&& (!(is_combat()))){
+						// Put a Use button where the Drop button normally goes,
+						// so there's no gap between Use and Info:
+						place_item_button(i,ITEMBTN_USE, ITEMBTN_DROP);
+					}
 				}
 			}
 			break;
@@ -459,12 +462,16 @@ void place_item_graphic(short which_slot,short graphic) {
 }
 
 // name, use, give, drop, info, sell/id
-void place_item_button(short which_slot,eItemButton button_type) {
+void place_item_button(short which_slot,eItemButton button_type, eItemButton button_pos) {
+	if(button_pos == MAX_eItemButton){
+		button_pos = button_type;
+	}
+
 	rectangle from_rect = {0,0,18,18},to_rect;
-	
+
 	sf::Texture& invenbtn_gworld = *ResMgr::graphics.get("invenbtns");
 	item_area_button_active[which_slot][button_type] = true;
-	rect_draw_some_item(invenbtn_gworld, item_buttons_from[button_type - 2], item_stats_gworld, item_buttons[which_slot][button_type], sf::BlendAlpha);
+	rect_draw_some_item(invenbtn_gworld, item_buttons_from[button_type - 2], item_stats_gworld, item_buttons[which_slot][button_pos], sf::BlendAlpha);
 }
 
 void place_item_bottom_buttons() {

--- a/src/game/boe.text.hpp
+++ b/src/game/boe.text.hpp
@@ -8,7 +8,7 @@ void put_item_screen(eItemWinMode screen_num);
 void place_item_bottom_buttons();
 void set_stat_window(eItemWinMode new_stat, bool record = false);
 void set_stat_window_for_pc(int pc, bool record = false);
-void place_item_button(short which_slot,eItemButton button_type = ITEMBTN_USE);
+void place_item_button(short which_slot,eItemButton button_type = ITEMBTN_USE,eItemButton button_pos = MAX_eItemButton);
 void place_item_graphic(short which_slot,short graphic);
 short first_active_pc();
 void refresh_stat_areas(short mode);


### PR DESCRIPTION
The Use button for special items draws a Drop button on master. I think I remember the change I made that broke this--and it all stems from the code being confusing (there was a TODO note that this resolves).