### PR TITLE
Fix simulacrum

### DIFF
--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2415,7 +2415,7 @@ void show_debug_help() {
 }
 
 // Non-comprehensive list of unused keys:
-// chijklnoqvy @#$-_+[]{},.'"`~/\|;:
+// hijklnoqvy @#$-_+[]{},.'"`~/\|;:
 void init_debug_actions() {
 	add_debug_action({'B'}, "Leave town", debug_leave_town);
 	add_debug_action({'C'}, "Get cleaned up (lose negative status effects)", debug_clean_up);
@@ -2448,6 +2448,7 @@ void init_debug_actions() {
 	add_debug_action({'T'}, "Enter town", debug_enter_town);
 	add_debug_action({'W'}, "Refresh jobs/shops", debug_refresh_stores);
 	add_debug_action({'X'}, "Kill party", debug_kill_party);
+	add_debug_action({'c'}, "Clear captured souls", clear_trapped_monst);
 	add_debug_action({'='}, "Heal, increase magic skills", debug_heal_plus_extra);
 	add_debug_action({'<'}, "Make one day pass", debug_increase_age);
 	add_debug_action({'>'}, "Reset towns (excludes the one you're in, if any)", debug_towns_forget);
@@ -4008,4 +4009,13 @@ void save_replay_log(){
 	fs::path out_file = nav_put_rsrc({"xml"});
 
 	start_log_file(out_file.string());
+}
+
+void clear_trapped_monst() {
+	if(recording){
+		record_action("clear_trapped_monst", "");
+	}
+	univ.party.imprisoned_monst.fill(0);
+	ASB("Debug: Captures souls cleared.");
+	print_buf();
 }

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2415,7 +2415,8 @@ void show_debug_help() {
 }
 
 // Non-comprehensive list of unused keys:
-// hijklnoqvy @#$-_+[]{},.'"`~/\|;:
+// chijklnoqvy @#$-_+[]{},.'"`\|;:
+// We want to keep lower-case for normal gameplay.
 void init_debug_actions() {
 	add_debug_action({'B'}, "Leave town", debug_leave_town);
 	add_debug_action({'C'}, "Get cleaned up (lose negative status effects)", debug_clean_up);
@@ -2448,7 +2449,7 @@ void init_debug_actions() {
 	add_debug_action({'T'}, "Enter town", debug_enter_town);
 	add_debug_action({'W'}, "Refresh jobs/shops", debug_refresh_stores);
 	add_debug_action({'X'}, "Kill party", debug_kill_party);
-	add_debug_action({'c'}, "Clear captured souls", clear_trapped_monst);
+	add_debug_action({'~'}, "Clear captured souls", clear_trapped_monst);
 	add_debug_action({'='}, "Heal, increase magic skills", debug_heal_plus_extra);
 	add_debug_action({'<'}, "Make one day pass", debug_increase_age);
 	add_debug_action({'>'}, "Reset towns (excludes the one you're in, if any)", debug_towns_forget);

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2415,7 +2415,7 @@ void show_debug_help() {
 }
 
 // Non-comprehensive list of unused keys:
-// chijklnoqvy @#$-_+[]{},.'"`\|;:
+// chjklnoqvy @#$-_+[]{},.'"`\|;:
 // We want to keep lower-case for normal gameplay.
 void init_debug_actions() {
 	add_debug_action({'B'}, "Leave town", debug_leave_town);
@@ -2704,8 +2704,9 @@ bool handle_keystroke(const sf::Event& event, cFramerateLimiter& fps_limiter){
 			toggle_debug_mode();
 			break;
 
-		// 'z', Really? 'i' is not used
+		// 'z', Really?
 		case 'z':
+		case 'i':
 			show_inventory();
 			break;
 			

--- a/src/game/boe.actions.hpp
+++ b/src/game/boe.actions.hpp
@@ -119,5 +119,6 @@ void easter_egg(int idx);
 void preview_dialog_xml();
 void preview_every_dialog_xml();
 void save_replay_log();
+void clear_trapped_monst();
 
 #endif

--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -4761,6 +4761,11 @@ bool combat_cast_mage_spell() {
 		}
 		
 		if(spell_num == eSpell::SIMULACRUM) {
+			if(!has_trapped_monst()){
+				add_string_to_buf("Simulacrum: You need to cast Capture\n");
+				add_string_to_buf("  Soul on a creature first.");
+				return false;
+			}
 			store_sum_monst = pick_trapped_monst();
 			if(store_sum_monst == 0)
 				return false;

--- a/src/game/boe.combat.cpp
+++ b/src/game/boe.combat.cpp
@@ -4769,7 +4769,10 @@ bool combat_cast_mage_spell() {
 			store_sum_monst = pick_trapped_monst();
 			if(store_sum_monst == 0)
 				return false;
-			get_monst = univ.scenario.scen_monsters[store_sum_monst];
+			if(store_sum_monst >= 10000)
+				get_monst = univ.party.summons[store_sum_monst-10000];
+			else
+				get_monst = univ.scenario.scen_monsters[store_sum_monst];
 			if(store_sp < get_monst.level) {
 				add_string_to_buf("Cast: Not enough spell points.");
 				return false;

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -926,6 +926,8 @@ static void replay_action(Element& action) {
 		debug_fight_encounter(str_to_bool(action.GetText()));
 	}else if(t == "preview_every_dialog_xml"){
 		preview_every_dialog_xml();
+	}else if(t == "clear_trapped_monst"){
+		clear_trapped_monst();
 	}else if(t == "advance_time"){
 		// This is bad regardless of strictness, because visual changes may have occurred which won't get redrawn/reprinted
 		throw std::string { "Replay system internal error! advance_time() was supposed to be called by the last action, but wasn't: " } + _last_action_type;

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -2278,6 +2278,13 @@ bool pick_pc_name(short pc_num,cDialog* parent) {
 	return 1;
 }
 
+bool has_trapped_monst() {
+	for(mon_num_t which : univ.party.imprisoned_monst) {
+		if(which != 0) return true;
+	}
+	return false;
+}
+
 mon_num_t pick_trapped_monst() {
 	short i = 0;
 	std::string sp;

--- a/src/game/boe.party.cpp
+++ b/src/game/boe.party.cpp
@@ -2298,6 +2298,7 @@ mon_num_t pick_trapped_monst() {
 			get_monst = which >= 10000 ? univ.party.summons[which - 10000] : univ.scenario.scen_monsters[which];
 			soulCrystal->getControl("lvl" + n).setTextToNum(get_monst.level);
 		}
+		i++;
 	}
 	
 	

--- a/src/game/boe.party.hpp
+++ b/src/game/boe.party.hpp
@@ -33,6 +33,7 @@ void do_alchemy();
 eAlchemy alch_choice(short pc_num);
 bool pick_pc_graphic(short pc_num,short mode,cDialog* parent_num);
 bool pick_pc_name(short pc_num,cDialog* parent)  ;
+bool has_trapped_monst();
 mon_num_t pick_trapped_monst();
 bool flying() ;
 void hit_party(short how_much,eDamageType damage_type,short snd_type = 0);

--- a/src/universe/party.cpp
+++ b/src/universe/party.cpp
@@ -943,9 +943,12 @@ void cParty::readFrom(const cTagFile& file) {
 			std::copy(roster.begin(), roster.end(), std::inserter(m_seen, m_seen.begin()));
 			
 			imprisoned_monst.fill(0);
-			std::vector<decltype(imprisoned_monst)::value_type> soul_crystal;
-			page["SOULCRYSTAL"].extract(soul_crystal);
-			std::copy_n(soul_crystal.begin(), std::min(soul_crystal.size(), imprisoned_monst.size()), imprisoned_monst.begin());
+			for(size_t n = 0; n < page["SOULCRYSTAL"].size(); n++){
+				size_t slot;
+				mon_num_t monster;
+				auto tmp = page["SOULCRYSTAL"] >> slot >> monster;
+				imprisoned_monst[n] = monster;
+			}
 			
 			alchemy.reset();
 			std::deque<bool> alch; // deque instead of vector to avoid the bitwise specialization


### PR DESCRIPTION
There were a bunch of bugs with Capture Soul/Simulacrum:

* The pick buttons in Simulacrum were not shown/hidden correctly for filled/unfilled slots
* With no captured souls, you would still get a picker dialog
* Monsters exported after leaving a scenario, would cause a crash when you try to summon them
* Loading a save file with captured souls, the slot number of a captured monster would be interpreted as the monster number (so Apprentice Mage (27) in slot 3 would be loaded as Townsperson (3) in slot 0-- the 27 would be dropped and not loaded).

I fixed all of these problems.

I also added a debug action which clears captured souls.