### PR TITLE
Actions fixes

### DIFF
--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -1087,7 +1087,8 @@ void handle_alchemy(bool& need_redraw, bool& need_reprint) {
 	need_redraw = true;
 	if(overall_mode == MODE_TOWN)
 		do_alchemy();
-	else add_string_to_buf("Alchemy: Only in town.");
+	else if(!is_town()) add_string_to_buf("Alchemy: Only in town.");
+	else add_string_to_buf("Alchemy: " + FINISH_FIRST);
 }
 
 static void handle_town_wait(bool& need_redraw, bool& need_reprint) {

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -1141,11 +1141,14 @@ void handle_wait(bool& did_something, bool& need_redraw, bool& need_reprint) {
 
 	if(overall_mode == MODE_TOWN) {
 		handle_town_wait(need_redraw, need_reprint);
-	} else if(overall_mode == MODE_COMBAT) {
+	} else if(!is_town()){
+		add_string_to_buf("Wait: In town only.");
+		print_buf();
+	}else if(overall_mode == MODE_COMBAT) {
 		handle_stand_ready(need_redraw, need_reprint);
 		advance_time(did_something, need_redraw, need_reprint);
-	} else if(overall_mode == MODE_OUTDOORS) {
-		add_string_to_buf("Wait: In town only.");
+	} else {
+		add_string_to_buf("Wait: " + FINISH_FIRST);
 		print_buf();
 	}
 }

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -881,7 +881,7 @@ void handle_switch_pc(short which_pc, bool& need_redraw, bool& need_reprint) {
 
 	cPlayer& pc = univ.party[which_pc];
 	if(!prime_time() && overall_mode != MODE_SHOPPING && overall_mode != MODE_TALKING && overall_mode != MODE_ITEM_TARGET)
-		add_string_to_buf("Set active: Finish what you're doing first.");
+		add_string_to_buf("Set active: " + FINISH_FIRST);
 	else if(is_combat()) {
 		if(univ.debug_mode && pc.ap <= 0){
 			pc.ap = 4;
@@ -912,7 +912,7 @@ void handle_switch_pc_items(short which_pc, bool& need_redraw) {
 
 	cPlayer& pc = univ.party[which_pc];
 	if(!prime_time() && overall_mode != MODE_TALKING && overall_mode != MODE_SHOPPING)
-		add_string_to_buf("Set active: Finish what you're doing first.");
+		add_string_to_buf("Set active: " + FINISH_FIRST);
 	else {
 		if(!is_combat()) {
 			if(pc.main_status != eMainStatus::ALIVE && (overall_mode != MODE_SHOPPING || active_shop.getType() != eShopType::ALLOW_DEAD))
@@ -950,7 +950,7 @@ void handle_equip_item(short item_hit, bool& need_redraw) {
 	} else if(stat_screen_mode > MODE_SHOP) {
 		// TODO: For some reason, the game didn't do anything at all in this case.
 		// I'm not sure why; maybe it intended to forward to the sell button?
-	} else add_string_to_buf("Equip: Finish what you're doing first.");
+	} else add_string_to_buf("Equip: " + FINISH_FIRST);
 }
 
 void handle_use_item(short item_hit, bool& did_something, bool& need_redraw) {
@@ -959,7 +959,7 @@ void handle_use_item(short item_hit, bool& did_something, bool& need_redraw) {
 	}
 
 	if(!prime_time()) {
-		add_string_to_buf("Use item: Finish what you're doing first.");
+		add_string_to_buf("Use item: " + FINISH_FIRST);
 		return;
 	}
 	use_item(stat_window, item_hit);
@@ -975,7 +975,7 @@ void handle_give_item(short item_hit, bool& did_something, bool& need_redraw) {
 	}
 
 	if(!prime_time()) {
-		add_string_to_buf("Give item: Finish what you're doing first.");
+		add_string_to_buf("Give item: " + FINISH_FIRST);
 		return;
 	}
 	give_thing(stat_window, item_hit);
@@ -993,7 +993,7 @@ void handle_drop_item(short item_hit, bool& need_redraw) {
 		add_string_to_buf("Drop item: Cancelled");
 		overall_mode = is_town() ? MODE_TOWN : MODE_COMBAT;
 	} else if(!prime_time())
-		add_string_to_buf("Drop item: Finish what you're doing first.");
+		add_string_to_buf("Drop item: " + FINISH_FIRST);
 	else if(is_out())
 		drop_item(stat_window,item_hit,univ.party.out_loc);
 	else {
@@ -1349,7 +1349,7 @@ void handle_trade_places(int which_pc, bool& need_reprint) {
 		record_action("handle_trade_places", boost::lexical_cast<std::string>(which_pc));
 	}
 	if(!prime_time())
-		add_string_to_buf("Trade places: Finish what you're doing first.");
+		add_string_to_buf("Trade places: " + FINISH_FIRST);
 	else if(is_combat())
 		add_string_to_buf("Trade places: Can't do this in combat.");
 	else {
@@ -1868,7 +1868,7 @@ void handle_menu_spell(eSpell spell_picked) {
 
 	eSkill spell_type = (*spell_picked).type;
 	if(!prime_time()) {
-		ASB("Finish what you're doing first.");
+		ASB("Cast: " + FINISH_FIRST);
 		print_buf();
 		return;
 	}
@@ -3287,7 +3287,7 @@ void handle_drop_pc() {
 		record_action("handle_drop_pc", "");
 	}
 	if(!prime_time()) {
-		ASB("Finish what you're doing first.");
+		ASB("Delete PC: " + FINISH_FIRST);
 		print_buf();
 	}else if(is_combat()){
 		add_string_to_buf("Delete PC: Not in combat.");

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -1423,6 +1423,7 @@ void menu_give_help(short help1){
 void handle_menu_choice(eMenu item_hit) {
 	std::string dialogToShow;
 	sf::Event dummyEvent = {sf::Event::KeyPressed};
+	bool did_something = false, need_redraw = false, need_reprint = false;
 	
 	switch(item_hit) {
 		case eMenu::NONE: break;
@@ -1518,10 +1519,7 @@ void handle_menu_choice(eMenu item_hit) {
 			showWelcome();
 			break;
 		case eMenu::ACTIONS_ALCHEMY:
-			// This will be recorded when the fake event is processed
-			dummyEvent.key.code = sf::Keyboard::A;
-			dummyEvent.key.shift = true;
-			queue_fake_event(dummyEvent);
+			handle_alchemy(need_redraw, need_reprint);
 			break;
 		case eMenu::ACTIONS_WAIT:
 			// This will be recorded when the fake event is processed
@@ -1544,6 +1542,9 @@ void handle_menu_choice(eMenu item_hit) {
 	}
 	if(!dialogToShow.empty()) {
 		show_dialog_action(dialogToShow);
+	}
+	if(did_something || need_redraw || need_reprint){
+		advance_time(did_something, need_redraw, need_reprint);
 	}
 }
 

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -1422,7 +1422,6 @@ void menu_give_help(short help1){
 
 void handle_menu_choice(eMenu item_hit) {
 	std::string dialogToShow;
-	sf::Event dummyEvent = {sf::Event::KeyPressed};
 	bool did_something = false, need_redraw = false, need_reprint = false;
 	
 	switch(item_hit) {
@@ -1522,9 +1521,7 @@ void handle_menu_choice(eMenu item_hit) {
 			handle_alchemy(need_redraw, need_reprint);
 			break;
 		case eMenu::ACTIONS_WAIT:
-			// This will be recorded when the fake event is processed
-			dummyEvent.key.code = sf::Keyboard::W;
-			queue_fake_event(dummyEvent);
+			handle_wait(did_something, need_redraw, need_reprint);
 			break;
 		case eMenu::ACTIONS_AUTOMAP:
 			display_map();

--- a/src/game/boe.town.cpp
+++ b/src/game/boe.town.cpp
@@ -1545,7 +1545,7 @@ void display_map() {
 	}
 
 	if(!prime_time()) {
-		ASB("Finish what you're doing first.");
+		ASB("Map: " + FINISH_FIRST);
 		print_buf();
 		return;
 	}

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -53,4 +53,6 @@ inline void LOG(std::string line) {
 
 #define LOG_VALUE(x) std::cout << #x << ": " << (x) << std::endl;
 
+const std::string FINISH_FIRST = "Finish what you're doing first.";
+
 #endif


### PR DESCRIPTION
- "Finish what you're doing first" comes up a lot in the text buffer. I wanted to add such a message to a new case but couldn't remember how to match the ones that are already in there. Solution: Make it a constant. Also, standardize existing messages so they all prefix with the attempted action.
- The menubar "Do Alchemy" button passing an 'A' key could have unexpected behavior, i.e. in talk mode, clicking "Ask About". Fixed this
- Don't know if the menubar "Wait" button could cause a bug by passing 'w', but fixed the kludge regardless. Also, some code paths of "Wait" would no-op silently. Fixed that.