### PR TITLE
Debug actions work

### DIFF
--- a/rsrc/dialogs/help-debug.xml
+++ b/rsrc/dialogs/help-debug.xml
@@ -39,5 +39,10 @@
 	<button name='btn28' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
 	<button name='btn29' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
 	<button name='btn30' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
-	<button name='okay' type='regular' top='400' left='387'>OK</button>
+	<button name='btn31' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn32' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn33' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn34' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='btn35' type='tiny' relative='pos-in pos' rel-anchor='prev' left='0' top='1'></button>
+	<button name='okay' relative='pos-in neg' rel-anchor='prev' type='regular' top='5' left='337'>OK</button>
 </dialog>

--- a/src/dialogxml/dialogs/dialog.cpp
+++ b/src/dialogxml/dialogs/dialog.cpp
@@ -50,6 +50,7 @@ std::mt19937 cDialog::ui_rand;
 extern std::map<std::string,sf::Color> colour_map;
 
 extern bool check_for_interrupt(std::string);
+extern void showError(std::string str1, cDialog* parent = nullptr);
 
 std::string cDialog::generateRandomString(){
 	// Not bothering to seed, because it doesn't actually matter if it's truly random.
@@ -1170,16 +1171,23 @@ void cDialogIterator::increment() {
 }
 
 void preview_dialog_xml(fs::path dialog_xml) {
-	std::unique_ptr<DialogDefn> defn(load_dialog_defn(dialog_xml));
-	cDialog dialog(*defn);
-	// Make every clickable control's click event close the dialog
-	for (auto control : dialog){
-		try{
-			control.second->attachClickHandler([](cDialog& me, std::string item_hit, eKeyMod mod) -> bool {
-				me.toast(false);
-				return true;
-			});
-		}catch(...){}
+	try{
+		std::unique_ptr<DialogDefn> defn(load_dialog_defn(dialog_xml));
+		cDialog dialog(*defn);
+
+		// Make every clickable control's click event close the dialog
+		for (auto control : dialog){
+			try{
+				control.second->attachClickHandler([](cDialog& me, std::string item_hit, eKeyMod mod) -> bool {
+					me.toast(false);
+					return true;
+				});
+			}catch(...){}
+		}
+		dialog.run();
+	}catch(std::exception& x) {
+		showError(x.what());
+	}catch(std::string& x){
+		showError(x);
 	}
-	dialog.run();
 }

--- a/src/dialogxml/keycodes.cpp
+++ b/src/dialogxml/keycodes.cpp
@@ -65,7 +65,7 @@ cKey charToKey(char ch) {
 		case '?':
 			return {false, w('/'), mod_shift};
 	}
-	throw "Tried to convert unsupported char to cKey!";
+	throw std::string {"Tried to convert unsupported char '"} + ch + "' to cKey!";
 }
 
 eKeyMod operator + (eKeyMod lhs, eKeyMod rhs){

--- a/src/dialogxml/keycodes.cpp
+++ b/src/dialogxml/keycodes.cpp
@@ -64,6 +64,8 @@ cKey charToKey(char ch) {
 			return {false, w('6'), mod_shift};
 		case '?':
 			return {false, w('/'), mod_shift};
+		case '~':
+			return {false, w('`'), mod_shift};
 	}
 	throw std::string {"Tried to convert unsupported char '"} + ch + "' to cKey!";
 }

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2445,7 +2445,8 @@ void debug_launch_scen(std::string scen_name) {
 	}
 	// Take party out of scenario they're in
 	if(univ.party.is_in_scenario()){
-		// TODO: Confirm
+		if(cChoiceDlog("leave-scenario",{"okay","cancel"}).show() != "okay")
+			return;
 		handle_victory(true);
 	}
 	// Force party into the scenario, skipping the intro:

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2148,20 +2148,30 @@ void debug_magic_map() {
 	print_buf();
 }
 
+extern void outd_move_to_first_town_entrance(int town);
+
 void debug_enter_town() {
 	if(recording){
 		record_action("debug_enter_town", "");
 	}
+
+	std::vector<std::string> town_names;
+	for(cTown* town : univ.scenario.towns){
+		town_names.push_back(town->name);
+	}
+	int town = get_num_response(0, univ.scenario.towns.size() - 1, "Enter Town Number", town_names);
+
+	if(has_feature_flag("debug-enter-town", "move-outdoors")){
+		end_town_mode(false, {0,0}, true);
+		outd_move_to_first_town_entrance(town);
+	}
+
 	short find_direction_from;
 	if(univ.party.direction == 0) find_direction_from = 2;
 	else if(univ.party.direction == 4) find_direction_from = 0;
 	else if(univ.party.direction < 4) find_direction_from = 3;
 	else find_direction_from = 1;
-	std::vector<std::string> town_names;
-	for(cTown* town : univ.scenario.towns){
-		town_names.push_back(town->name);
-	}
-	start_town_mode(get_num_response(0, univ.scenario.towns.size() - 1, "Enter Town Number", town_names), find_direction_from);
+	start_town_mode(town, find_direction_from);
 }
 
 void debug_refresh_stores() {

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2473,11 +2473,11 @@ void init_debug_actions() {
 	add_debug_action({'J'}, "Preview a dialog's layout", preview_dialog_xml, true);
 	add_debug_action({'U'}, "Preview EVERY dialog's layout", preview_every_dialog_xml, true);
 	add_debug_action({'K'}, "Kill everything", debug_kill);
-	add_debug_action({'N'}, "End scenario", []() -> void {handle_victory(true, true);});
+	add_debug_action({'N'}, "End scenario", []() {handle_victory(true, true);});
 	add_debug_action({'O'}, "Print your location", debug_print_location);
 	add_debug_action({'Q'}, "Magic map", debug_magic_map);
 	add_debug_action({'R'}, "Return to start", debug_return_to_start);
-	add_debug_action({'S'}, "Set stuff done flags", []() -> void {
+	add_debug_action({'S'}, "Set stuff done flags", []() {
 		// edit_stuff_done() is used in the character editor which
 		// doesn't have replays, so its replay action is recorded
 		// external to the function definition unlike most actions.
@@ -2496,13 +2496,13 @@ void init_debug_actions() {
 	add_debug_action({'!'}, "Toggle Special Node Step-through Mode", debug_step_through);
 
 	// Enter core scenarios, skipping intro:
-	add_debug_action({'@'}, "Quick-launch The Valley of Dying Things", []() -> void {debug_launch_scen("valleydy.boes");}, true);
-	add_debug_action({'#'}, "Quick-launch A Small Rebellion", []() -> void {debug_launch_scen("stealth.boes");}, true);
-	add_debug_action({'$'}, "Quick-launch The Za-Khazi Run", []() -> void {debug_launch_scen("zakhazi.boes");}, true);
+	add_debug_action({'@'}, "Quick-launch The Valley of Dying Things", []() {debug_launch_scen("valleydy.boes");}, true);
+	add_debug_action({'#'}, "Quick-launch A Small Rebellion", []() {debug_launch_scen("stealth.boes");}, true);
+	add_debug_action({'$'}, "Quick-launch The Za-Khazi Run", []() {debug_launch_scen("zakhazi.boes");}, true);
 
 	// std::bind won't work here for reasons
-	add_debug_action({'%'}, "Fight wandering encounter from this section", []() -> void {debug_fight_encounter(true);});
-	add_debug_action({'^'}, "Fight special encounter from this section", []() -> void {debug_fight_encounter(false);});
+	add_debug_action({'%'}, "Fight wandering encounter from this section", []() {debug_fight_encounter(true);});
+	add_debug_action({'^'}, "Fight special encounter from this section", []() {debug_fight_encounter(false);});
 	add_debug_action({'/', '?'}, "Bring up this window", show_debug_help, true);
 	add_debug_action({'Z'}, "Save the current action log for bug reporting", save_replay_log, true);
 }
@@ -4047,7 +4047,7 @@ void preview_every_dialog_xml() {
 	dlog->getControl("msg").setText(text);
 	std::string confirm = dlog.show();
 	if(confirm == "yes"){
-		std::for_each(dialog_paths.begin(), dialog_paths.end(), [](fs::path path) -> void {
+		std::for_each(dialog_paths.begin(), dialog_paths.end(), [](fs::path path) {
 			ASB("Previewing dialog: " + path.stem().string());
 			print_buf();
 			preview_dialog_xml(path);

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2434,8 +2434,26 @@ void show_debug_help() {
 	debug_panel.run();
 }
 
+void debug_launch_scen(std::string scen_name) {
+	if(recording){
+		record_action("debug_launch_scen", scen_name);
+	}
+	// Start by using the default party
+	if(!party_in_memory){
+		// TODO: Could add a debug party preference like the scenario editor has
+		start_new_game(true);
+	}
+	// Take party out of scenario they're in
+	if(univ.party.is_in_scenario()){
+		// TODO: Confirm
+		handle_victory(true);
+	}
+	// Force party into the scenario, skipping the intro:
+	put_party_in_scen(scen_name, true);
+}
+
 // Non-comprehensive list of unused keys:
-// chjklnoqvy @#$-_+[]{},.'"`\|;:
+// chjklnoqvy -_+[]{},.'"`\|;:
 // We want to keep lower-case for normal gameplay.
 void init_debug_actions() {
 	// optional `true` argument means you can use this action in the startup menu.
@@ -2475,6 +2493,12 @@ void init_debug_actions() {
 	add_debug_action({'<'}, "Make one day pass", debug_increase_age);
 	add_debug_action({'>'}, "Reset towns (excludes the one you're in, if any)", debug_towns_forget);
 	add_debug_action({'!'}, "Toggle Special Node Step-through Mode", debug_step_through);
+
+	// Enter core scenarios, skipping intro:
+	add_debug_action({'@'}, "Quick-launch The Valley of Dying Things", []() -> void {debug_launch_scen("valleydy.boes");}, true);
+	add_debug_action({'#'}, "Quick-launch A Small Rebellion", []() -> void {debug_launch_scen("stealth.boes");}, true);
+	add_debug_action({'$'}, "Quick-launch The Za-Khazi Run", []() -> void {debug_launch_scen("zakhazi.boes");}, true);
+
 	// std::bind won't work here for reasons
 	add_debug_action({'%'}, "Fight wandering encounter from this section", []() -> void {debug_fight_encounter(true);});
 	add_debug_action({'^'}, "Fight special encounter from this section", []() -> void {debug_fight_encounter(false);});

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -3976,7 +3976,7 @@ void handle_rename_pc() {
 
 void preview_dialog_xml() {
 	fs::path dialog_xml = nav_get_rsrc({"xml"});
-	preview_dialog_xml(dialog_xml);
+	if(!dialog_xml.empty()) preview_dialog_xml(dialog_xml);
 }
 
 void preview_every_dialog_xml() {

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2417,9 +2417,11 @@ void show_debug_help() {
 			});
 		}
 	}
-	for(; idx < 30; ++idx){
+	for(; ; ++idx){
 		std::ostringstream btn_name;
 		btn_name << "btn" << (idx+1);
+		if(!debug_panel.hasControl(btn_name.str()))
+			break;
 		cControl& button = debug_panel[btn_name.str()];
 		button.hide();
 	}

--- a/src/game/boe.actions.hpp
+++ b/src/game/boe.actions.hpp
@@ -105,6 +105,7 @@ void debug_increase_age();
 void debug_towns_forget();
 void debug_heal_plus_extra();
 void debug_heal();
+void debug_launch_scen(std::string scen_name);
 void handle_print_pc_hp(int which_pc, bool& need_reprint);
 void handle_print_pc_sp(int which_pc, bool& need_reprint);
 void handle_trade_places(int which_pc, bool& need_reprint);

--- a/src/game/boe.graphics.cpp
+++ b/src/game/boe.graphics.cpp
@@ -404,9 +404,16 @@ void draw_startup_stats() {
 	pc_rect.offset(5,5);
 	pc_rect.top = pc_rect.bottom - 30;
 	pc_rect.left = pc_rect.right - string_length(copyright, style) - 32;
-	// TODO: Should replace this with a more appropriate copyright string
 	// Windows replaced it with "That is not dead which can eternally lie..." - I don't think that's quite appropriate though.
 	win_draw_string(mainPtr, pc_rect, copyright, eTextMode::WRAP, style);
+
+	if(univ.debug_mode){
+		pc_rect = startup_top;
+		pc_rect.offset(5,5);
+		pc_rect.top = pc_rect.bottom - 30;
+		pc_rect.left = pc_rect.left + 32;
+		win_draw_string(mainPtr, pc_rect, "Debug Mode: On", eTextMode::WRAP, style);
+	}
 }
 
 

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -96,7 +96,11 @@ std::string help_text_rsrc = "help";
 	{"graphics-sheet", {"V2", "V3"}}
 }
 */
-std::map<std::string,std::vector<std::string>> feature_flags = {};
+std::map<std::string,std::vector<std::string>> feature_flags = {
+	// Legacy behavior of the T debug action (used by some replays)
+	// does not change the party's outdoors location
+	{"debug-enter-town", {"move-outdoors"}}
+};
 
 struct cParseEntrance {
 	boost::optional<short>& opt;
@@ -406,6 +410,33 @@ static void process_args(int argc, char* argv[]) {
 	}
 }
 
+void outd_move_to_first_town_entrance(int town) {
+	// Try to put the party in an outdoor section from which you can enter the town --
+	// so when you leave, you'll hopefully be in the right place.
+	auto town_entrances = univ.scenario.find_town_entrances(town);
+	if(!town_entrances.empty()){
+		// When there are multiple entrances, this part of the code shouldn't matter,
+		// but also won't hurt.
+		town_entrance_t first_entrance_found = town_entrances[0];
+		int x = first_entrance_found.out_sec.x;
+		int y = first_entrance_found.out_sec.y;
+		// Very janky but I don't know how else to make it properly load the right sections and set i_w_c
+		while(univ.party.outdoor_corner.x > x){
+			shift_universe_left();
+		}
+		while(univ.party.outdoor_corner.x < x){
+			shift_universe_right();
+		}
+		while(univ.party.outdoor_corner.y > y){
+			shift_universe_up();
+		}
+		while(univ.party.outdoor_corner.y < y){
+			shift_universe_down();
+		}
+		outd_move_party(local_to_global(first_entrance_found.loc), true);
+	}
+}
+
 static void handle_scenario_args() {
 	bool resetting = false;
 	if(scen_arg_path){
@@ -455,30 +486,8 @@ static void handle_scenario_args() {
 			std::cerr << "Expected a scenario with at least " << (*scen_arg_town + 1) << " towns" << std::endl;
 			exit(1);
 		}
-		// Try to put the party in an outdoor section from which you can enter the town --
-		// so when you leave, you'll hopefully be in the right place.
-		auto town_entrances = univ.scenario.find_town_entrances(*scen_arg_town);
-		if(!town_entrances.empty()){
-			// When there are multiple entrances, this part of the code shouldn't matter,
-			// but also won't hurt.
-			town_entrance_t first_entrance_found = town_entrances[0];
-			int x = first_entrance_found.out_sec.x;
-			int y = first_entrance_found.out_sec.y;
-			// Very janky but I don't know how else to make it properly load the right sections and set i_w_c
-			while(univ.party.outdoor_corner.x > x){
-				shift_universe_left();
-			}
-			while(univ.party.outdoor_corner.x < x){
-				shift_universe_right();
-			}
-			while(univ.party.outdoor_corner.y > y){
-				shift_universe_up();
-			}
-			while(univ.party.outdoor_corner.y < y){
-				shift_universe_down();
-			}
-			outd_move_party(local_to_global(first_entrance_found.loc), true);
-		}
+
+		outd_move_to_first_town_entrance(*scen_arg_town);
 
 		short town_entrance = 0;
 		location town_location;

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -790,6 +790,9 @@ static void replay_action(Element& action) {
 	}else if(t == "toggle_debug_mode"){
 		toggle_debug_mode();
 		return;
+	}else if(t == "debug_launch_scen"){
+		debug_launch_scen(action.GetText());
+		return;
 	}else if(t == "debug_give_item"){
 		debug_give_item();
 		return;


### PR DESCRIPTION
* Previewing dialogxmls, don't crash the game if the XML has an error in it (just show the message)
* Allow canceling the file picker for previewing dialogxmls
* Allow toggling debug mode in the startup menu. In the startup menu, you can only use actions that make sense.
* Debug enter town: new behavior - move the party's outdoors location to a town entrance if possible (Fix #664)
* Fix debug help menu crashing when trying to make '~' into a cKey
* Make the debug help window more readily expandible, and add more buttons.
    * Note: I still don't want to make it a stupidly tall dialog like the ones we've had to split up to fit on screens when scaled. It shouldn't get much bigger -- maybe it should paginate if it has to. Although, if it bleeds off the screen, at least it won't break players' default experience, because it's a debug feature
* New debug actions (useful from the startup menu): Shift-2, Shift-3, Shift-4 (@, #, $) launch into the core scenarios, skipping the intro dialog.
    * if the party is in a scenario already, confirm before switching