### PR TITLE
Don't display 'no item' response if another PC can shop.

### DIFF
--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -897,6 +897,14 @@ void handle_switch_pc(short which_pc, bool& need_redraw, bool& need_reprint) {
 		add_string_to_buf("Set active: PC must be here & active.");
 	else {
 		univ.cur_pc = which_pc;
+
+		// The shop interface may have taken control of the active PC. If the player
+		// manually sets active PC before shopping ends, don't restore the active PC from before
+		// shopping switched it. Unless the player buys something again, forcing it to store again.
+		extern short store_cur_pc;
+		if(store_cur_pc != -1)
+			store_cur_pc = -1;
+
 		set_stat_window_for_pc(which_pc);
 		add_string_to_buf("Now " + std::string(overall_mode == MODE_SHOPPING ? "shopping" : "active") + ": " + pc.name);
 		adjust_spell_menus();

--- a/src/game/boe.dlgutil.hpp
+++ b/src/game/boe.dlgutil.hpp
@@ -5,7 +5,7 @@
 #include "dialogxml/dialogs/dialog.hpp"
 #include "scenario/shop.hpp"
 
-bool start_shop_mode(short which,short cost_adj,std::string store_name, bool cancel_when_empty = false);
+bool start_shop_mode(short which,short cost_adj,std::string store_name, bool cancel_when_empty = false, bool already_started = false);
 void end_shop_mode();
 bool handle_shop_event(location p, cFramerateLimiter& fps_limiter);
 void handle_sale(int i);


### PR DESCRIPTION
In comments on #669 I outlined a way to intuitively handle shopping from a healer if the active PC is fully healed. This PR implements my suggestion. I think it feels pretty good and makes shopping better even outside the case that was buggy before: it's just nice to have the shop cycle between injured PCs if you're trying to buy healing for everyone.

These are the rules:

- If the active PC gets an empty shop, iterate from the first to last PC until finding someone who can see a shop item
    - If none can shop, show the 'no item' response
- When the active PC buys something, if this clears out the shop, iterate from the first to last PC until finding someone who can see a shop item
    - if none can see an item, stay on the empty shop of the PC that was active when the last item was bought.
- When shopping ends, if the shop interface was the last thing to change the player's active PC, it puts it back how it was.

Fix #669 