### PR TITLE
On catching fatal error, prompt to save the log and report

### DIFF
--- a/rsrc/dialogs/ask-save-replay.xml
+++ b/rsrc/dialogs/ask-save-replay.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
+<dialog defbtn='no'>
+	<pict type='dlog' num='7' top='6' left='6'/>
+	<text top='6' left='48' width='249'>
+		Want to help improve OpenBoE? 
+		You can save and send a log of your session to help the developers solve this error.
+		Click below to start your bug report (making a GitHub account if you don't have one),
+		then save and upload your error log in a zip file.
+	</text>
+	<text colour='link' relative='pos-in pos' rel-anchor='prev' top='4' left='0' width='249'>
+		https://github.com/calref/cboe/issues/new/
+	</text>
+	<text relative='pos-in pos' rel-anchor='prev' top='4' left='0' width='249'>
+		Save a replay log?
+	</text>
+	<button name='no' relative='abs pos' rel-anchor='prev' type='regular' def-key='n' top='4' left='239'>No</button>
+	<button name='yes' relative='abs pos-in' rel-anchor='prev' type='regular' def-key='y' top='0' left='172'>Yes</button>
+</dialog>

--- a/rsrc/dialogs/debug-crash-confirm.xml
+++ b/rsrc/dialogs/debug-crash-confirm.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<?xml-stylesheet href="dialog.xsl" type="text/xsl"?>
+<dialog defbtn='no'>
+	<pict type='dlog' num='7' top='6' left='6'/>
+	<text top='6' left='48' width='249' height='67'>
+		You are about to crash the game on purpose.<br/>
+		<br/>
+		Are you sure you want to do this?
+	</text>
+	<button name='no' type='regular' def-key='n' top='84' left='239'>No</button>
+	<button name='yes' type='regular' def-key='y' top='84' left='172'>Yes</button>
+</dialog>

--- a/src/dialogxml/keycodes.cpp
+++ b/src/dialogxml/keycodes.cpp
@@ -66,6 +66,8 @@ cKey charToKey(char ch) {
 			return {false, w('/'), mod_shift};
 		case '~':
 			return {false, w('`'), mod_shift};
+		case '\\':
+			return {false, w('\\'), mod_none};
 	}
 	throw std::string {"Tried to convert unsupported char '"} + ch + "' to cKey!";
 }

--- a/src/game/boe.actions.cpp
+++ b/src/game/boe.actions.cpp
@@ -2458,7 +2458,7 @@ void debug_launch_scen(std::string scen_name) {
 }
 
 // Non-comprehensive list of unused keys:
-// chjklnoqvy -_+[]{},.'"`\|;:
+// chjklnoqvy -_+[]{},.'"`|;:
 // We want to keep lower-case for normal gameplay.
 void init_debug_actions() {
 	// optional `true` argument means you can use this action in the startup menu.
@@ -2509,6 +2509,7 @@ void init_debug_actions() {
 	add_debug_action({'^'}, "Fight special encounter from this section", []() {debug_fight_encounter(false);});
 	add_debug_action({'/', '?'}, "Bring up this window", show_debug_help, true);
 	add_debug_action({'Z'}, "Save the current action log for bug reporting", save_replay_log, true);
+	add_debug_action({'\\'}, "Crash the game", debug_crash, true);
 }
 
 // Later we might want to know whether the key is used or not
@@ -4066,6 +4067,18 @@ void save_replay_log(){
 	fs::path out_file = nav_put_rsrc({"xml"});
 
 	start_log_file(out_file.string());
+}
+
+void debug_crash() {
+	// If they don't confirm, the game can continue normally, and we'll need to replay
+	// that the confirmation opened and closed.
+	if(recording){
+		record_action("debug_crash", "");
+	}
+	std::string confirm = cChoiceDlog("debug-crash-confirm",{"yes","no"}).show();
+	if(confirm == "yes"){
+		throw std::string { "Be careful what you wish for!" };
+	}
 }
 
 void clear_trapped_monst() {

--- a/src/game/boe.actions.hpp
+++ b/src/game/boe.actions.hpp
@@ -120,6 +120,7 @@ void easter_egg(int idx);
 void preview_dialog_xml();
 void preview_every_dialog_xml();
 void save_replay_log();
+void debug_crash();
 void clear_trapped_monst();
 
 #endif

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -201,6 +201,17 @@ eMenuChoice menuChoice=eMenuChoice::MENU_CHOICE_NONE;
 short menuChoiceId=-1;
 #endif
 
+static void handleFatalError(std::string what) {
+	showFatalError(what);
+	if(recording){
+		record_action("error", what);
+		extern fs::path log_file;
+		if(log_file.empty() && cChoiceDlog("ask-save-replay", {"yes", "no"}).show() == "yes") {
+			save_replay_log();
+		}
+	}
+}
+
 int main(int argc, char* argv[]) {
 #if 0
 	void debug_oldstructs();
@@ -233,13 +244,13 @@ int main(int argc, char* argv[]) {
 		close_program();
 		return 0;
 	} catch(std::exception& x) {
-		showFatalError(x.what());
+		handleFatalError(x.what());
 		throw;
 	} catch(std::string& x) {
-		showFatalError(x);
+		handleFatalError(x);
 		throw;
 	} catch(...) {
-		showFatalError("An unknown error occurred!");
+		handleFatalError("An unknown error occurred!");
 		throw;
 	}
 }
@@ -942,6 +953,8 @@ static void replay_action(Element& action) {
 		preview_every_dialog_xml();
 	}else if(t == "clear_trapped_monst"){
 		clear_trapped_monst();
+	}else if(t == "error"){
+		// The error is recorded for debugging only. It should be triggered by replaying the actions.
 	}else if(t == "advance_time"){
 		// This is bad regardless of strictness, because visual changes may have occurred which won't get redrawn/reprinted
 		throw std::string { "Replay system internal error! advance_time() was supposed to be called by the last action, but wasn't: " } + _last_action_type;

--- a/src/game/boe.main.cpp
+++ b/src/game/boe.main.cpp
@@ -955,6 +955,8 @@ static void replay_action(Element& action) {
 		clear_trapped_monst();
 	}else if(t == "error"){
 		// The error is recorded for debugging only. It should be triggered by replaying the actions.
+	}else if(t == "debug_crash"){
+		debug_crash();
 	}else if(t == "advance_time"){
 		// This is bad regardless of strictness, because visual changes may have occurred which won't get redrawn/reprinted
 		throw std::string { "Replay system internal error! advance_time() was supposed to be called by the last action, but wasn't: " } + _last_action_type;


### PR DESCRIPTION
This one probably needs some discussion and refinement.

The main idea is, if a player finds a crash in the game, I want to capture as much info about it as possible. So this prompts the player to save the replay log and links them to this issue tracker.

Drawback: GitHub doesn't support drag-and-drop for XML files. So players have to zip the XML file themselves. (I think we have a dependency that could do the zipping? But I don't know how to write that code.)

Drawback: GitHub requires an account before adding an issue. It might be more ideal to find an external bug tracker, or host our own portal for it, to remove friction for less technically inclined players.

If any of this sounds undesirable in the core repo, I can also have it be exclusive to Itch edition and point to my fork's issue tracker.