### PR TITLE
Set scale-aware text size before initializing the sf::Text object

### DIFF
--- a/src/game/boe.text.cpp
+++ b/src/game/boe.text.cpp
@@ -23,6 +23,7 @@ const int TEXT_BUF_LEN = 70;
 #include "fileio/resmgr/res_font.hpp"
 #include "spell.hpp"
 #include "tools/enum_map.hpp"
+#include "tools/winutil.hpp"
 #include "replay.hpp"
 #include <boost/lexical_cast.hpp>
 
@@ -1091,7 +1092,7 @@ void print_buf () {
 	location moveTo;
 	while((line_to_print!= buf_pointer) && (num_lines_printed < LINES_IN_TEXT_WIN)) {
 		moveTo = location(4, 1 + 12 * num_lines_printed);
-		sf::Text text(text_buffer[line_to_print].line, *ResMgr::fonts.get("plain"), 12);
+		sf::Text text(text_buffer[line_to_print].line, *ResMgr::fonts.get("plain"), 12 * get_ui_scale());
 		text.setColor(Colours::BLACK);
 		text.setPosition(moveTo);
 		draw_scale_aware_text(text_area_gworld, text);

--- a/src/gfx/render_text.cpp
+++ b/src/gfx/render_text.cpp
@@ -14,7 +14,7 @@
 #include <utility>
 #include "winutil.hpp"
 
-void TextStyle::applyTo(sf::Text& text) {
+void TextStyle::applyTo(sf::Text& text, double scale) {
 	switch(font) {
 		case FONT_PLAIN:
 			text.setFont(*ResMgr::fonts.get("plain"));
@@ -29,7 +29,7 @@ void TextStyle::applyTo(sf::Text& text) {
 			text.setFont(*ResMgr::fonts.get("maidenword"));
 			break;
 	}
-	text.setCharacterSize(pointSize);
+	text.setCharacterSize(pointSize * scale);
 	int style = sf::Text::Regular;
 	if(italic) style |= sf::Text::Italic;
 	if(underline) style |= sf::Text::Underlined;
@@ -153,8 +153,6 @@ sf::Vector2f scaled_view_top_left(sf::RenderTarget& dest_window, sf::View& scale
 }
 
 void draw_scale_aware_text(sf::RenderTarget& dest_window, sf::Text str_to_draw) {
-	str_to_draw.setCharacterSize(str_to_draw.getCharacterSize() * get_ui_scale());
-
 	if(dynamic_cast<sf::RenderWindow*>(&dest_window) != nullptr){
 		// Temporarily switch window to its unscaled view to draw scale-aware text
 		sf::View scaled_view = dest_window.getView();
@@ -197,6 +195,8 @@ static void win_draw_string(sf::RenderTarget& dest_window,rectangle dest_rect,st
 	
 	str_to_draw.setString(str);
 	short total_width = str_to_draw.getLocalBounds().width;
+
+	options.style.applyTo(str_to_draw, get_ui_scale());
 	
 	eTextMode mode = options.mode;
 	if(mode == eTextMode::WRAP && total_width < dest_rect.width() && !options.right_align)

--- a/src/gfx/render_text.hpp
+++ b/src/gfx/render_text.hpp
@@ -36,7 +36,7 @@ struct TextStyle {
 	int pointSize = 10, lineHeight = 10;
 	sf::Color colour;
 	TextStyle() : colour(sf::Color::Black) {}
-	void applyTo(sf::Text& text);
+	void applyTo(sf::Text& text, double scale = 1.0);
 };
 
 // elements: std::make_tuple(last_line_break, last_word_break, line_width)


### PR DESCRIPTION
Ever since I added scale-aware text, the About Dialog has looked like this (I didn't notice until recently):

<img width="750" alt="Screenshot 2025-03-06 at 8 01 29 PM" src="https://github.com/user-attachments/assets/2d13ad2b-1aca-44d4-a57c-c43d8fddad08" />

Today I figured out that it's because of something weird with sf::Text and sf::Font. When we change the character size of the text right before rendering it, it doesn't properly prepare all the large-size glyphs that it needs, and many characters get a blank glyph. If I set the character size of the text to the scaled size *before* initializing it with all the other things in win_draw_string(), then we get our glyphs.
