### PR TITLE
Make all scenarios match VoDT arrow/bolt values

### DIFF
--- a/rsrc/bases/bladbase/items.xml
+++ b/rsrc/bases/bladbase/items.xml
@@ -1991,7 +1991,7 @@
     </item>
     <item id="103">
         <variety>arrow</variety>
-        <level>11</level>
+        <level>12</level>
         <awkward>0</awkward>
         <bonus>0</bonus>
         <protection>0</protection>
@@ -2011,7 +2011,7 @@
     </item>
     <item id="104">
         <variety>arrow</variety>
-        <level>11</level>
+        <level>12</level>
         <awkward>0</awkward>
         <bonus>2</bonus>
         <protection>0</protection>
@@ -2031,7 +2031,7 @@
     </item>
     <item id="105">
         <variety>arrow</variety>
-        <level>11</level>
+        <level>12</level>
         <awkward>0</awkward>
         <bonus>5</bonus>
         <protection>0</protection>
@@ -2225,7 +2225,7 @@
     </item>
     <item id="115">
         <variety>bolts</variety>
-        <level>14</level>
+        <level>17</level>
         <awkward>0</awkward>
         <bonus>0</bonus>
         <protection>0</protection>
@@ -2245,7 +2245,7 @@
     </item>
     <item id="116">
         <variety>bolts</variety>
-        <level>14</level>
+        <level>17</level>
         <awkward>0</awkward>
         <bonus>2</bonus>
         <protection>0</protection>
@@ -2265,7 +2265,7 @@
     </item>
     <item id="117">
         <variety>bolts</variety>
-        <level>14</level>
+        <level>17</level>
         <awkward>0</awkward>
         <bonus>5</bonus>
         <protection>0</protection>

--- a/rsrc/scenarios/stealth/items.xml
+++ b/rsrc/scenarios/stealth/items.xml
@@ -1991,7 +1991,7 @@
     </item>
     <item id="103">
         <variety>arrow</variety>
-        <level>11</level>
+        <level>12</level>
         <awkward>0</awkward>
         <bonus>0</bonus>
         <protection>0</protection>
@@ -2011,7 +2011,7 @@
     </item>
     <item id="104">
         <variety>arrow</variety>
-        <level>11</level>
+        <level>12</level>
         <awkward>0</awkward>
         <bonus>2</bonus>
         <protection>0</protection>
@@ -2031,7 +2031,7 @@
     </item>
     <item id="105">
         <variety>arrow</variety>
-        <level>11</level>
+        <level>12</level>
         <awkward>0</awkward>
         <bonus>5</bonus>
         <protection>0</protection>
@@ -2225,7 +2225,7 @@
     </item>
     <item id="115">
         <variety>bolts</variety>
-        <level>14</level>
+        <level>17</level>
         <awkward>0</awkward>
         <bonus>0</bonus>
         <protection>0</protection>
@@ -2245,7 +2245,7 @@
     </item>
     <item id="116">
         <variety>bolts</variety>
-        <level>14</level>
+        <level>17</level>
         <awkward>0</awkward>
         <bonus>2</bonus>
         <protection>0</protection>
@@ -2265,7 +2265,7 @@
     </item>
     <item id="117">
         <variety>bolts</variety>
-        <level>14</level>
+        <level>17</level>
         <awkward>0</awkward>
         <bonus>5</bonus>
         <protection>0</protection>

--- a/rsrc/scenarios/zakhazi/items.xml
+++ b/rsrc/scenarios/zakhazi/items.xml
@@ -2005,7 +2005,7 @@
     </item>
     <item id="103">
         <variety>arrow</variety>
-        <level>9</level>
+        <level>12</level>
         <awkward>0</awkward>
         <bonus>0</bonus>
         <protection>0</protection>
@@ -2025,7 +2025,7 @@
     </item>
     <item id="104">
         <variety>arrow</variety>
-        <level>9</level>
+        <level>12</level>
         <awkward>0</awkward>
         <bonus>2</bonus>
         <protection>0</protection>
@@ -2045,7 +2045,7 @@
     </item>
     <item id="105">
         <variety>arrow</variety>
-        <level>9</level>
+        <level>12</level>
         <awkward>0</awkward>
         <bonus>5</bonus>
         <protection>0</protection>
@@ -2239,7 +2239,7 @@
     </item>
     <item id="115">
         <variety>bolts</variety>
-        <level>14</level>
+        <level>17</level>
         <awkward>0</awkward>
         <bonus>0</bonus>
         <protection>0</protection>
@@ -2259,7 +2259,7 @@
     </item>
     <item id="116">
         <variety>bolts</variety>
-        <level>14</level>
+        <level>17</level>
         <awkward>0</awkward>
         <bonus>2</bonus>
         <protection>0</protection>
@@ -2279,7 +2279,7 @@
     </item>
     <item id="117">
         <variety>bolts</variety>
-        <level>14</level>
+        <level>17</level>
         <awkward>0</awkward>
         <bonus>5</bonus>
         <protection>0</protection>


### PR DESCRIPTION
Fix #264

After going back and forth in my head a bunch, I made this PR which does what the issue's OP requested: make VoDT arrow and bolt values authoritative.