### PR TITLE
SDF Finder WIP

### DIFF
--- a/src/scenario/scenario.cpp
+++ b/src/scenario/scenario.cpp
@@ -610,3 +610,33 @@ std::string cScenario::get_sdf_name(int row, int col) {
 		return "";
 	return sdf_names[row][col];
 }
+
+void cScenario::for_each_special(std::function<void(const cSpecial&)> callback) {
+	for_each_scen_special(callback);
+	for(int town = 0; town < towns.size(); ++town){
+		for_each_town_special(town, callback);
+	}
+	for(int x = 0; x < outdoors.width(); ++x){
+		for(int y = 0; y < outdoors.height(); ++y){
+			for_each_out_special(x, y, callback);
+		}
+	}
+}
+
+void cScenario::for_each_scen_special(std::function<void(const cSpecial&)> callback) {
+	for(cSpecial special : scen_specials){
+		callback(special);
+	}
+}
+
+void cScenario::for_each_town_special(int town, std::function<void(const cSpecial&)> callback) {
+	for(cSpecial special : towns[town]->specials){
+		callback(special);
+	}
+}
+
+void cScenario::for_each_out_special(int sector_x, int sector_y, std::function<void(const cSpecial&)> callback) {
+	for(cSpecial special : outdoors[sector_x][sector_y]->specials){
+		callback(special);
+	}
+}

--- a/src/scenario/scenario.hpp
+++ b/src/scenario/scenario.hpp
@@ -58,6 +58,12 @@ public:
 		cItemStorage& operator = (legacy::item_storage_shortcut_type& old);
 	};
 	void destroy_terrain();
+	// Iterate through EVERY special node with a callback.
+	void for_each_special(std::function<void(const cSpecial&)> callback);
+	// Factored into 3 separate functions in case there's ever a reason to be more selective:
+	void for_each_scen_special(std::function<void(const cSpecial&)> callback);
+	void for_each_town_special(int town, std::function<void(const cSpecial&)> callback);
+	void for_each_out_special(int sector_x, int sector_y, std::function<void(const cSpecial&)> callback);
 public:
 	unsigned short difficulty,intro_pic,default_ground;
 	int bg_out, bg_fight, bg_town, bg_dungeon;


### PR DESCRIPTION
Contexts SDFs can be used, which need to be searched:
- [ ] the explicit sdf fields of special nodes
- [ ] other sdf fields (see https://github.com/NQNStudios/cboe/blob/94d9ee268ffe199a781a22f8ca69d3d529b2196b/src/scenario/special.cpp#L777 for something that needs to be done before these can be searched)
- [ ] dialog nodes
- [ ] SDF flag creature's life is linked to (in creature advanced details)
- [ ] SDF flag to eliminate outdoor wandering/special encounters

...AND MORE THAT I'M NOT AWARE OF/DIDN'T THINK OF YET?

The first step I've taken towards SDF finder implementation is to make functions that will be useful for checking all of a scenario's special nodes for SDFs they reference.