### PR TITLE
Scenario editor zoom & area-shift improvements

### DIFF
--- a/src/scenedit/scen.actions.cpp
+++ b/src/scenedit/scen.actions.cpp
@@ -1848,8 +1848,10 @@ void handle_keystroke(sf::Event event) {
 	mouse_button_held = false;
 }
 
-// Don't repeatedly prompt when the designer scrolls out of bounds and says no to shifting
+// Don't repeatedly prompt when the designer scrolls out of bounds and says no to shifting.
+// Unless it's in a new direction.
 bool did_out_of_bounds_prompt = false;
+int last_dx = 0, last_dy = 0;
 
 static bool handle_outdoor_sec_shift(int dx, int dy){
 	if(did_out_of_bounds_prompt) return false;
@@ -1892,7 +1894,6 @@ static bool handle_outdoor_sec_shift(int dx, int dy){
 	return true;
 }
 
-// TODO account for zoom levels
 void handle_editor_screen_shift(int dx, int dy) {
 	// Outdoors, you can see 1 tile across the border with neighboring sections:
 	int min = (editing_town ? 0 : -1);
@@ -1904,6 +1905,11 @@ void handle_editor_screen_shift(int dx, int dy) {
 	// when prompting whether to shift areas:
 	rectangle shift_bounds = visible_bounds();
 	bool out_of_bounds = false;
+	if(dx != last_dx || dy != last_dy){
+		did_out_of_bounds_prompt = false;
+	}
+	last_dx = dx;
+	last_dy = dy;
 	if(dx < 0 && shift_bounds.left + dx < min){
 		// In outdoors, prompt whether to swap to the next section west
 		if(handle_outdoor_sec_shift(-1, 0)) return;

--- a/src/scenedit/scen.graphics.hpp
+++ b/src/scenedit/scen.graphics.hpp
@@ -13,6 +13,7 @@ void draw_lb_slot (short which,short mode) ;
 void draw_rb();
 void draw_rb_slot (short which,short mode) ;
 void set_up_terrain_buttons(bool reset);
+rectangle visible_bounds();
 void draw_terrain();
 void draw_monsts();
 void draw_items();


### PR DESCRIPTION
The first commit makes the editor stop prompting you whether to shift areas after the first time you attempt scrolling out of bounds.

The second commit here is a really gory one. The overall purpose is to make the area-shift prompt more functional when zoomed out. When zoomed out, the editor still tracks a center relative to 1x zoom, which may not match the center of the zoomed-out view. I think this is a good thing, so I preserved it (the prior commit being an important part of that). However, previously, you could scroll to the visual limit of an outdoor section/town view, and yet not be prompted to shift to the next logical area (i.e. town entrance, neighboring outdoor section). You had to keep scrolling until the *technical* center hit its maximum, which felt weird. The new behavior is that when you can't visually scroll further in the direction you attempt to shift, you will get the area-shift prompt. If you say no to the shift, you can keep moving your technical centerpoint past that boundary. The technical centerpoint is useful because it's where you're centered when you zoom in again.

Now it's really nice to zoom all the way out in the outdoors and have the arrow keys jump you around from section to section with 1 keypress.

The third commit adds hotkeys for zoom in/out.
