### PR TITLE
Scenario picker fixes

### DIFF
--- a/rsrc/dialogs/pick-scenario.xml
+++ b/rsrc/dialogs/pick-scenario.xml
@@ -75,6 +75,7 @@
 	<button name='x' def-key='x' type='tiny' relative='pos pos-in' rel-anchor='prev' top='0' left='4'>X</button>
 	<button name='y' def-key='y' type='tiny' relative='pos pos-in' rel-anchor='prev' top='0' left='4'>Y</button>
 	<button name='z' def-key='z' type='tiny' relative='pos pos-in' rel-anchor='prev' top='0' left='4'>Z</button>
+	<button name='#' def-key='shift 3' type='tiny' relative='neg pos-in' anchor='j' top='0' left='32'>#</button>
 
 	<button name='cancel' type='regular' top='330' left='5'>Cancel</button>
 	<button name='prev' type='left' def-key='left' relative='pos pos-in' rel-anchor='prev' top='0' left='14'/>

--- a/src/fileio/fileio_scen.cpp
+++ b/src/fileio/fileio_scen.cpp
@@ -266,8 +266,11 @@ bool load_scenario_v1(fs::path file_to_load, cScenario& scenario, eLoadScenario 
 		return false;
 	}
 	port_item_list(&item_data);
-	scenario.import_legacy(temp_scenario);
-	scenario.import_legacy(item_data);
+	scenario.import_legacy(temp_scenario, load_type == eLoadScenario::ONLY_HEADER);
+	if(load_type == eLoadScenario::FULL){
+		scenario.ter_types[23].fly_over = false;
+		scenario.import_legacy(item_data);
+	}
 	
 	// TODO: Consider skipping the fread and assignment when len is 0
 	scenario.special_items.resize(50);
@@ -294,8 +297,6 @@ bool load_scenario_v1(fs::path file_to_load, cScenario& scenario, eLoadScenario 
 	}
 	
 	fclose(file_id);
-	
-	scenario.ter_types[23].fly_over = false;
 	
 	scenario.scen_file = file_to_load;
 	if(load_type == eLoadScenario::ONLY_HEADER) return true;

--- a/src/game/boe.dlgutil.cpp
+++ b/src/game/boe.dlgutil.cpp
@@ -1786,8 +1786,16 @@ class cChooseScenario {
 		for(auto& hdr : scen_headers){
 			// I just checked, and the scenario editor will let you name your scenario "" or " "!
 			std::string name = name_alphabetical(hdr.name);
-			if(!name.empty())
-				me[name.substr(0, 1)].show();
+			if(!name.empty()){
+				// Starts with a letter:
+				if(me.hasControl(name.substr(0, 1))){
+					me[name.substr(0, 1)].show();
+				}
+				// Starts with a digit:
+				else if(name[0] >= '0' && name[0] <= '9'){
+					me["#"].show();
+				}
+			}
 		}
 	}
 
@@ -1870,6 +1878,7 @@ public:
 			stk.setPage(0);
 			return true;
 		});
+		// Letter buttons scroll to an alphabetical position:
 		for(int i = 0; i < 26; ++i){
 			std::string letter(1, (char)('a' + i));
 			me[letter].attachClickHandler([this](cDialog& me, std::string letter, eKeyMod) -> bool {
@@ -1883,6 +1892,12 @@ public:
 				return true;
 			});
 		}
+		// Number button scrolls to scenarios that start with symbols or digits:
+		me["#"].attachClickHandler([this](cDialog& me, std::string letter, eKeyMod) -> bool {
+			auto& stk = dynamic_cast<cStack&>(me["list"]);
+			stk.setPage(1);
+			return true;
+		});
 		
 		put_scen_info();
 		

--- a/src/game/boe.fileio.cpp
+++ b/src/game/boe.fileio.cpp
@@ -340,6 +340,8 @@ std::string name_alphabetical(std::string a) {
 	// The scenario editor will let you prepend whitespace to a scenario name :(
 	boost::algorithm::trim_left(a);
 	std::transform(a.begin(), a.end(), a.begin(), tolower);
+	// Some party makers start with the name of the corresponding scenario in quotes
+	if(a.substr(0,1) == "\"") a.erase(a.begin(), a.begin() + 1);
 	if(a.substr(0,2) == "a ") a.erase(a.begin(), a.begin() + 2);
 	else if(a.substr(0,4) == "the ") a.erase(a.begin(), a.begin() + 4);
 	return a;

--- a/src/scenario/scenario.cpp
+++ b/src/scenario/scenario.cpp
@@ -231,7 +231,7 @@ cScenario::cItemStorage::cItemStorage() : ter_type(-1), property(0) {
 		item_odds[i] = 0;
 }
 
-void cScenario::import_legacy(legacy::scenario_data_type& old){
+void cScenario::import_legacy(legacy::scenario_data_type& old, bool header_only){
 	is_legacy = true;
 	// TODO eventually the absence of feature flags here will replace is_legacy altogether
 	feature_flags = {};
@@ -267,6 +267,9 @@ void cScenario::import_legacy(legacy::scenario_data_type& old){
 	rating = eContentRating(old.rating);
 	// TODO: Is this used anywhere?
 	uses_custom_graphics = old.uses_custom_graphics;
+
+	if(header_only) return;
+
 	boats.resize(30);
 	horses.resize(30);
 	for(short i = 0; i < 30; i++) {

--- a/src/scenario/scenario.hpp
+++ b/src/scenario/scenario.hpp
@@ -148,7 +148,7 @@ public:
 		towns.back()->init_start();
 	}
 	
-	void import_legacy(legacy::scenario_data_type& old);
+	void import_legacy(legacy::scenario_data_type& old, bool header_only = false);
 	void import_legacy(legacy::scen_item_data_type& old);
 	void writeTo(cTagFile& file) const;
 	void readFrom(const cTagFile& file);


### PR DESCRIPTION
I threw the whole scenario archive in my scenarios folder and found some bugs.

* Some scenarios like 100 Evil Sliths don't start with a letter and the alphabetical buttons don't handle that (it will crash)
* Scenarios with unrecognized special nodes will show an error even if you're just loading the header for the scenario picker

This fixes them and adds a '#' button which pages the picker to the first page of custom scenarios.